### PR TITLE
tests: lock in dispatch flag-conflict contract and version.String

### DIFF
--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/polius/fsend/internal/fserrors"
+)
+
+// dispatch returns ErrUsage with a specific message for each invalid
+// flag combination. Lock the contract in so refactors can't silently
+// drop a guard or change the wording users will see in [E024].
+func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantSub string
+	}{
+		{
+			"connect_with_send",
+			[]string{"--connect=host:443", "--send", "file.txt"},
+			"--connect cannot be combined with --send",
+		},
+		{
+			"connect_with_text",
+			[]string{"--connect=host:443", "--text=hi"},
+			"--connect cannot be combined with --text",
+		},
+		{
+			"send_and_receive_both",
+			[]string{"--send", "--receive", "abc-defg-jkm"},
+			"--send and --receive are mutually exclusive",
+		},
+		{
+			"invalid_mode",
+			[]string{"--mode=garbage"},
+			`invalid --mode "garbage"`,
+		},
+		{
+			"force_receive_zero_args",
+			[]string{"--receive"},
+			"--receive requires exactly one positional argument",
+		},
+		{
+			"force_receive_two_args",
+			[]string{"--receive", "abc-defg-jkm", "extra"},
+			"--receive requires exactly one positional argument",
+		},
+		{
+			"text_empty_string",
+			[]string{"--text="},
+			"--text requires a non-empty string",
+		},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			cmd := rootCmd()
+			cmd.SetArgs(c.args)
+			cmd.SetOut(io.Discard)
+			cmd.SetErr(io.Discard)
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatalf("expected error, got nil")
+			}
+			if !errors.Is(err, fserrors.ErrUsage) {
+				t.Errorf("got %v, want wrapping ErrUsage", err)
+			}
+			if !strings.Contains(err.Error(), c.wantSub) {
+				t.Errorf("got %q, want substring %q", err.Error(), c.wantSub)
+			}
+		})
+	}
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,28 @@
+package version
+
+import "testing"
+
+// String shapes the user-visible header on --version and --help. Dev
+// builds collapse to "fsend dev" because Commit/Date are unset; release
+// builds carry the full "(build SHA, DATE)" parenthetical.
+func TestString(t *testing.T) {
+	orig := struct{ Ver, Commit, Date string }{Version, Commit, Date}
+	t.Cleanup(func() { Version, Commit, Date = orig.Ver, orig.Commit, orig.Date })
+
+	cases := []struct {
+		name                  string
+		version, commit, date string
+		want                  string
+	}{
+		{"dev_default", "dev", "unknown", "unknown", "fsend dev"},
+		{"dev_empty_commit", "dev", "", "2026-06-01", "fsend dev"},
+		{"dev_empty_date", "dev", "abc1234", "", "fsend dev"},
+		{"release", "0.1.0", "abc1234", "2026-06-01", "fsend 0.1.0 (build abc1234, 2026-06-01)"},
+	}
+	for _, c := range cases {
+		Version, Commit, Date = c.version, c.commit, c.date
+		if got := String(); got != c.want {
+			t.Errorf("%s: got %q, want %q", c.name, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Two focused, valid-scenario tests for paths users actually hit but no automated guard exists for today. Pure coverage — no production code touched.

### 1. \`cmd/fsend/root_test.go\` — dispatch's ErrUsage surface

\`dispatch\` (in \`cmd/fsend/root.go\`) has seven well-defined ErrUsage branches and zero unit tests. Table-driven test exercises each:

| Case | Args | Locked-in substring |
|---|---|---|
| connect+send | \`--connect=host:443 --send file.txt\` | \`--connect cannot be combined with --send\` |
| connect+text | \`--connect=host:443 --text=hi\` | \`--connect cannot be combined with --text\` |
| send+receive | \`--send --receive abc-defg-jkm\` | \`--send and --receive are mutually exclusive\` |
| invalid mode | \`--mode=garbage\` | \`invalid --mode \"garbage\"\` |
| force-receive 0 args | \`--receive\` | \`--receive requires exactly one positional argument\` |
| force-receive 2 args | \`--receive abc-defg-jkm extra\` | \`--receive requires exactly one positional argument\` |
| empty --text | \`--text=\` | \`--text requires a non-empty string\` |

Each case asserts the error wraps \`ErrUsage\` AND carries the user-visible substring, so a refactor that silently drops a guard or shifts the wording shows up in CI.

All seven cases short-circuit BEFORE \`runSend\` / \`runReceive\`, so the tests don't touch the network.

### 2. \`internal/version/version_test.go\` — \`String()\`

\`version.String()\` shapes the user-visible \`--version\` and \`--help\` header but had 0% coverage. Two branches:

- Dev: \`Commit\` or \`Date\` unset → \`\"fsend dev\"\`
- Release: both set → \`\"fsend 0.1.0 (build abc1234, 2026-06-01)\"\`

Four sub-cases cover the dev short-circuit (default \"unknown\", empty Commit, empty Date) plus the release format.

## What I deliberately skipped

- \`landisc.Announce\`/\`Query\` (0% coverage but need UDP multicast).
- \`runSend\`/\`runReceive\`/\`dispatch\`'s auto-detect run paths (covered by \`test/e2e\` via the compiled binary).
- Interactive code paths (\`promptCodeOrPath\`, \`readPasswordHidden\`) — need a TTY harness.

These would require infrastructure, not just tests; not worth the over-engineering trade today.

## Test plan

- [x] \`go test ./...\` — full suite passes
- [x] \`gofmt -l .\` — clean
- [x] \`go vet ./...\` — clean
- [x] Coverage uplift: \`cmd/fsend\` 38.7% → 40.4%, \`internal/version\` 0% → 100%

🤖 Generated with [Claude Code](https://claude.com/claude-code)