### PR TITLE
cli: surface relay idle eviction; nudge self-host on rate limit

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -158,6 +158,8 @@ func classifyRelayDrop(ctx context.Context, client *signaling.Client, sessionID 
 	switch status.Reason {
 	case relay.ReasonCapHit:
 		return fserrors.ErrRelayCapHit
+	case relay.ReasonIdle:
+		return fserrors.ErrRelayIdleTimeout
 	}
 	return runErr
 }

--- a/cmd/fsend/internet_test.go
+++ b/cmd/fsend/internet_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"errors"
+	"net/http"
 	"net/http/httptest"
 	"sync"
 	"testing"
@@ -87,6 +88,92 @@ func TestJoinWithRetry_NonRetriableErrorPropagatesImmediately(t *testing.T) {
 	}
 	if elapsed > 2*time.Second {
 		t.Errorf("retried a non-retriable error: %v elapsed", elapsed)
+	}
+}
+
+// Each eviction reason the relay reports must map to its sentinel; any
+// other state must leave runErr untouched.
+func TestClassifyRelayDrop_MapsReasons(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		runErr    error
+		wantErr   error
+		wantSame  bool // when true, expect runErr to be returned unchanged
+	}{
+		{
+			name:    "cap_hit_promotes_to_sentinel",
+			body:    `{"state":"evicted","reason":"cap_hit"}`,
+			runErr:  errors.New("idle timeout"),
+			wantErr: fserrors.ErrRelayCapHit,
+		},
+		{
+			name:    "idle_promotes_to_sentinel",
+			body:    `{"state":"evicted","reason":"idle"}`,
+			runErr:  errors.New("idle timeout"),
+			wantErr: fserrors.ErrRelayIdleTimeout,
+		},
+		{
+			name:     "active_keeps_run_err",
+			body:     `{"state":"active"}`,
+			runErr:   errors.New("idle timeout"),
+			wantSame: true,
+		},
+		{
+			name:     "unknown_keeps_run_err",
+			body:     `{"state":"unknown"}`,
+			runErr:   errors.New("idle timeout"),
+			wantSame: true,
+		},
+		{
+			name:     "unmapped_reason_keeps_run_err",
+			body:     `{"state":"evicted","reason":"future_reason"}`,
+			runErr:   errors.New("idle timeout"),
+			wantSame: true,
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/relay/status" {
+					http.NotFound(w, r)
+					return
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(c.body))
+			}))
+			defer ts.Close()
+			client := signaling.New(ts.URL, "test")
+			got := classifyRelayDrop(context.Background(), client, "sess-1", c.runErr)
+			if c.wantSame {
+				if got != c.runErr {
+					t.Errorf("expected runErr unchanged, got %v", got)
+				}
+				return
+			}
+			if !errors.Is(got, c.wantErr) {
+				t.Errorf("got %v, want %v", got, c.wantErr)
+			}
+		})
+	}
+}
+
+// A successful transfer (nil runErr) must not get a sentinel pinned on it.
+func TestClassifyRelayDrop_NilStaysNil(t *testing.T) {
+	client := signaling.New("http://127.0.0.1:1", "test") // unreachable; not called
+	if err := classifyRelayDrop(context.Background(), client, "sess-1", nil); err != nil {
+		t.Errorf("nil runErr should pass through, got %v", err)
+	}
+}
+
+// A failing status probe must not mask the underlying runErr.
+func TestClassifyRelayDrop_ProbeFailureFallsBackToRunErr(t *testing.T) {
+	client := signaling.New("http://127.0.0.1:1", "test")
+	runErr := errors.New("idle timeout")
+	got := classifyRelayDrop(context.Background(), client, "sess-1", runErr)
+	if got != runErr {
+		t.Errorf("expected runErr to survive a probe failure, got %v", got)
 	}
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -176,6 +176,7 @@ failure.
 | `25`  | `E025` — source file or directory not found. |
 | `27`  | `E027` — could not open local-network listener (port in use, mDNS init failed). |
 | `28`  | `E028` — pairing server requires a password (missing or wrong). |
+| `29`  | `E029` — relay session idle-timed out; allocation reclaimed by the server. |
 | `99`  | `E099` — unexpected error. Run with `--debug` and file an issue. |
 | `130` | `E026` — cancelled by user (Ctrl-C / SIGTERM). |
 

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -90,6 +90,10 @@ var (
 	// shared password and the client either didn't send one or sent the
 	// wrong one.
 	ErrServerAuthRequired = errors.New("server password required")
+	// E029 — relay reaped the allocation for inactivity
+	// (FSEND_SESSION_IDLE_TIMEOUT). Distinct from E020 so the user
+	// knows it's a server-set ceiling, not their network.
+	ErrRelayIdleTimeout = errors.New("relay session idle-timed out")
 )
 
 // Entry is one row of the user-facing error catalog.
@@ -219,7 +223,10 @@ var catalog = map[error]Entry{
 	ErrRateLimited: {
 		Code: "E017", Exit: 17,
 		Message: "Too many attempts from your network — rate limit hit on the server.",
-		Action:  "Wait a minute and try again, or use --connect to use a different server.",
+		Action: "Wait a minute and try again, or switch servers:\n" +
+			"    fsend --connect <host:port>\n" +
+			"  Or self-host your own server (`fsend server`) and raise\n" +
+			"  FSEND_MAX_SESSIONS_PER_IP / FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN.",
 	},
 	ErrServerRetired: {
 		Code: "E018", Exit: 18,
@@ -284,6 +291,13 @@ var catalog = map[error]Entry{
 		Action: "Set it with:\n" +
 			"    fsend --connect <host:port> <password>\n" +
 			"  Ask the server operator for the password if you don't have it.",
+	},
+	ErrRelayIdleTimeout: {
+		Code: "E029", Exit: 29,
+		Message: "The relay session was reclaimed for inactivity. Transfer aborted.",
+		Action: "The server tore down the relay allocation because no traffic\n" +
+			"  flowed within its idle window. Try again, or self-host\n" +
+			"  (`fsend server`) and raise FSEND_SESSION_IDLE_TIMEOUT.",
 	},
 }
 

--- a/internal/fserrors/fserrors_test.go
+++ b/internal/fserrors/fserrors_test.go
@@ -125,6 +125,7 @@ func TestNewSentinels_LookupAndExit(t *testing.T) {
 		{ErrUsage, "E024", 24},
 		{ErrSourceNotFound, "E025", 25},
 		{ErrUserCancelled, "E026", 130},
+		{ErrRelayIdleTimeout, "E029", 29},
 	}
 	for _, c := range cases {
 		entry, ok := Lookup(c.err)


### PR DESCRIPTION
## Summary

Two narrow gaps in how the CLI surfaces operator-tuned server limits:

- **`FSEND_SESSION_IDLE_TIMEOUT`** — when the relay reaped an allocation for inactivity, `classifyRelayDrop` saw `relay.ReasonIdle`, fell through, and let the retry loop exhaust to **E020** "Check your network connection." That message is actively misleading: it points the user at their own network when it's a server-set ceiling that bit. Now maps to a dedicated **E029** `ErrRelayIdleTimeout` that names the env var and points to self-hosting.
- **`FSEND_MAX_SESSIONS_PER_IP` / `_PER_MIN`** — E017's action only suggested `--connect <other server>`. E023 (relay byte cap) already nudges self-host for the same class of operator-tunable limit; E017 was the odd one out. Aligned the wording.

Other "limits" surfaced in the audit (ICE candidate cap, 16 KiB request body, paired-TTL) were verified as **not** worth surfacing: the first two are hardcoded constants (no env knob, so a clean error wouldn't unlock anything for the user), and paired-TTL reaps almost never bite an in-flight transfer because once ICE candidates are exchanged the data path stops touching signaling.

## Test plan

- [x] `go test ./...` — all packages pass, including `test/e2e`
- [x] `go vet ./...` — clean
- [x] New `TestClassifyRelayDrop_MapsReasons` table covers cap_hit / idle / active / unknown / unmapped-future-reason
- [x] New `TestClassifyRelayDrop_NilStaysNil` guards against pinning a sentinel on a successful transfer
- [x] New `TestClassifyRelayDrop_ProbeFailureFallsBackToRunErr` guards against a flaky status probe masking the underlying error
- [x] E029 added to `TestNewSentinels_LookupAndExit`; `TestCatalog_UniqueCodes` enforces the unique-exit invariant
- [x] `docs/usage.md` exit-code table updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)