### PR TITLE
refactor: move install.sh into scripts/

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -76,7 +76,7 @@ release:
   draft: false
   prerelease: auto
   extra_files:
-    - glob: ./install.sh
+    - glob: ./scripts/install.sh
 
 changelog:
   use: github

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -33,7 +33,7 @@ Flags:
 Environment variables (overridden by the matching flag):
   PREFIX, FSEND_VERSION
 
-Source: https://github.com/polius/fsend/blob/main/install.sh
+Source: https://github.com/polius/fsend/blob/main/scripts/install.sh
 EOF
 }
 


### PR DESCRIPTION
## Summary
- Moves `install.sh` to `scripts/install.sh` so the repo root stays focused on items tooling expects there (`go.mod`, `Dockerfile`, lint/release configs).
- Updates GoReleaser's `release.extra_files` glob and the in-file `Source:` URL to match.
- Public release asset URL is unchanged — GoReleaser uploads by basename, so `https://github.com/polius/fsend/releases/latest/download/install.sh` continues to resolve.

## Test plan
- [ ] Local dry-run: `goreleaser release --snapshot --clean --skip=publish,sign` and confirm `install.sh` appears in `dist/`.
- [ ] On next `v*` tag, verify the release page lists `install.sh` as an asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)