### PR TITLE
docs: add fsend wordmark icon at top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="docs/assets/icon.svg" alt="fsend" width="220">
+</p>
+
 # fsend
 
 **Truly peer-to-peer file transfer.** Direct, encrypted, relay only as a fallback.

--- a/docs/assets/icon.svg
+++ b/docs/assets/icon.svg
@@ -1,0 +1,36 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 200" fill="none" role="img" aria-label="&gt;_ fsend">
+  <defs>
+    <style>
+      .prompt {
+        stroke: #C25B43;
+        stroke-width: 18;
+        stroke-linecap: round;
+        stroke-linejoin: round;
+        fill: none;
+      }
+      .cursor { fill: #C25B43; }
+      .word {
+        font-family: ui-monospace, SFMono-Regular, "JetBrains Mono", "Menlo", "Consolas", monospace;
+        font-size: 92px;
+        font-weight: 500;
+        fill: #1A1410;
+        letter-spacing: -0.02em;
+      }
+
+      @media (prefers-color-scheme: dark) {
+        .prompt { stroke: #E89478; }
+        .cursor { fill: #E89478; }
+        .word   { fill: #FAF7F5; }
+      }
+    </style>
+  </defs>
+
+  <!-- > chevron, sized to cap-height of wordmark -->
+  <path class="prompt" d="M 30 70 L 62 101 L 30 132"/>
+
+  <!-- _ underscore / cursor -->
+  <rect class="cursor" x="78" y="134" width="40" height="10" rx="3"/>
+
+  <!-- fsend wordmark -->
+  <text class="word" x="138" y="132" text-anchor="start">fsend</text>
+</svg>


### PR DESCRIPTION
## Summary

Adds `docs/assets/icon.svg` (SVG wordmark — `>_ fsend`) and references it as a centered header image above the title in `README.md`. Width 220 for visual impact at the top of the fold without dominating mobile widths.

The icon uses light/dark variants via CSS `@media (prefers-color-scheme: dark)`, so it renders correctly on both GitHub themes.

## Test plan

- [ ] Open the README on the PR's "Files changed" tab and confirm the icon renders centered above the title
- [ ] Toggle GitHub's light/dark theme and confirm the icon recolors
- [ ] Check that the icon scales reasonably on a narrow viewport (the SVG has its own `viewBox`, so width=220 is the display size only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)