### PR TITLE
errors: show server-set limit values in E023/E029

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -157,8 +157,14 @@ func classifyRelayDrop(ctx context.Context, client *signaling.Client, sessionID 
 	}
 	switch status.Reason {
 	case relay.ReasonCapHit:
+		if status.LimitBytes > 0 {
+			return fmt.Errorf("%w: Server limit: %s", fserrors.ErrRelayCapHit, uxlog.HumanBytes(int64(status.LimitBytes)))
+		}
 		return fserrors.ErrRelayCapHit
 	case relay.ReasonIdle:
+		if status.IdleSeconds > 0 {
+			return fmt.Errorf("%w: Server idle window: %s", fserrors.ErrRelayIdleTimeout, uxlog.HumanDuration(time.Duration(status.IdleSeconds)*time.Second))
+		}
 		return fserrors.ErrRelayIdleTimeout
 	}
 	return runErr

--- a/cmd/fsend/internet_test.go
+++ b/cmd/fsend/internet_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -92,23 +93,41 @@ func TestJoinWithRetry_NonRetriableErrorPropagatesImmediately(t *testing.T) {
 }
 
 // Each eviction reason the relay reports must map to its sentinel; any
-// other state must leave runErr untouched.
+// other state must leave runErr untouched. When the server includes a
+// limit value, it must surface as a wrap detail so the renderer can
+// print it on its own line; without a value, the bare sentinel must
+// pass through cleanly so old servers don't break the user message.
 func TestClassifyRelayDrop_MapsReasons(t *testing.T) {
 	cases := []struct {
-		name      string
-		body      string
-		runErr    error
-		wantErr   error
-		wantSame  bool // when true, expect runErr to be returned unchanged
+		name       string
+		body       string
+		runErr     error
+		wantErr    error
+		wantDetail string // substring expected in err.Error() (skipped when empty)
+		wantSame   bool   // when true, expect runErr to be returned unchanged
 	}{
 		{
-			name:    "cap_hit_promotes_to_sentinel",
+			name:       "cap_hit_with_limit_includes_value",
+			body:       `{"state":"evicted","reason":"cap_hit","limit_bytes":104857600}`,
+			runErr:     errors.New("idle timeout"),
+			wantErr:    fserrors.ErrRelayCapHit,
+			wantDetail: "Server limit: 100.0 MB",
+		},
+		{
+			name:    "cap_hit_without_limit_is_bare_sentinel",
 			body:    `{"state":"evicted","reason":"cap_hit"}`,
 			runErr:  errors.New("idle timeout"),
 			wantErr: fserrors.ErrRelayCapHit,
 		},
 		{
-			name:    "idle_promotes_to_sentinel",
+			name:       "idle_with_seconds_includes_value",
+			body:       `{"state":"evicted","reason":"idle","idle_seconds":60}`,
+			runErr:     errors.New("idle timeout"),
+			wantErr:    fserrors.ErrRelayIdleTimeout,
+			wantDetail: "Server idle window: 1m00s",
+		},
+		{
+			name:    "idle_without_seconds_is_bare_sentinel",
 			body:    `{"state":"evicted","reason":"idle"}`,
 			runErr:  errors.New("idle timeout"),
 			wantErr: fserrors.ErrRelayIdleTimeout,
@@ -154,6 +173,9 @@ func TestClassifyRelayDrop_MapsReasons(t *testing.T) {
 			}
 			if !errors.Is(got, c.wantErr) {
 				t.Errorf("got %v, want %v", got, c.wantErr)
+			}
+			if c.wantDetail != "" && !strings.Contains(got.Error(), c.wantDetail) {
+				t.Errorf("got %q, want detail containing %q", got.Error(), c.wantDetail)
 			}
 		})
 	}

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -139,11 +139,15 @@ func renderError(err error, debug bool) int {
 	}
 	entry, known := fserrors.Lookup(err)
 
-	// For usage / source-not-found errors the wrap context is the
-	// useful part ("invalid --mode \"foo\"", "/path/to/missing.txt").
-	// Surface it so users see WHY without having to enable --debug.
+	// Surface wrap context as a second line so users see WHY without
+	// having to enable --debug. Used for:
+	//   - usage / source-not-found: the missing path or bad flag.
+	//   - relay-limit hits: the server's configured limit ("100 MiB").
 	detail := ""
-	if known && (errors.Is(err, fserrors.ErrUsage) || errors.Is(err, fserrors.ErrSourceNotFound)) {
+	if known && (errors.Is(err, fserrors.ErrUsage) ||
+		errors.Is(err, fserrors.ErrSourceNotFound) ||
+		errors.Is(err, fserrors.ErrRelayCapHit) ||
+		errors.Is(err, fserrors.ErrRelayIdleTimeout)) {
 		if extra := extractDetail(err.Error()); extra != "" {
 			detail = extra
 		}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -93,6 +93,12 @@ func NewServer(conn net.PacketConn, cfg ServerConfig) *Server {
 	}
 }
 
+// Limits exposes the configured per-session ceilings so the signaling
+// layer can include them in the relay-status response.
+func (s *Server) Limits() (maxBytes uint64, idleTimeout time.Duration) {
+	return s.cfg.MaxBytesPerSession, s.cfg.SessionIdleTimeout
+}
+
 // Status returns the eviction reason for a token, or "" if the
 // allocation is still live or unknown. Used by the signaling layer's
 // /v1/relay/status endpoint so the CLI can surface the real reason a

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -111,6 +111,7 @@ type Server struct {
 type RelayAllocator interface {
 	Allocate() (relay.Token, error)
 	Status(relay.Token) string
+	Limits() (maxBytes uint64, idleTimeout time.Duration)
 }
 
 // WithRelay wires a relay allocator and its public address into the
@@ -229,7 +230,15 @@ func (s *Server) relayStatus(w http.ResponseWriter, r *http.Request) {
 		writeJSON(w, http.StatusOK, RelayStatusResponse{State: "active"})
 		return
 	}
-	writeJSON(w, http.StatusOK, RelayStatusResponse{State: "evicted", Reason: reason})
+	resp := RelayStatusResponse{State: "evicted", Reason: reason}
+	maxBytes, idle := s.relayAllocator.Limits()
+	switch reason {
+	case relay.ReasonCapHit:
+		resp.LimitBytes = maxBytes
+	case relay.ReasonIdle:
+		resp.IdleSeconds = int(idle / time.Second)
+	}
+	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) allocateRelay(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,6 +8,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/polius/fsend/internal/relay"
 )
 
 func newTestServer(t *testing.T) *httptest.Server {
@@ -399,4 +401,107 @@ func TestServerPassword_OpenByDefault(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Errorf("open server: status = %d, want 200", resp.StatusCode)
 	}
+}
+
+// fakeRelay implements RelayAllocator with fixed responses, so the
+// relay-status handler can be exercised without standing up a UDP relay.
+type fakeRelay struct {
+	tok      relay.Token
+	reason   string
+	maxBytes uint64
+	idle     time.Duration
+}
+
+func (f *fakeRelay) Allocate() (relay.Token, error)              { return f.tok, nil }
+func (f *fakeRelay) Status(t relay.Token) string                 { return f.reason }
+func (f *fakeRelay) Limits() (uint64, time.Duration)             { return f.maxBytes, f.idle }
+
+// /v1/relay/status must echo back the operator-set ceiling so the CLI
+// can render a concrete error ("server limit 100 MiB") instead of a
+// generic "limit reached." Cap-hit and idle each carry their own field;
+// the other stays zero (omitempty drops it from the JSON entirely).
+func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
+	cases := []struct {
+		name        string
+		reason      string
+		wantBytes   uint64
+		wantSeconds int
+	}{
+		{name: "cap_hit", reason: relay.ReasonCapHit, wantBytes: 100 * 1024 * 1024},
+		{name: "idle", reason: relay.ReasonIdle, wantSeconds: 60},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			s := New(Config{
+				ServerVersion:        "0.0.0-test",
+				UnpairedTTL:          2 * time.Second,
+				PairedTTL:            5 * time.Second,
+				LongPollTimeout:      500 * time.Millisecond,
+				MaxSessionsPerIP:     10,
+				MaxNewSessionsPerMin: 100,
+			})
+			alloc := &fakeRelay{
+				tok:      relay.Token{1, 2, 3, 4},
+				reason:   c.reason,
+				maxBytes: 100 * 1024 * 1024,
+				idle:     60 * time.Second,
+			}
+			s.WithRelay(alloc, "127.0.0.1:9999")
+			ts := httptest.NewServer(s.Handler())
+			defer ts.Close()
+
+			// Pair: create a session and allocate the relay token so
+			// /relay/status has a token to look up.
+			created := postJSON(t, ts.URL+"/v1/session", CreateSessionRequest{})
+			defer created.Body.Close()
+			var cr CreateSessionResponse
+			if err := json.NewDecoder(created.Body).Decode(&cr); err != nil {
+				t.Fatal(err)
+			}
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/relay/allocate",
+				bytes.NewReader(mustJSON(t, RelayAllocateRequest{SessionID: cr.SessionID})))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+cr.RoleToken)
+			alloced, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			alloced.Body.Close()
+			if alloced.StatusCode != 200 {
+				t.Fatalf("allocate: status = %d", alloced.StatusCode)
+			}
+
+			resp, err := http.Get(ts.URL + "/v1/relay/status?session_id=" + cr.SessionID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			var body RelayStatusResponse
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.State != "evicted" {
+				t.Fatalf("state = %q, want evicted", body.State)
+			}
+			if body.Reason != c.reason {
+				t.Errorf("reason = %q, want %q", body.Reason, c.reason)
+			}
+			if body.LimitBytes != c.wantBytes {
+				t.Errorf("limit_bytes = %d, want %d", body.LimitBytes, c.wantBytes)
+			}
+			if body.IdleSeconds != c.wantSeconds {
+				t.Errorf("idle_seconds = %d, want %d", body.IdleSeconds, c.wantSeconds)
+			}
+		})
+	}
+}
+
+func mustJSON(t *testing.T, v any) []byte {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return b
 }

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -108,9 +108,16 @@ type HealthResponse struct {
 //
 // Reason is set only when State == "evicted"; valid values are
 // relay.ReasonCapHit and relay.ReasonIdle.
+//
+// LimitBytes is populated when Reason == ReasonCapHit; IdleSeconds when
+// Reason == ReasonIdle. Both are omitempty so older servers that don't
+// set them round-trip as zero and the CLI falls back to the generic
+// message instead of saying "0 MiB" / "0s".
 type RelayStatusResponse struct {
-	State  string `json:"state"`
-	Reason string `json:"reason,omitempty"`
+	State       string `json:"state"`
+	Reason      string `json:"reason,omitempty"`
+	LimitBytes  uint64 `json:"limit_bytes,omitempty"`
+	IdleSeconds int    `json:"idle_seconds,omitempty"`
 }
 
 // ErrorResponse is the body of any 4xx/5xx response.


### PR DESCRIPTION
## Summary

When the relay evicts a session for `cap_hit` or `idle`, the CLI now renders the operator's configured ceiling on its own line:

\`\`\`
✗ [E023] The server's transfer-size limit was reached. Transfer aborted.
  Server limit: 100.0 MB
  Only fallback transfers routed through the server count against this
  limit; same-network and direct internet transfers are uncapped.
  Workarounds: ...

✗ [E029] The server closed the connection because no data was flowing. Transfer aborted.
  Server idle window: 1m00s
  The fallback relay drops sessions that go idle for too long.
  Try again, or self-host (\`fsend server\`) and raise FSEND_SESSION_IDLE_TIMEOUT.
\`\`\`

The value is **sourced from the server**, not hardcoded — a self-hosted instance with \`FSEND_MAX_RELAY_BYTES_PER_SESSION=1GiB\` shows \"1.0 GB\", and a future change to the default never needs a coordinated CLI release.

## Wire-protocol change (backward-compatible)

\`RelayStatusResponse\` grows two omitempty fields:

\`\`\`go
LimitBytes  uint64 \`json:\"limit_bytes,omitempty\"\`
IdleSeconds int    \`json:\"idle_seconds,omitempty\"\`
\`\`\`

Older servers don't set them → JSON drops the fields → CLI decodes zero → \`classifyRelayDrop\` returns the bare sentinel → user sees today's generic message. New CLI on old server still works.

## Implementation note

No new error type needed. The catalog already has a detail-line mechanism (used today for E024 \"invalid usage\" and E025 \"source not found\"): wrap the sentinel with \`fmt.Errorf(\"%w: <detail>\", ...)\`, and \`renderError\` extracts the detail via \`extractDetail\`. This PR opts \`ErrRelayCapHit\` and \`ErrRelayIdleTimeout\` into the same path and has \`classifyRelayDrop\` build the wrap from the server-returned values.

\`RelayAllocator\` interface grows one method:

\`\`\`go
Limits() (maxBytes uint64, idleTimeout time.Duration)
\`\`\`

## Out of scope (per the design discussion)

- **E017** rate limit: knowing \"5 concurrent sessions\" doesn't change what the user does. The self-host nudge is already in the message; the numeric value isn't actionable.
- **E028** server password: no value to show. Explicitly not nudged toward self-host either — if you can't get the password, you usually can't self-host.

## Test plan

- [x] \`go test ./...\` — all packages pass
- [x] \`go vet ./...\` — clean
- [x] \`TestClassifyRelayDrop_MapsReasons\` extended: covers cap_hit-with-limit, cap_hit-bare (old server), idle-with-seconds, idle-bare (old server), plus existing active/unknown/unmapped pass-through cases
- [x] New \`TestRelayStatus_IncludesConfiguredLimits\` on the server side: stands up \`Server.WithRelay(fakeRelay{...})\` via \`httptest\`, drives create→allocate→status, asserts that \`limit_bytes\` is populated for cap_hit and \`idle_seconds\` for idle (each leaving the other field at zero)

🤖 Generated with [Claude Code](https://claude.com/claude-code)