### PR TITLE
docs: trim and reorder README About section

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,14 @@ $ fsend abc-defg-jkm
 fsend lets any two computers transfer files **directly** to each other — no accounts, no cloud, no third party storing the file.
 
 - **Peer-to-peer** — bytes go straight from sender to receiver at your own internet speed (relay only as a fallback)
-- **Send anything** — files, folders, multiple at once, stdin streams, or literal text
-- **Smart excludes** — skip junk when bundling a folder (`--exclude 'node_modules,*.log,.git'`)
-- **Resumable** — connection drops? Rerun the same code and fsend picks up where it stopped
-- **No ports to open** — works on any network, no router or firewall setup
 - **End-to-end encrypted** — two independent layers; even the fallback relay never sees the file
+- **No ports to open** — works on any network, no router or firewall setup
+- **Send anything** — files, folders, multiple at once, stdin streams, or literal text
+- **Resumable** — connection drops? Rerun the same code and fsend picks up where it stopped
 - **Password-protected** — gate any transfer with `--pass`; receiver supplies it to unlock
 - **Post-quantum** — X25519 + ML-KEM-768 (NIST); future quantum computers can't decrypt today's transfer
-- **Runs anywhere** — single static binary on Linux, macOS, FreeBSD, Windows; x86 and ARM
 - **Self-hostable** — same ~20 MB binary, no database
+- **Runs anywhere** — single static binary on Linux, macOS, FreeBSD, Windows; x86 and ARM
 
 ## Install
 


### PR DESCRIPTION
## Summary
- Drop the **Smart excludes** bullet — it described a single CLI flag (`--exclude`) rather than a categorical feature, and overlapped with the existing **Send anything** bullet. Usage details belong in `docs/usage.md`.
- Reorder remaining About bullets by importance so the opening cluster anchors the mental model: pitch (peer-to-peer → E2EE → no ports) → capability (send anything, resumable) → security depth (password, post-quantum) → deployment (self-hostable, runs anywhere).

## Test plan
- [ ] Verify the rendered About section reads cleanly on GitHub
- [ ] Confirm no broken links or formatting regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)