### PR TITLE
errors: plain-language rewrites for 9 catalog entries

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,27 +156,27 @@ failure.
 | `3`   | `E003` — code already claimed by another receiver. |
 | `4`   | `E004` — invalid code format. |
 | `6`   | `E006` — receiver declined the transfer. |
-| `7`   | `E007` — session expired before a receiver paired. |
+| `7`   | `E007` — code timed out before anyone received. |
 | `8`   | `E008` — disk full. |
 | `9`   | `E009` — could not write the target file. |
 | `10`  | `E010` — could not read the source file. |
-| `11`  | `E011` — transfer completed but hash didn't verify. |
+| `11`  | `E011` — file arrived corrupted; hash didn't match. |
 | `12`  | `E012` — path traversal rejected. |
 | `13`  | `E013` — target file exists; use `--overwrite`. |
-| `14`  | `E014` — could not connect to peer, even via relay. |
-| `15`  | `E015` — protocol error (incompatible versions). |
+| `14`  | `E014` — could not reach the other side, even via the fallback relay. |
+| `15`  | `E015` — sender and receiver are on incompatible fsend versions. |
 | `17`  | `E017` — rate limited. |
 | `18`  | `E018` — default server retired. |
-| `19`  | `E019` — source file changed; stale partial discarded, re-run. |
+| `19`  | `E019` — source file changed; incomplete download discarded, re-run. |
 | `20`  | `E020` — transient transfer failure (retries exhausted). |
 | `21`  | `E021` — wrong transfer password. |
-| `22`  | `E022` — peer authentication failed (code mismatch or tampering). |
-| `23`  | `E023` — relay's per-session byte cap reached. |
+| `22`  | `E022` — could not verify the other side (code mismatch or tampering). |
+| `23`  | `E023` — server-set transfer-size limit reached. |
 | `24`  | `E024` — invalid usage (bad flag, bad arg shape). |
 | `25`  | `E025` — source file or directory not found. |
-| `27`  | `E027` — could not open local-network listener (port in use, mDNS init failed). |
+| `27`  | `E027` — could not open the local-network port (port in use, mDNS init failed). |
 | `28`  | `E028` — pairing server requires a password (missing or wrong). |
-| `29`  | `E029` — relay session idle-timed out; allocation reclaimed by the server. |
+| `29`  | `E029` — server closed the connection because no data was flowing. |
 | `99`  | `E099` — unexpected error. Run with `--debug` and file an issue. |
 | `130` | `E026` — cancelled by user (Ctrl-C / SIGTERM). |
 

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -165,8 +165,8 @@ var catalog = map[error]Entry{
 	},
 	ErrSessionExpired: {
 		Code: "E007", Exit: 7,
-		Message: "The session expired on the server before a receiver paired.",
-		Action:  "Re-run your command to publish a fresh code.",
+		Message: "Your code timed out before anyone received it.",
+		Action:  "Run the command again to get a fresh code.",
 	},
 	ErrDiskFull: {
 		Code: "E008", Exit: 8,
@@ -185,9 +185,9 @@ var catalog = map[error]Entry{
 	},
 	ErrHashMismatch: {
 		Code: "E011", Exit: 11,
-		Message: "Transfer completed but the file did not verify correctly.",
-		Action: "This usually means the sender's file changed mid-transfer, or there\n" +
-			"  was data corruption. The partial file has been deleted.\n" +
+		Message: "The file arrived corrupted — it doesn't match the sender's original.",
+		Action: "Usually this means the source changed during the transfer, or data\n" +
+			"  was damaged in transit. The partial file has been deleted.\n" +
 			"  Ask the sender to try again.",
 	},
 	ErrPathTraversal: {
@@ -203,17 +203,19 @@ var catalog = map[error]Entry{
 	},
 	ErrConnectFailed: {
 		Code: "E014", Exit: 14,
-		Message: "Could not connect to the other peer, even via the relay.",
-		Action: "This usually means one of:\n" +
-			"    - The relay server is unreachable from your network\n" +
-			"    - The other peer's connection dropped\n" +
-			"    - Your firewall blocks UDP traffic\n" +
-			"  Try: fsend --connect <different-server> or run with --debug for details.",
+		Message: "Could not reach the other side.",
+		Action: "fsend tried a direct connection and the server-relayed fallback;\n" +
+			"  neither worked. Common causes:\n" +
+			"    - The other side's fsend stopped or lost network.\n" +
+			"    - A firewall on either end blocks outbound traffic.\n" +
+			"    - The server is unreachable from your network.\n" +
+			"  Try a different server (`fsend --connect <host:port>`)\n" +
+			"  or re-run with --debug for details.",
 	},
 	ErrProtocolError: {
 		Code: "E015", Exit: 15,
-		Message: "Protocol error talking to the other peer.",
-		Action:  "Both sides must run a compatible fsend version.",
+		Message: "The two sides could not agree on how to transfer.",
+		Action:  "Make sure sender and receiver are on compatible fsend versions.",
 	},
 	ErrConfigCorrupted: {
 		Code: "E016", Exit: 0, // warning, not fatal
@@ -237,8 +239,8 @@ var catalog = map[error]Entry{
 	},
 	ErrPartialMismatch: {
 		Code: "E019", Exit: 19,
-		Message: "The source file changed since the last attempt — stale partial discarded.",
-		Action:  "Run the same command again to fetch a fresh copy from scratch.",
+		Message: "The source file changed since the last attempt — the incomplete download was discarded.",
+		Action:  "Run the same command again to start fresh.",
 	},
 	ErrTransientFailure: {
 		Code: "E020", Exit: 20,
@@ -254,16 +256,18 @@ var catalog = map[error]Entry{
 	},
 	ErrPeerAuthFailed: {
 		Code: "E022", Exit: 22,
-		Message: "Could not authenticate the other peer.",
-		Action: "Either the codes don't match or something in the network path\n" +
-			"  tampered with the connection. Re-share the code and try again.",
+		Message: "Could not verify the other side.",
+		Action: "Either the code you used doesn't match the one the sender shared,\n" +
+			"  or someone on the network tried to interfere. Re-share the code\n" +
+			"  and try again.",
 	},
 	ErrRelayCapHit: {
 		Code: "E023", Exit: 23,
-		Message: "The relay server's per-session byte cap was reached. Transfer aborted.",
-		Action: "Same-LAN and NAT-hole-punched transfers are uncapped; only the relay\n" +
-			"  fallback is metered. Workarounds:\n" +
-			"    - Send from a different network so the peers can hole-punch directly.\n" +
+		Message: "The server's transfer-size limit was reached. Transfer aborted.",
+		Action: "Only fallback transfers routed through the server count against this\n" +
+			"  limit; same-network and direct internet transfers are uncapped.\n" +
+			"  Workarounds:\n" +
+			"    - Run again from a different network so fsend can connect you directly.\n" +
 			"    - Self-host your own server (`fsend server`) and raise FSEND_MAX_RELAY_BYTES_PER_SESSION.",
 	},
 	ErrUsage: {
@@ -281,9 +285,9 @@ var catalog = map[error]Entry{
 	},
 	ErrLANListenerFailed: {
 		Code: "E027", Exit: 27,
-		Message: "Could not open the local-network listener.",
-		Action: "Another fsend (or another program) may already be using the port.\n" +
-			"  Try again — most codes use a different port.",
+		Message: "Could not open the port fsend uses to find the other side on your local network.",
+		Action: "Another fsend (or another program) may already be using that port.\n" +
+			"  Try again — most codes pick a different port.",
 	},
 	ErrServerAuthRequired: {
 		Code: "E028", Exit: 28,
@@ -294,10 +298,10 @@ var catalog = map[error]Entry{
 	},
 	ErrRelayIdleTimeout: {
 		Code: "E029", Exit: 29,
-		Message: "The relay session was reclaimed for inactivity. Transfer aborted.",
-		Action: "The server tore down the relay allocation because no traffic\n" +
-			"  flowed within its idle window. Try again, or self-host\n" +
-			"  (`fsend server`) and raise FSEND_SESSION_IDLE_TIMEOUT.",
+		Message: "The server closed the connection because no data was flowing. Transfer aborted.",
+		Action: "The fallback relay drops sessions that go idle for too long.\n" +
+			"  Try again, or self-host (`fsend server`) and raise\n" +
+			"  FSEND_SESSION_IDLE_TIMEOUT.",
 	},
 }
 


### PR DESCRIPTION
## Summary

Drop fsend-internal jargon from user-facing error messages so a CLI user without protocol knowledge can read them. Sentinel names, codes, and exit values are unchanged; only the `Message` and `Action` strings shift.

**Touched (9 entries):** E007, E011, E014, E015, E019, E022, E023, E027, E029.

**Left as-is (18 entries):** already read cleanly or use only standard CLI vocabulary (\"timeout\", \"rate limit\", \"config file\", etc.).

### Before / after highlights

| Code | Was | Is |
|---|---|---|
| E007 | \"The session expired on the server before a receiver paired.\" | \"Your code timed out before anyone received it.\" |
| E011 | \"Transfer completed but the file did not verify correctly.\" | \"The file arrived corrupted — it doesn't match the sender's original.\" |
| E014 | \"Could not connect to the other peer, even via the relay.\" + action with \"UDP\", \"relay server\", \"peer\" | \"Could not reach the other side.\" + plain-language action |
| E015 | \"Protocol error talking to the other peer.\" | \"The two sides could not agree on how to transfer.\" |
| E019 | \"...stale partial discarded.\" | \"...the incomplete download was discarded.\" |
| E022 | \"Could not authenticate the other peer.\" + \"network path tampered\" | \"Could not verify the other side.\" + \"someone on the network tried to interfere\" |
| E023 | \"...per-session byte cap...\" + \"NAT-hole-punched\" | \"...transfer-size limit...\" + plain-language workarounds |
| E027 | \"Could not open the local-network listener.\" | \"Could not open the port fsend uses to find the other side on your local network.\" |
| E029 | \"The relay session was reclaimed for inactivity.\" + \"tore down the relay allocation\" | \"The server closed the connection because no data was flowing.\" + \"The fallback relay drops sessions that go idle for too long.\" |

## Test plan

- [x] \`go test ./...\` — all packages pass (no tests assert on message text; only sentinel/code identity)
- [x] \`go vet ./...\` — clean
- [x] Exit-code table in \`docs/usage.md\` updated to match the new short-form wording

## Follow-up (separate branch)

Show server-set values inline for E023/E029 (e.g. \"100 MiB transfer-size limit reached\"), sourced from the server's relay-status response — not hardcoded. Will land as its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)