### PR TITLE
ci: fix gofmt regression in internal/server/server_test.go

### DIFF
--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -412,9 +412,9 @@ type fakeRelay struct {
 	idle     time.Duration
 }
 
-func (f *fakeRelay) Allocate() (relay.Token, error)              { return f.tok, nil }
-func (f *fakeRelay) Status(t relay.Token) string                 { return f.reason }
-func (f *fakeRelay) Limits() (uint64, time.Duration)             { return f.maxBytes, f.idle }
+func (f *fakeRelay) Allocate() (relay.Token, error)  { return f.tok, nil }
+func (f *fakeRelay) Status(t relay.Token) string     { return f.reason }
+func (f *fakeRelay) Limits() (uint64, time.Duration) { return f.maxBytes, f.idle }
 
 // /v1/relay/status must echo back the operator-set ceiling so the CLI
 // can render a concrete error ("server limit 100 MiB") instead of a


### PR DESCRIPTION
## Summary

CI's lint job has been failing on every run since #17 merged. Root cause: I hand-aligned three \`fakeRelay\` method signatures with extra padding spaces, which gofmt rejects:

\`\`\`go
func (f *fakeRelay) Allocate() (relay.Token, error)              { return f.tok, nil }
func (f *fakeRelay) Status(t relay.Token) string                 { return f.reason }
func (f *fakeRelay) Limits() (uint64, time.Duration)             { return f.maxBytes, f.idle }
\`\`\`

golangci-lint surfaces this as:

\`\`\`
internal/server/server_test.go:415:1: File is not properly formatted (gofmt)
\`\`\`

Fix: \`gofmt -w internal/server/server_test.go\`. That's all. No behavior changes, no workarounds, no infra changes — the existing CI already does the right thing; my code was just out-of-spec.

## Verification

- \`gofmt -l .\` — no unformatted files anywhere in the tree (confirmed nothing else was lurking)
- \`go build ./... && go vet ./... && go test ./...\` — all green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)