### PR TITLE
release: attach install.sh as release asset

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,6 +75,8 @@ release:
     name: fsend
   draft: false
   prerelease: auto
+  extra_files:
+    - glob: ./install.sh
 
 changelog:
   use: github


### PR DESCRIPTION
## Summary
- Adds `install.sh` to GoReleaser's `release.extra_files` so it is uploaded as a release asset on every tagged release.
- Enables `https://github.com/polius/fsend/releases/latest/download/install.sh` as a stable URL that always serves the script shipped with the latest release — lets `getfsend.alzina.dev` point at it via a Cloudflare redirect rule with no per-release server updates.

## Test plan
- [ ] Local dry-run: `goreleaser release --snapshot --clean --skip=publish,sign` and confirm `install.sh` appears in `dist/`.
- [ ] On next `v*` tag, verify the release page lists `install.sh` as an asset.
- [ ] `curl -fsSL https://github.com/polius/fsend/releases/latest/download/install.sh` returns the expected script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)