### PR TITLE
docs: README overhaul — hero, About, install, examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,13 @@
 </p>
 
 ```bash
-# Sender — prints a code to share with the receiver
+# Sender
 $ fsend report.pdf
-  Share this code:  abc-defg-jkm
+Share this code:  abc-defg-jkm
 
-# Receiver — uses that code
+# Receiver — same command, code instead of file
 $ fsend abc-defg-jkm
+✓ Saved to ~/Downloads  ·  2.4 MB
 ```
 
 ## About
@@ -30,7 +31,7 @@ fsend lets any two computers transfer files **directly** to each other — no ac
 - **No ports to open** — works on any network, no router or firewall setup
 - **End-to-end encrypted** — two independent layers; even the fallback relay never sees the file
 - **Password-protected** — gate any transfer with `--pass`; receiver supplies it to unlock
-- **Post-quantum** — X25519 + ML-KEM-768 (NIST standard); even tomorrow's quantum computers can't decrypt today's transfer
+- **Post-quantum** — X25519 + ML-KEM-768 (NIST); future quantum computers can't decrypt today's transfer
 - **Runs anywhere** — single static binary on Linux, macOS, FreeBSD, Windows; x86 and ARM
 - **Self-hostable** — same ~20 MB binary, no database
 
@@ -40,15 +41,20 @@ fsend lets any two computers transfer files **directly** to each other — no ac
 curl -fsSL https://getfsend.alzina.dev | sh
 ```
 
-Linux, macOS, FreeBSD, and Windows (Git Bash / MSYS2). Inspect the script first with `curl -fsSL https://getfsend.alzina.dev`.
+Works on Linux, macOS, FreeBSD, and Windows — x86 and ARM.
 
-Or install from source:
+<details>
+<summary>Other install methods</summary>
+
+From source:
 
 ```bash
 go install github.com/polius/fsend/cmd/fsend@latest
 ```
 
 Or grab a release binary from [the releases page](https://github.com/polius/fsend/releases).
+
+</details>
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="docs/assets/icon.svg" alt="fsend" width="250">
 </p>
 
-<p align="center"><strong>Peer-to-peer file transfer. Direct and end-to-end encrypted.</strong></p>
+<p align="center"><strong>Direct, end-to-end encrypted file transfer.</strong></p>
 
 <p align="center">
   <a href="https://github.com/polius/fsend/actions/workflows/test.yml"><img src="https://github.com/polius/fsend/actions/workflows/test.yml/badge.svg" alt="CI"></a>

--- a/docs/assets/icon.svg
+++ b/docs/assets/icon.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 58 560 88" fill="none" role="img" aria-label="&gt;_ fsend">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 58 560 98" fill="none" role="img" aria-label="&gt;_ fsend">
   <defs>
     <style>
       .prompt {


### PR DESCRIPTION
## Summary
- Rewritten README hero: scaled-up wordmark, tighter tagline (*"Direct, end-to-end encrypted file transfer."*), CI/release/license badges, and a sender/receiver demo snippet that closes the loop with realistic `✓ Saved to …` output.
- New **About** section with a scannable feature bullet list (peer-to-peer, send anything, smart excludes, resumable, no ports, E2EE, password-gated, post-quantum, cross-platform, self-hostable), replacing the prose-heavy "Why fsend" section.
- **Install** section restructured: primary `curl | sh` stays front and center, alternative install methods (`go install`, release binaries) collapsed under a `<details>` disclosure; platform line now mentions x86 and ARM.
- Split the old "Send anything" block into an **Examples** section covering both sending and receiving flows.
- Bumped icon SVG `viewBox` height by 10px to add breathing room between the wordmark and the tagline.

## Test plan
- [ ] Open the rendered README on GitHub and confirm the hero, badges, `<details>` collapse, and tables render correctly
- [ ] Verify the icon spacing reads naturally in both light and dark modes
- [ ] Confirm all linked docs (`docs/usage.md`, `docs/architecture.md`, etc.) still resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)