### PR TITLE
ci: rename test.yml workflow to checks.yml

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,4 +1,4 @@
-name: test
+name: checks
 
 on:
   push:

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 <p align="center"><strong>Direct, end-to-end encrypted file transfer.</strong></p>
 
 <p align="center">
-  <a href="https://github.com/polius/fsend/actions/workflows/test.yml"><img src="https://github.com/polius/fsend/actions/workflows/test.yml/badge.svg" alt="CI"></a>
+  <a href="https://github.com/polius/fsend/actions/workflows/checks.yml"><img src="https://github.com/polius/fsend/actions/workflows/checks.yml/badge.svg" alt="checks"></a>
   <a href="https://github.com/polius/fsend/releases"><img src="https://img.shields.io/github/v/release/polius/fsend" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
 </p>


### PR DESCRIPTION
## Summary

The workflow currently named \`test\` runs three jobs — \`test\`, \`lint\`, \`cross-compile\` — so calling the whole thing \"test\" undersells it. \"Checks\" reads more accurately on the README badge: it covers anything that can pass or fail in CI.

## What changes

- \`.github/workflows/test.yml\` → \`.github/workflows/checks.yml\` (file rename).
- \`name: test\` → \`name: checks\` inside the workflow. This is the string GitHub renders on the badge — the filename only matters for the URL.
- README badge URL and alt text updated to match.

## What does NOT change

- **Job IDs** (\`test\`, \`lint\`, \`cross-compile\`) and **matrix combos** (\`test (ubuntu-latest)\` etc.) are unchanged, so any branch-protection required-status-checks keep matching.
- **Triggers** (\`push\` to main, \`pull_request\`) are unchanged.
- **Job contents** are byte-identical.

## Things to double-check on GitHub after merging

- The first push to main after this lands will populate \`checks.yml\` with its first run. Until then the badge may briefly say \"no status.\"
- If you have branch-protection rules in repo Settings → Branches that reference the workflow file path (rare — most reference job names), they'll need a one-line update. Job-name-based rules are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)