### PR TITLE
test/e2e: build fsend with -cover so the binary's coverage is measured

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -243,18 +243,26 @@ func iceEstablish(parent context.Context, sig *signaling.Client, sessionID, role
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		// Push each gathered local candidate one-shot. We use the parent
-		// ctx for the HTTP call so it can outlive pumpCtx briefly when
-		// pumpCtx is cancelled mid-push (we still want the candidate to
-		// land if possible).
-		for cstr := range agent.LocalCandidates() {
-			if pumpCtx.Err() != nil {
+		// Push each gathered local candidate one-shot. The select on
+		// pumpCtx is load-bearing: if ICE times out before pion finishes
+		// gathering (no STUN host on loopback, no candidates beyond the
+		// initial host set), agent.LocalCandidates never closes — a bare
+		// `for range` would block here, wg.Wait() would hang waiting for
+		// it, and the deferred agent.Close() (which closes the channel)
+		// would never run. Closing the loop on pumpCtx breaks that cycle.
+		for {
+			select {
+			case <-pumpCtx.Done():
 				return
-			}
-			if err := sig.PushCandidates(pumpCtx, sessionID, roleToken, []string{cstr}); err != nil {
-				// Best-effort: pion's ICE will keep going with whatever
-				// candidates have already crossed; surface in --debug only.
-				_ = err
+			case cstr, ok := <-agent.LocalCandidates():
+				if !ok {
+					return
+				}
+				if err := sig.PushCandidates(pumpCtx, sessionID, roleToken, []string{cstr}); err != nil {
+					// Best-effort: pion's ICE will keep going with whatever
+					// candidates have already crossed; surface in --debug only.
+					_ = err
+				}
 			}
 		}
 	}()

--- a/docs/development.md
+++ b/docs/development.md
@@ -32,6 +32,19 @@ go test -v ./test/e2e/
 The E2E suite builds its own binary in a temp dir and runs an isolated
 server on loopback — no shell wrapper needed.
 
+## Coverage
+
+```sh
+scripts/coverage.sh
+```
+
+Runs unit and E2E tests with coverage and prints the merged total. The
+E2E suite builds `fsend` with `-cover -coverpkg=./...` when `go test`
+is invoked with `-cover`, so orchestration code exercised by the E2E
+harness (sender/receiver pairing, ICE, relay) shows up in the number
+instead of reading as 0% the way per-package profiling does. Current
+total hovers around 77%.
+
 ## LAN smoke test (no server needed)
 
 `fsend` uses mDNS for direct peer-to-peer on the same LAN.

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -23,7 +23,10 @@ go test -coverpkg="$unit_pkgs" -coverprofile=unit_coverage.out \
     $(go list ./... | grep -v '/test/e2e$') >/dev/null
 
 echo "==> e2e tests"
-go test -cover -coverpkg=./... ./test/e2e/ >/dev/null
+# -count=1 disables the test cache. Cached test results skip TestMain,
+# which is where the harness converts covdata to e2e_coverage.out — so
+# without this, a second invocation produces no e2e profile.
+go test -count=1 -cover -coverpkg=./... ./test/e2e/ >/dev/null
 
 echo "==> merge"
 {

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# Runs unit and e2e tests with coverage and prints the merged total.
+#
+# Unit tests use Go's classic -coverprofile output. The e2e suite builds
+# fsend with -cover (see test/e2e/harness_test.go) and writes its
+# profile to e2e_coverage.out on shutdown. Both are "set" mode by
+# default and can be concatenated — the second mode header is stripped.
+#
+# Outputs (gitignored, *.out):
+#   unit_coverage.out      — unit-test coverage profile
+#   e2e_coverage.out       — e2e-binary coverage profile
+#   merged_coverage.out    — both, ready for `go tool cover`
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+echo "==> unit tests"
+# Exclude the e2e package from unit-test instrumentation — it runs the
+# binary as a subprocess and has no unit-testable statements of its own.
+unit_pkgs=$(go list ./... | grep -v '/test/e2e$' | paste -sd, -)
+go test -coverpkg="$unit_pkgs" -coverprofile=unit_coverage.out \
+    $(go list ./... | grep -v '/test/e2e$') >/dev/null
+
+echo "==> e2e tests"
+go test -cover -coverpkg=./... ./test/e2e/ >/dev/null
+
+echo "==> merge"
+{
+    cat unit_coverage.out
+    tail -n +2 e2e_coverage.out
+} > merged_coverage.out
+
+go tool cover -func=merged_coverage.out | tail -1

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -42,6 +42,13 @@ type harness struct {
 	httpPort int
 	udpPort  int
 
+	// withCover is true when the suite ran under `go test -cover`. In
+	// that mode the binary is built with -cover -coverpkg=./... and the
+	// harness converts the covdata go test writes to GOCOVERDIR into a
+	// textual profile on shutdown. Subprocesses inherit GOCOVERDIR
+	// automatically via os.Environ().
+	withCover bool
+
 	serverCmd    *exec.Cmd
 	serverOutput bytes.Buffer
 }
@@ -83,7 +90,8 @@ func startHarness() (*harness, error) {
 		fsendBin: filepath.Join(binDir, binName),
 	}
 
-	if err := goBuild(repoDir, hh.fsendBin, "./cmd/fsend"); err != nil {
+	hh.withCover = testing.CoverMode() != ""
+	if err := goBuild(repoDir, hh.fsendBin, "./cmd/fsend", hh.withCover); err != nil {
 		return nil, fmt.Errorf("build fsend: %w", err)
 	}
 
@@ -131,7 +139,31 @@ func (hh *harness) shutdown() {
 	}
 	_ = hh.serverCmd.Process.Kill()
 	_, _ = hh.serverCmd.Process.Wait()
+	hh.emitCoverageProfile()
 	_ = os.RemoveAll(filepath.Dir(hh.fsendBin))
+}
+
+// emitCoverageProfile converts the covdata go test wrote to its
+// GOCOVERDIR into a textual profile at <repoDir>/e2e_coverage.out.
+// No-op when the harness ran without -cover.
+func (hh *harness) emitCoverageProfile() {
+	if !hh.withCover {
+		return
+	}
+	covdir := os.Getenv("GOCOVERDIR")
+	if covdir == "" {
+		fmt.Fprintln(os.Stderr, "e2e: -cover is on but GOCOVERDIR is unset; no profile to emit")
+		return
+	}
+	out := filepath.Join(hh.repoDir, "e2e_coverage.out")
+	cmd := exec.Command("go", "tool", "covdata", "textfmt", "-i="+covdir, "-o="+out)
+	cmd.Stdout = os.Stderr
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "e2e: covdata textfmt failed: %v\n", err)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "e2e: coverage profile written to %s\n", out)
 }
 
 // repoRoot returns the directory containing go.mod for the current module.
@@ -147,8 +179,13 @@ func repoRoot() (string, error) {
 	return filepath.Dir(gomod), nil
 }
 
-func goBuild(repoDir, outPath, pkg string) error {
-	cmd := exec.Command("go", "build", "-o", outPath, pkg)
+func goBuild(repoDir, outPath, pkg string, withCover bool) error {
+	args := []string{"build"}
+	if withCover {
+		args = append(args, "-cover", "-coverpkg=./...")
+	}
+	args = append(args, "-o", outPath, pkg)
+	cmd := exec.Command("go", args...)
 	cmd.Dir = repoDir
 	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Summary

Wire up end-to-end coverage measurement so the orchestration code in \`cmd/fsend\` that's exercised by the e2e suite (but invisible to per-package unit profiling) actually counts. Adds \`scripts/coverage.sh\` as the single source of truth for \"what's our coverage?\". Also fixes a real production deadlock that was lurking in \`iceEstablish\`, exposed by cover instrumentation.

## Result

| | Before (main) | After (this PR) |
|---|---|---|
| **Overall coverage** | **59.4%** | **76.8%** |

The +17 pp uplift is entirely \"invisible coverage\" — code the e2e suite was already exercising but Go's per-package profiling couldn't see across the binary boundary. Sample of functions that flipped from 0% → covered:

| Function | Before | After |
|---|---|---|
| \`internet.go:classifyRelayDrop\` | 0% | 100% |
| \`internet.go:runReceiverQUICOver\` | 0% | 88.2% |
| \`internet.go:iceEstablish\` | 0% | 81.8% |
| \`internet.go:runReceiveOverInternet\` | 0% | 50.0% |
| \`internet.go:joinWithRetry\` | 0% | 88.2% |

Zero new tests written; this PR just makes existing test coverage measurable.

## How the instrumentation works

1. **Harness builds the binary with \`-cover\`** when \`testing.CoverMode() != \"\"\` (i.e., \`go test -cover\` was invoked). Otherwise it builds normally — no overhead in the default path.
2. **Subprocesses inherit \`GOCOVERDIR\`** from \`go test\` automatically via \`os.Environ()\` — no per-spawn plumbing.
3. **On harness shutdown**, \`go tool covdata textfmt\` converts the accumulated covdata to \`e2e_coverage.out\` at the repo root.
4. **\`scripts/coverage.sh\`** runs unit tests + e2e tests, concatenates the two \"set\"-mode profiles, and prints the merged total. Uses \`-count=1\` on the e2e step so the test cache can't skip TestMain (which would leave the profile unwritten).

Total diff: ~50 lines in \`test/e2e/harness_test.go\`, ~25 lines in \`scripts/coverage.sh\`.

## Real bug found and fixed

Wiring up the instrumentation exposed a deadlock in \`cmd/fsend/internet.go:iceEstablish\`. The push goroutine ranged over \`agent.LocalCandidates()\`, which only closes when pion finishes gathering. If ICE timed out *before* gathering completed — the exact case \`TestServer_PasswordGate\` exercises with \`--mode stun\` on loopback — the channel never closed, the push goroutine blocked in \`for range\`, \`wg.Wait()\` hung, and the deferred \`agent.Close()\` (which would have closed the channel) was unreachable. Classic close-vs-wait deadlock.

The bug was always there but only fired under slow execution. Cover instrumentation slowed gathering enough to make it routine: \`~1/3\` of e2e-with-cover runs hung on \`TestServer_PasswordGate\` before this fix. Same flake under \`go test -race\`. The fix replaces the bare \`for range\` with a select that respects \`pumpCtx\` cancellation — same happy-path behavior, but the timeout path now actually terminates.

**Stress results after the fix:** 10/10 with \`-cover\`, 8/8 with \`-race\`. Suite runtime back to ~14s.

## Test plan

- [x] \`gofmt -l .\` — clean
- [x] \`go vet ./...\` — clean
- [x] \`go test ./...\` (no \`-cover\`) — passes in ~14s (unchanged from main)
- [x] \`go test -cover -coverpkg=./... ./test/e2e/\` — 10/10 stable
- [x] \`go test -race ./test/e2e/\` — 8/8 stable
- [x] \`bash scripts/coverage.sh\` — produces \`76.8%\` total

## Follow-ups (separate work)

- Decide whether to add the coverage badge to the README now that the number reflects reality.
- Optionally wire \`scripts/coverage.sh\` into CI as a non-blocking step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)