### PR TITLE
test/e2e: wait for sidecar before SIGINT in SenderSIGINTMidTransfer

### DIFF
--- a/test/e2e/signal_test.go
+++ b/test/e2e/signal_test.go
@@ -37,7 +37,18 @@ func TestSignal_SenderSIGINTMidTransfer(t *testing.T) {
 	rDone := make(chan error, 1)
 	go func() { rDone <- rCmd.Wait() }()
 
-	time.Sleep(400 * time.Millisecond)
+	// Poll for the sidecar instead of a fixed sleep — a 400 ms wait was
+	// below CI's noise floor on fast Ubuntu runners, where the 64 MiB
+	// loopback transfer could finish before SIGINT landed and the
+	// receiver would legitimately exit 0. Sidecar presence proves the
+	// receiver is actively writing chunks, so SIGINT is guaranteed to
+	// interrupt an in-flight transfer.
+	if !waitForSidecar(dst, 5*time.Second) {
+		_ = s.cmd.Process.Kill()
+		_ = rCmd.Process.Kill()
+		<-rDone
+		t.Fatal("no .fsend-partial sidecar appeared within 5s — receiver never started writing")
+	}
 	s.signal(t, syscall.SIGINT)
 	s.wait(t, 5*time.Second)
 


### PR DESCRIPTION
## Summary

Cherry-picked from the stale \`release/install-sh-asset\` branch, which is otherwise redundant with what's already on main (PRs #6 and #8). This is the one commit on that branch that never landed.

\`TestSignal_SenderSIGINTMidTransfer\` at \`test/e2e/signal_test.go:40\` currently waits a fixed \`time.Sleep(400 * time.Millisecond)\` before sending SIGINT. On fast CI runners (Ubuntu), the 64 MiB loopback transfer can finish before SIGINT lands, so the receiver legitimately exits 0 and the test fails its \"should be non-zero\" check.

Switch to polling for the \`.fsend-partial\` sidecar — its presence proves the receiver is actively writing chunks, so SIGINT is guaranteed to interrupt an in-flight transfer. Same pattern \`TestSignal_ResumeAfterSIGINT\` (sibling test in the same file) already uses for exactly the same reason.

## Test plan

- [x] \`go test ./...\` — full suite passes
- [x] \`go test -run TestSignal_SenderSIGINTMidTransfer -count=3 ./test/e2e/\` — runs cleanly across repeats
- [x] \`go vet ./...\` — clean

## After this merges

The \`release/install-sh-asset\` branch will have nothing unique left and can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)