### PR TITLE
chore: remove .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,0 @@
-* text=auto eol=lf
-*.sh text eol=lf
-*.go text eol=lf
-*.md text eol=lf
-*.yml text eol=lf
-*.yaml text eol=lf


### PR DESCRIPTION
## Summary
- Removes `.gitattributes`. CRLF risk on shell scripts (mainly `install.sh`) will be caught in PR review rather than enforced via git attribute normalization.
- Trims one root-level dotfile that wasn't required by any tooling.

## Test plan
- [ ] Confirm `install.sh` still has LF line endings after a fresh clone on Linux/macOS (default).