### PR TITLE
docs: factual fixes, restructure, and consistency pass

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -4,7 +4,7 @@ When you run `fsend file.pdf`, the sender opens **two paths at the same
 time** — a LAN listener (mDNS-announced) and a session on the pairing
 server. Whichever path the receiver reaches first wins; the other is
 cancelled. There is **no timeout** between the two — neither side ever
-waits on a budget.
+waits on a deadline.
 
 ## Same network (sender and receiver on the same Wi-Fi)
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -54,8 +54,9 @@ UDP multicast and connect directly. No meaningful difference.
 The **single UDP port** is a real-world advantage: one port is much
 easier to get past a corporate firewall than a TCP range, and UDP/443 is
 already allowed almost everywhere because it's the port HTTP/3 uses.
-QUIC makes this possible by multiplexing all the transfer's streams over
-one UDP socket, where TCP would need a separate connection per stream.
+QUIC multiplexes parallel streams over a single UDP socket, so fsend
+stays on one port even at high throughput; croc opens multiple TCP
+connections to parallelize and so reserves a port range.
 
 ## What this means in practice
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -5,7 +5,7 @@ is the `fsend server` subcommand) from source.
 
 ## Prerequisites
 
-- **Go ≥ 1.25.5** (matches `go.mod`).
+- **Go ≥ 1.25.11** (matches `go.mod`).
 - Optional: **Docker** + **docker compose v2**, only for the reverse-proxy
   stack in `deploy/compose/`.
 
@@ -20,6 +20,18 @@ go build -o /tmp/fsend ./cmd/fsend
 /tmp/fsend server --help
 ```
 
+## Tests
+
+```sh
+go test ./...           # unit + E2E (~30s)
+go test -short ./...    # skip E2E
+go test -race ./...
+go test -v ./test/e2e/
+```
+
+The E2E suite builds its own binary in a temp dir and runs an isolated
+server on loopback — no shell wrapper needed.
+
 ## LAN smoke test (no server needed)
 
 `fsend` uses mDNS for direct peer-to-peer on the same LAN.
@@ -28,13 +40,13 @@ Terminal A (sender):
 ```sh
 echo "hello" > /tmp/hello.txt
 /tmp/fsend /tmp/hello.txt
-# → abc-defgh-jkm
+# → abc-defg-jkm
 ```
 
 Terminal B (receiver):
 ```sh
 mkdir -p /tmp/recv && cd /tmp/recv
-/tmp/fsend --yes abc-defgh-jkm
+/tmp/fsend --yes abc-defg-jkm
 ```
 
 ## Run the server locally
@@ -50,8 +62,10 @@ FSEND_LOG_LEVEL=debug \
 /tmp/fsend server
 ```
 
-`:443` needs root; `:8080` often collides. `FSEND_PUBLIC_ADDR` is what
-the server advertises to clients for relay — must be dialable.
+Ports `18080`/`18443` are chosen to avoid the privileged-port requirement
+of `:443` (would need root) and the common port collision on `:8080`.
+`FSEND_PUBLIC_ADDR` is what the server advertises to clients for relay —
+must be dialable from the client side.
 
 Point a client at it (persists to `~/.config/fsend/config.toml`):
 
@@ -65,13 +79,13 @@ Reset to the public default:
 /tmp/fsend --connect default
 ```
 
-Health check:
+Health check (the env var tells the probe where to look):
 
 ```sh
 FSEND_HTTP_ADDR=":18080" /tmp/fsend server --health-check
 ```
 
-### Server env vars
+### Common server env vars
 
 | Var | Default | Notes |
 |---|---|---|
@@ -82,21 +96,14 @@ FSEND_HTTP_ADDR=":18080" /tmp/fsend server --health-check
 | `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MiB` | |
 | `FSEND_SESSION_IDLE_TIMEOUT` | `60s` | |
 
-Full list: `/tmp/fsend server --help`.
-
-## Tests
-
-```sh
-go test ./...           # unit + E2E (~30s)
-go test -short ./...    # skip E2E
-go test -race ./...
-go test -v ./test/e2e/
-```
-
-The E2E suite builds its own binary in a temp dir and runs an isolated
-server on loopback — no shell wrapper needed.
+Full list: `/tmp/fsend server --help`. For deployment, ports, and all
+tunables, see [Self-hosting](self-hosting.md).
 
 ## Isolated config
+
+To experiment with `--connect` without overwriting your real
+`~/.config/fsend/config.toml`, point the client at a throwaway config
+root:
 
 ```sh
 XDG_CONFIG_HOME=/tmp/fsend-dev /tmp/fsend --connect http://127.0.0.1:18080

--- a/docs/security.md
+++ b/docs/security.md
@@ -20,21 +20,9 @@ either.
 
 ## Post-quantum forward secrecy
 
-TLS 1.3's key exchange uses the **X25519 + ML-KEM-768 hybrid** by default
-(Go 1.24+). Ciphertext captured today is not retroactively decryptable by
-a future large-scale quantum computer.
-
-## vs croc
-
-|                                  | fsend                                              | croc                                              |
-|----------------------------------|----------------------------------------------------|---------------------------------------------------|
-| End-to-end encrypted             | ✓                                                  | ✓                                                 |
-| PAKE protocol                    | SPAKE2 (RFC 9382, IETF-standardized)               | `schollz/pake` (non-standardized, Boneh-Shoup textbook construction) |
-| Crypto layers over the wire      | TLS 1.3 over QUIC **plus** SPAKE2, channel-bound via the RFC 5705 exporter | Single AEAD (AES-GCM or XChaCha20-Poly1305) keyed directly from PAKE |
-| Post-quantum forward secrecy     | ✓ (X25519 + ML-KEM-768 hybrid, Go 1.24+ default)   | ✗ (classical ECC only)                            |
-| MITM defense                     | Two layers — TLS catches a network MITM, SPAKE2 binding catches a TLS-handshake MITM | Single layer — PAKE alone                         |
-| Relay does not see the file      | ✓ — relay only forwards opaque UDP datagrams; QUIC/TLS terminate at the peers | ✓ — relay only forwards ciphertext after PAKE     |
-| How often the relay is in path   | Fallback only (used when ICE hole-punching fails)  | Every cross-network transfer                      |
+TLS 1.3's key exchange uses the **X25519 + ML-KEM-768 hybrid** (Go's
+standard since 1.24). Ciphertext captured today is not retroactively
+decryptable by a future large-scale quantum computer.
 
 ## Is the pairing server something to worry about?
 
@@ -77,8 +65,8 @@ carrier moving sealed envelopes. It moves the parcel; it can't open it.
 |---------------------------------------------------|-----------------|
 | File contents                                     | ✗ never         |
 | File names, sizes, hashes                         | ✗ never         |
-| Encrypted ciphertext (on the relay-fallback path) | ✓ as opaque bytes — not decryptable, not even by the server's operator |
-| The 7-character pairing code & your IP            | ✓ briefly, in memory only, for pairing — never written to disk |
+| Ciphertext (on the relay-fallback path)           | ✓ as opaque bytes — not decryptable, not even by the server's operator |
+| The 10-letter pairing code and your IP            | ✓ briefly, in memory only, for pairing — never written to disk |
 
 End-to-end encryption means even the operator of the server can't
 decrypt traffic that goes through it. The encryption keys never leave
@@ -113,3 +101,15 @@ excluded for legibility). Codes are:
 - **System-generated** — fsend picks the code for each transfer. For
   persistent shared secrets across many transfers (scripts, kiosks),
   use `--pass` instead.
+
+## Compared to croc
+
+|                                  | fsend                                              | croc                                              |
+|----------------------------------|----------------------------------------------------|---------------------------------------------------|
+| End-to-end encrypted             | ✓                                                  | ✓                                                 |
+| PAKE protocol                    | SPAKE2 (RFC 9382, IETF-standardized)               | `schollz/pake` (non-standardized, Boneh-Shoup textbook construction) |
+| Crypto layers over the wire      | TLS 1.3 over QUIC **plus** SPAKE2, channel-bound via the RFC 5705 exporter | Single AEAD (AES-GCM or XChaCha20-Poly1305) keyed directly from PAKE |
+| Post-quantum forward secrecy     | ✓ (X25519 + ML-KEM-768 hybrid)                     | ✗ (classical ECC only)                            |
+| MITM defense                     | Two layers — TLS catches a network MITM, SPAKE2 binding catches a TLS-handshake MITM | Single layer — PAKE alone                         |
+| Relay does not see the file      | ✓ — relay only forwards opaque UDP datagrams; QUIC/TLS terminate at the peers | ✓ — relay only forwards ciphertext after PAKE     |
+| How often the relay is in path   | Fallback only (used when ICE hole-punching fails)  | Every cross-network transfer                      |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -16,10 +16,13 @@ The fastest production-quality setup uses the bundled compose stack
 API with Caddy and provisions a Let's Encrypt cert automatically:
 
 ```sh
-export FSEND_DOMAIN=fs.example.com
+export FSEND_DOMAIN=fs.example.com    # used by Caddy to request the cert
 docker compose -f deploy/compose/docker-compose.yml up -d
 fsend --connect fs.example.com:443    # on each client
 ```
+
+Point `fs.example.com` at the host's public IP before bringing the stack
+up — Caddy needs the DNS record to complete the ACME HTTP-01 challenge.
 
 For a quick LAN-only test (no TLS), use the image directly:
 
@@ -44,7 +47,7 @@ recommended on the public internet.
 | Port             | Direction | Purpose                                         |
 |------------------|-----------|-------------------------------------------------|
 | `8080/tcp`       | inbound   | Signaling HTTP API (clients POST session/join)  |
-| `443/udp`        | inbound   | ICE STUN-style reflection + relay fallback (opaque QUIC datagrams) |
+| `443/udp`        | inbound   | NAT address discovery + relay fallback (opaque QUIC datagrams) |
 
 Clients connect with `fsend --connect http://host:8080`. If you change
 `FSEND_UDP_ADDR`, also set `FSEND_PUBLIC_ADDR=host:port` to the address
@@ -52,13 +55,17 @@ clients should dial for relay.
 
 ### HTTPS mode
 
-Reverse proxy with your own domain — recommended for any
-public-internet deployment. Matches the `deploy/compose/` stack.
+Reverse proxy with your own domain — required for any public-internet
+deployment. File data on UDP/443 is already end-to-end encrypted, but
+the HTTP pairing channel carries share codes and bearer tokens in
+plaintext, so the signaling port **must** be TLS-terminated.
+
+Matches the `deploy/compose/` stack.
 
 | Port             | Direction | Purpose                                              |
 |------------------|-----------|------------------------------------------------------|
 | `443/tcp`        | inbound   | HTTPS signaling — terminated by Caddy/nginx/Traefik  |
-| `443/udp`        | inbound   | ICE STUN-style reflection + relay fallback — goes **directly** to the fsend container |
+| `443/udp`        | inbound   | NAT address discovery + relay fallback — goes **directly** to the fsend container |
 | `80/tcp`         | inbound   | Let's Encrypt ACME HTTP-01 challenge (cert issue/renew) |
 
 Clients then connect with `fsend --connect fs.example.com:443` (HTTPS
@@ -84,8 +91,3 @@ All optional; defaults shown.
 | `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit. |
 | `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MiB` | Accepts `500m`, `1GiB`, `104857600`. |
 | `FSEND_SESSION_IDLE_TIMEOUT` | `60s` | Go duration. |
-
-Internet-exposed deployments need a TLS-terminating reverse proxy in
-front of `:8080` — file data on UDP/443 is already end-to-end
-encrypted, but the HTTP pairing channel carries share codes and bearer
-tokens in plaintext.


### PR DESCRIPTION
## Summary

Production-grade pass across all six docs in `docs/`. No content invented — strictly fact fixes, restructuring for flow, and removing duplication.

**Factual fixes**
- `security.md`: "7-character pairing code" (×2) → "10-letter" — the actual code (`abc-defg-jkm`) is 10 letters
- `development.md`: "Go ≥ 1.25.5" → "Go ≥ 1.25.11" (matches `go.mod`)
- `development.md`: `abc-defgh-jkm` (×2) → `abc-defg-jkm` — extra letter in middle group
- `comparison.md`: rewrote QUIC paragraph — old wording wrongly implied TCP forces one connection per stream; croc uses multiple TCP conns for parallelism, not because TCP requires it

**Restructure**
- `security.md`: moved "Compared to croc" from mid-doc to the end (flow: properties → server → codes → comparison)
- `development.md`: moved Tests section up to sit right after Build (natural flow: build → verify → smoke → run)
- `self-hosting.md`: moved "why HTTPS is required" rationale from Configuration tail into the HTTPS-mode section; removed the duplicate at the end

**Clarity / dejargon**
- `architecture.md`: "waits on a budget" → "waits on a deadline" (plain language)
- `self-hosting.md`: "ICE STUN-style reflection" → "NAT address discovery" in both port tables
- `self-hosting.md`: added inline comment for `FSEND_DOMAIN` and called out the DNS-must-exist-first prerequisite for ACME
- `development.md`: explained why dev uses ports 18080/18443; why the health-check command sets `FSEND_HTTP_ADDR`; why you'd use `XDG_CONFIG_HOME`

**Dedup**
- `development.md`: renamed "Server env vars" → "Common server env vars" and linked to `self-hosting.md` for the full table
- `security.md`: dropped redundant "Encrypted ciphertext" (ciphertext is encrypted by definition)
- `security.md`: "& your IP" → "and your IP"

## Test plan

- [ ] Render each doc on the PR's "Files changed" tab and confirm formatting (tables, code fences, ASCII diagrams) is intact
- [ ] Click each cross-link (`Self-hosting`, `Security`, `Compared to croc`) and confirm anchors resolve
- [ ] Spot-check the factual corrections against source of truth (`go.mod` for Go version, code-generation logic for `abc-defg-jkm` shape)
- [ ] Re-read `security.md` end-to-end to confirm the reorder reads naturally
- [ ] Re-read `development.md` to confirm Build → Tests → Smoke → Server flow makes sense

🤖 Generated with [Claude Code](https://claude.com/claude-code)