### PR TITLE
docs/readme: full overhaul + tighten icon viewBox

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,14 @@
 <p align="center">
-  <img src="docs/assets/icon.svg" alt="fsend" width="220">
+  <img src="docs/assets/icon.svg" alt="fsend" width="250">
 </p>
 
-# fsend
+<p align="center"><strong>Peer-to-peer file transfer. Direct and end-to-end encrypted.</strong></p>
 
-**Truly peer-to-peer file transfer.** Direct, encrypted, relay only as a fallback.
+<p align="center">
+  <a href="https://github.com/polius/fsend/actions/workflows/test.yml"><img src="https://github.com/polius/fsend/actions/workflows/test.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/polius/fsend/releases"><img src="https://img.shields.io/github/v/release/polius/fsend" alt="Release"></a>
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+</p>
 
 ```bash
 # Sender — prints a code to share with the receiver
@@ -15,48 +19,63 @@ $ fsend report.pdf
 $ fsend abc-defg-jkm
 ```
 
+## About
+
+fsend lets any two computers transfer files **directly** to each other — no accounts, no cloud, no third party storing the file.
+
+- **Peer-to-peer** — bytes go straight from sender to receiver at your own internet speed (relay only as a fallback)
+- **Send anything** — files, folders, multiple at once, stdin streams, or literal text
+- **Smart excludes** — skip junk when bundling a folder (`--exclude 'node_modules,*.log,.git'`)
+- **Resumable** — connection drops? Rerun the same code and fsend picks up where it stopped
+- **No ports to open** — works on any network, no router or firewall setup
+- **End-to-end encrypted** — two independent layers; even the fallback relay never sees the file
+- **Password-protected** — gate any transfer with `--pass`; receiver supplies it to unlock
+- **Post-quantum** — X25519 + ML-KEM-768 (NIST standard); even tomorrow's quantum computers can't decrypt today's transfer
+- **Runs anywhere** — single static binary on Linux, macOS, FreeBSD, Windows; x86 and ARM
+- **Self-hostable** — same ~20 MB binary, no database
+
 ## Install
 
 ```bash
 curl -fsSL https://getfsend.alzina.dev | sh
 ```
 
-Linux, macOS, FreeBSD, and Windows (Git Bash / MSYS2). Or grab a release
-binary from [the releases page](https://github.com/polius/fsend/releases).
+Linux, macOS, FreeBSD, and Windows (Git Bash / MSYS2). Inspect the script first with `curl -fsSL https://getfsend.alzina.dev`.
 
-## Why fsend
+Or install from source:
 
-- **Direct peer-to-peer, even across the internet.** Hole-punches through both
-  NATs with ICE + STUN. Falls back to an encrypted relay only when NAT
-  topology blocks the punch — so your transfer is capped by your own bandwidth,
-  not someone else's relay.
-- **One UDP port.** UDP/443 — the port HTTP/3 uses, allowed almost everywhere.
-  Most tools need a TCP range that corporate firewalls block.
-- **Two-layer end-to-end encryption.** TLS 1.3 over QUIC **plus** SPAKE2
-  (RFC 9382), channel-bound. An attacker has to break both.
-- **Post-quantum forward secrecy** by default (X25519 + ML-KEM-768 hybrid).
-  Captured today, still safe against tomorrow's quantum computer.
-- **Self-hostable.** Same binary, `fsend server`. No database, no per-transfer
-  logs, ~20 MB.
+```bash
+go install github.com/polius/fsend/cmd/fsend@latest
+```
 
-## Send anything
+Or grab a release binary from [the releases page](https://github.com/polius/fsend/releases).
+
+## Examples
+
+Send:
 
 ```bash
 fsend ./project                    # whole folder
 fsend a.txt b.txt c.txt            # multiple files
-tar c ./build | fsend              # piped from stdin
+pg_dump mydb | fsend               # piped from stdin
 fsend --text "wifi: hunter2"       # literal string
 fsend report.pdf --pass            # password-gated
 ```
 
-Cancelled transfers resume on the next run.
+Receive:
+
+```bash
+fsend abc-defg-jkm                 # confirm before saving
+fsend --yes abc-defg-jkm           # skip the confirmation
+fsend --out ~/Downloads abc-defg-jkm
+```
 
 ## Documentation
 
 | | |
 |---|---|
 | [Usage](docs/usage.md) | Every flag, env var, and exit code |
-| [How it works](docs/architecture.md) | The dual-path design, ICE, fallback relay |
+| [How it works](docs/architecture.md) | The dual-path design and fallback relay |
 | [Comparison](docs/comparison.md) | How fsend differs from croc |
 | [Security](docs/security.md) | Threat model — what the server can and cannot see |
 | [Self-hosting](docs/self-hosting.md) | Run your own pairing + relay server |

--- a/docs/assets/icon.svg
+++ b/docs/assets/icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 560 200" fill="none" role="img" aria-label="&gt;_ fsend">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 58 560 88" fill="none" role="img" aria-label="&gt;_ fsend">
   <defs>
     <style>
       .prompt {


### PR DESCRIPTION
## Summary

Rebuilds the README around a centered header (icon + tagline + badges) and a croc-style feature list, and tightens the icon SVG's viewBox so the wordmark doesn't render with empty vertical padding.

### Header
- Drop defensive "Truly" — new tagline: **Peer-to-peer file transfer. Direct and end-to-end encrypted.**
- Centered tagline and badges (CI / Release / License) to match the existing centered icon block

### About (replaces "Why fsend")
- Plain-language opener
- 10 flat bullets, capitalised leads, single-line each:
  - **Peer-to-peer** — *with explicit relay-only-as-fallback note*
  - **Send anything** — files, folders, multiple, stdin, text
  - **Smart excludes** — `--exclude` globs
  - **Resumable** — connection-drop recovery
  - **No ports to open** — no router/firewall config
  - **End-to-end encrypted** — relay never sees the file
  - **Password-protected** — `--pass` gating
  - **Post-quantum** — X25519 + ML-KEM-768 (NIST standard), with the *why* (record-now-decrypt-later mitigated)
  - **Runs anywhere** — single static binary
  - **Self-hostable** — same ~20 MB binary

### Install
- Inspect-the-script note (`curl -fsSL https://getfsend.alzina.dev`) for users wary of `curl | sh`
- `go install github.com/polius/fsend/cmd/fsend@latest` from source
- Release-binary fallback link

### Examples (replaces "Send anything")
- Split into **Send** and **Receive** subsections
- `pg_dump mydb | fsend` replaces the unclear `tar c ./build | fsend`
- New receive examples: `--yes`, `--out`

### Documentation table
- Drop "ICE" jargon — now reads "The dual-path design and fallback relay"

### Icon (`docs/assets/icon.svg`)
- ViewBox cropped from `0 0 560 200` → `0 58 560 88`
- Content positions unchanged; just removes ~110px of empty vertical space
- Aspect ratio changes from 2.8:1 to ~6.4:1, so at the current `width="250"` the displayed height shrinks from ~89px to ~39px. If we want comparable visual weight, bumping `width` to ~360–400 would put the displayed height back around 56–62px

## Test plan

- [ ] Open the README in the PR's "Files changed" tab; confirm header (icon, tagline, badges) is centered on both light and dark themes
- [ ] Verify all three badges render (CI workflow `test.yml` exists, GitHub release exists, license link resolves)
- [ ] Confirm the icon renders tightly without extra vertical padding
- [ ] Spot-check that all internal doc links resolve (`docs/usage.md`, `docs/architecture.md`, etc.)
- [ ] Confirm `go install github.com/polius/fsend/cmd/fsend@latest` works on a clean Go toolchain
- [ ] Decide whether to bump README `width` to compensate for tighter SVG

🤖 Generated with [Claude Code](https://claude.com/claude-code)