### PR TITLE
audit pass: retry classifier, dead-code cleanup, doc fixes, deadcode CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,6 +34,23 @@ jobs:
           version: latest
           args: --timeout=5m
 
+  deadcode:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.25"
+          cache: true
+      - run: go install golang.org/x/tools/cmd/deadcode@latest
+      - run: |
+          out=$(deadcode -test ./...)
+          if [ -n "$out" ]; then
+            echo "deadcode found unreachable symbols:"
+            echo "$out"
+            exit 1
+          fi
+
   cross-compile:
     runs-on: ubuntu-latest
     strategy:

--- a/deploy/compose/Caddyfile
+++ b/deploy/compose/Caddyfile
@@ -2,7 +2,9 @@
 
 {$FSEND_DOMAIN} {
     reverse_proxy fsend:8080 {
-        # X-Real-IP isn't set by Caddy; the server uses it for rate-limiting.
+        # Caddy doesn't set X-Real-IP by default; the fsend server reads it
+        # for per-IP rate limiting, so set it explicitly to the upstream
+        # peer's address.
         header_up X-Real-IP {remote_host}
 
         # Must exceed the 25s signaling long-poll window.

--- a/docs/development.md
+++ b/docs/development.md
@@ -80,7 +80,7 @@ of `:443` (would need root) and the common port collision on `:8080`.
 `FSEND_PUBLIC_ADDR` is what the server advertises to clients for relay —
 must be dialable from the client side.
 
-Point a client at it (persists to `~/.config/fsend/config.toml`):
+Point a client at it (persists to the config file — see "Isolated config" below for the path):
 
 ```sh
 /tmp/fsend --connect http://127.0.0.1:18080
@@ -114,13 +114,13 @@ tunables, see [Self-hosting](self-hosting.md).
 
 ## Isolated config
 
-To experiment with `--connect` without overwriting your real
-`~/.config/fsend/config.toml`, point the client at a throwaway config
-root:
+To experiment with `--connect` without overwriting your real config,
+point the client at a throwaway config root:
 
 ```sh
 XDG_CONFIG_HOME=/tmp/fsend-dev /tmp/fsend --connect http://127.0.0.1:18080
 ```
 
-Config lives at `~/.config/fsend/config.toml` (macOS/Linux) or
-`%APPDATA%\fsend\config.toml` (Windows).
+Config lives at `~/.config/fsend/config.json` (Linux),
+`~/Library/Application Support/fsend/config.json` (macOS), or
+`%APPDATA%\fsend\config.json` (Windows).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -66,7 +66,9 @@ On every client that should use your server instead of the default:
 fsend --connect fs.example.com:443
 ```
 
-Persists to `~/.config/fsend/config.toml`. Revert to the public default
+Persists to `~/.config/fsend/config.json` (Linux),
+`~/Library/Application Support/fsend/config.json` (macOS), or
+`%APPDATA%\fsend\config.json` (Windows). Revert to the public default
 with `fsend --connect default`.
 
 ## Operations

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -85,8 +85,9 @@ fsend --connect default                      # back to the public default
 fsend --connect                              # show current
 ```
 
-Config is at `~/.config/fsend/config.toml` (macOS/Linux) or
-`%APPDATA%\fsend\config.toml` (Windows). See
+Config is at `~/.config/fsend/config.json` (Linux),
+`~/Library/Application Support/fsend/config.json` (macOS), or
+`%APPDATA%\fsend\config.json` (Windows). See
 [Self-hosting](self-hosting.md) to run your own.
 
 ## Shared flags

--- a/internal/connpath/connpath.go
+++ b/internal/connpath/connpath.go
@@ -96,22 +96,6 @@ func FromICE(localType, remoteType string) Info {
 	return info
 }
 
-// Short returns the compact lowercase form, e.g. "direct (local network)".
-// Currently unused by production code; retained for parity with Tag()
-// in case a caller wants the inline-noun form.
-func (i Info) Short() string {
-	switch i.Kind {
-	case KindLocal:
-		return "direct (local network)"
-	case KindDirectNAT:
-		return "direct (internet)"
-	case KindRelay:
-		return "relayed"
-	default:
-		return "unknown"
-	}
-}
-
 // Tag returns the compact path label used in summary lines and inline
 // chips, e.g. "Direct on local network", "Direct over the internet",
 // "Relayed via <host>".

--- a/internal/connpath/connpath_test.go
+++ b/internal/connpath/connpath_test.go
@@ -4,47 +4,43 @@ import "testing"
 
 func TestFromICE_Classification(t *testing.T) {
 	cases := []struct {
-		name      string
-		local     string
-		remote    string
-		want      Kind
-		wantShort string
+		name   string
+		local  string
+		remote string
+		want   Kind
 	}{
 		// Spec rule: host ↔ host means peers reached each other on
 		// interface addresses, so we claim Local.
-		{"host_host_is_local", "host", "host", KindLocal, "direct (local network)"},
+		{"host_host_is_local", "host", "host", KindLocal},
 
 		// Anything involving srflx / prflx means a NAT was crossed —
 		// classified as DirectNAT (direct peer-to-peer over the internet).
-		{"srflx_srflx_is_direct_nat", "srflx", "srflx", KindDirectNAT, "direct (internet)"},
-		{"srflx_host_is_direct_nat", "srflx", "host", KindDirectNAT, "direct (internet)"},
-		{"host_srflx_is_direct_nat", "host", "srflx", KindDirectNAT, "direct (internet)"},
-		{"prflx_host_is_direct_nat", "prflx", "host", KindDirectNAT, "direct (internet)"},
-		{"host_prflx_is_direct_nat", "host", "prflx", KindDirectNAT, "direct (internet)"},
-		{"prflx_prflx_is_direct_nat", "prflx", "prflx", KindDirectNAT, "direct (internet)"},
-		{"srflx_prflx_is_direct_nat", "srflx", "prflx", KindDirectNAT, "direct (internet)"},
+		{"srflx_srflx_is_direct_nat", "srflx", "srflx", KindDirectNAT},
+		{"srflx_host_is_direct_nat", "srflx", "host", KindDirectNAT},
+		{"host_srflx_is_direct_nat", "host", "srflx", KindDirectNAT},
+		{"prflx_host_is_direct_nat", "prflx", "host", KindDirectNAT},
+		{"host_prflx_is_direct_nat", "host", "prflx", KindDirectNAT},
+		{"prflx_prflx_is_direct_nat", "prflx", "prflx", KindDirectNAT},
+		{"srflx_prflx_is_direct_nat", "srflx", "prflx", KindDirectNAT},
 
 		// Relay anywhere means a relay candidate was selected — surface
 		// it distinctly even though the controlling side may have a
 		// direct candidate.
-		{"relay_host_is_relay", "relay", "host", KindRelay, "relayed"},
-		{"host_relay_is_relay", "host", "relay", KindRelay, "relayed"},
-		{"relay_relay_is_relay", "relay", "relay", KindRelay, "relayed"},
-		{"relay_srflx_is_relay", "relay", "srflx", KindRelay, "relayed"},
+		{"relay_host_is_relay", "relay", "host", KindRelay},
+		{"host_relay_is_relay", "host", "relay", KindRelay},
+		{"relay_relay_is_relay", "relay", "relay", KindRelay},
+		{"relay_srflx_is_relay", "relay", "srflx", KindRelay},
 
 		// Unknown / empty inputs fall through to DirectNAT as the
 		// conservative choice (don't overclaim "local").
-		{"empty_pair_is_direct_nat", "", "", KindDirectNAT, "direct (internet)"},
-		{"unknown_value_is_direct_nat", "wat", "host", KindDirectNAT, "direct (internet)"},
+		{"empty_pair_is_direct_nat", "", "", KindDirectNAT},
+		{"unknown_value_is_direct_nat", "wat", "host", KindDirectNAT},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			got := FromICE(c.local, c.remote)
 			if got.Kind != c.want {
 				t.Errorf("Kind = %v, want %v", got.Kind, c.want)
-			}
-			if got.Short() != c.wantShort {
-				t.Errorf("Short() = %q, want %q", got.Short(), c.wantShort)
 			}
 			if got.LocalCand != c.local || got.RemoteCand != c.remote {
 				t.Errorf("candidate types not preserved: got (%q,%q), want (%q,%q)",
@@ -62,9 +58,6 @@ func TestFromLAN(t *testing.T) {
 	if got.LocalCand != "" || got.RemoteCand != "" {
 		t.Errorf("LAN path should not carry candidate types: got (%q,%q)", got.LocalCand, got.RemoteCand)
 	}
-	if got.Short() != "direct (local network)" {
-		t.Errorf("Short() = %q, want %q", got.Short(), "direct (local network)")
-	}
 	if got.Detail() != "" {
 		t.Errorf("Detail() = %q, want empty for LAN path", got.Detail())
 	}
@@ -77,9 +70,6 @@ func TestFromRelay(t *testing.T) {
 	}
 	if got.RelayAddr != "fsend.alzina.dev:443" {
 		t.Errorf("RelayAddr = %q, want fsend.alzina.dev:443", got.RelayAddr)
-	}
-	if got.Short() != "relayed" {
-		t.Errorf("Short() = %q", got.Short())
 	}
 	// Headline collapses to the compact Tag() form; the address still
 	// appears so operators can see which relay.

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -327,12 +327,6 @@ func Lookup(err error) (Entry, bool) {
 	}, false
 }
 
-// IsWarning reports whether the error is a non-fatal warning (Exit==0).
-func IsWarning(err error) bool {
-	entry, ok := Lookup(err)
-	return ok && entry.Exit == 0
-}
-
 // Chain returns the full wrap chain of err as a slice of error strings,
 // outermost first. Used by --debug rendering to expose the underlying
 // technical details after the friendly catalog message.

--- a/internal/fserrors/fserrors_test.go
+++ b/internal/fserrors/fserrors_test.go
@@ -82,15 +82,6 @@ func TestCatalog_UniqueCodes(t *testing.T) {
 	}
 }
 
-func TestIsWarning(t *testing.T) {
-	if !IsWarning(ErrConfigCorrupted) {
-		t.Error("ErrConfigCorrupted should be a warning")
-	}
-	if IsWarning(ErrServerUnreachable) {
-		t.Error("ErrServerUnreachable should not be a warning")
-	}
-}
-
 func TestEntryRender_PrependsCode(t *testing.T) {
 	e := Entry{Code: "E001", Message: "Boom.", Action: "Try X."}
 	got := e.Render()

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -69,7 +69,6 @@ func WithBackoff(ctx context.Context, opts Options, isTransient func(error) bool
 	}
 
 	wait := opts.Base
-	var lastErr error
 	for attempt := 1; attempt <= opts.Attempts; attempt++ {
 		if err := ctx.Err(); err != nil {
 			return err
@@ -78,9 +77,18 @@ func WithBackoff(ctx context.Context, opts Options, isTransient func(error) bool
 		if err == nil {
 			return nil
 		}
-		lastErr = err
-		if !isTransient(err) || attempt == opts.Attempts {
+		// Non-transient: caller is the right place to handle (e.g. wrong
+		// password, hash mismatch). Bubble out unchanged.
+		if !isTransient(err) {
 			return err
+		}
+		// Transient but no budget left: wrap in ErrTransientFailure so the
+		// catalog maps it to E020 ("Transfer was interrupted and retries
+		// did not recover") instead of falling through to E099. The raw
+		// underlying error (e.g. "QUIC accept: ...context deadline
+		// exceeded") rarely matches any user-facing sentinel on its own.
+		if attempt == opts.Attempts {
+			return fmt.Errorf("%w: %v", fserrors.ErrTransientFailure, err)
 		}
 		if opts.OnRetry != nil {
 			opts.OnRetry(attempt+1, wait, err)
@@ -98,8 +106,8 @@ func WithBackoff(ctx context.Context, opts Options, isTransient func(error) bool
 			wait = opts.Max
 		}
 	}
-	// Unreachable; loop always returns.
-	return fmt.Errorf("%w: %v", fserrors.ErrTransientFailure, lastErr)
+	// Unreachable: the loop always returns inside the body.
+	return nil
 }
 
 // IsTransient is the default classifier. An error is transient when

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -149,9 +149,23 @@ func IsTransient(err error) bool {
 	// match by error-string fallback. This is brittle but the
 	// alternative — importing quic-go just for one type — pulls the
 	// retry package into the transport's dependency graph.
+	//
+	// "Application error 0x..." is the shape quic-go renders when either
+	// side closes the connection with CloseWithError. In fsend this fires
+	// when a peer is killed mid-transfer (Ctrl-C, OOM, network drop) and
+	// the surviving side's next read/write surfaces the abrupt close. The
+	// peer can come back on a retry and resume from its .fsend-partial,
+	// so this is the canonical transient case — without this match it
+	// surfaced as E099 "please file an issue".
+	//
+	// Terminal disagreements (wrong password, hash mismatch, peer
+	// declined, ...) are surfaced via wire-level ErrorFrames BEFORE the
+	// QUIC stream tears down, so they're already caught by the terminal
+	// sentinel check above and never reach this fallback.
 	if s := err.Error(); strings.Contains(s, "idle timeout") ||
 		strings.Contains(s, "connection reset by peer") ||
-		strings.Contains(s, "use of closed network connection") {
+		strings.Contains(s, "use of closed network connection") ||
+		strings.Contains(s, "Application error 0x") {
 		return true
 	}
 

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -69,8 +69,11 @@ func TestWithBackoff_ExhaustsBudget(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected error after exhaustion")
 	}
-	if !errors.Is(err, io.EOF) {
-		t.Fatalf("expected wrapped io.EOF, got %v", err)
+	// Exhausted-transient must wrap ErrTransientFailure so the catalog
+	// maps it to E020. Without this wrap, the raw underlying error (often
+	// not in the catalog) falls through to E099.
+	if !errors.Is(err, fserrors.ErrTransientFailure) {
+		t.Fatalf("expected ErrTransientFailure wrap, got %v", err)
 	}
 	if calls != 2 {
 		t.Fatalf("want 2 calls, got %d", calls)

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -141,6 +141,18 @@ func TestIsTransient_Classification(t *testing.T) {
 		{"deadline_exceeded_transient", context.DeadlineExceeded, true},
 		{"idle_timeout_string_transient", errors.New("Application error 0x0: idle timeout"), true},
 
+		// Peer-abort: receiver Ctrl-C'd mid-transfer and the sender's
+		// next chunk write surfaces "Application error 0x0 (remote)".
+		// Must retry — the peer can come back and resume from its
+		// .fsend-partial. Without this, E099 lies about a routine
+		// interruption.
+		{"quic_application_error_remote_transient",
+			errors.New("wire: writing chunk payload: Application error 0x0 (remote)"), true},
+		{"quic_application_error_local_transient",
+			errors.New("Application error 0x0 (local)"), true},
+		{"quic_application_error_with_message_transient",
+			errors.New("Application error 0x100 (remote): peer left"), true},
+
 		// Terminal cases — explicitly tested because a wrapping mistake
 		// here would silently turn user errors into 3-retry hangs.
 		{"hash_mismatch_terminal", fserrors.ErrHashMismatch, false},

--- a/internal/transfer/archive_test.go
+++ b/internal/transfer/archive_test.go
@@ -257,8 +257,11 @@ func TestExtractArchive_ConflictWithoutOverwrite(t *testing.T) {
 	}
 }
 
-func TestImohash_PrefixMatchesFull(t *testing.T) {
-	// Sanity: for two identical files of the same size, imohash matches.
+func TestPrefixImohash_StableForIdenticalContent(t *testing.T) {
+	// Sanity: identical content of the same length must produce identical
+	// PrefixImohash digests. This is the property the resume path relies
+	// on — sender and receiver fingerprint the same prefix bytes and the
+	// digests have to match.
 	dir := t.TempDir()
 	content := make([]byte, 4*1024*1024)
 	if _, err := rand.Read(content); err != nil {
@@ -272,25 +275,16 @@ func TestImohash_PrefixMatchesFull(t *testing.T) {
 	if err := os.WriteFile(p2, content, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	h1, err := FileImohash(p1)
+	h1, err := PrefixImohash(p1, int64(len(content)))
 	if err != nil {
 		t.Fatal(err)
 	}
-	h2, err := FileImohash(p2)
+	h2, err := PrefixImohash(p2, int64(len(content)))
 	if err != nil {
 		t.Fatal(err)
 	}
 	if h1 != h2 {
-		t.Errorf("expected identical files to share imohash")
-	}
-
-	// PrefixImohash on the full file matches FileImohash.
-	hp, err := PrefixImohash(p1, int64(len(content)))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if hp != h1 {
-		t.Errorf("PrefixImohash(full) != FileImohash")
+		t.Errorf("expected identical files to share PrefixImohash digest")
 	}
 }
 

--- a/internal/transfer/imohash.go
+++ b/internal/transfer/imohash.go
@@ -25,20 +25,6 @@ const ImohashSize = imohash.Size
 // worry about for non-adversarial resumes).
 var imohashHasher = imohash.New()
 
-// FileImohash returns the imohash digest of a file on disk.
-//
-// Cost is constant for files above SampleThreshold (~128 KiB): three
-// 16 KiB samples + the file size. Use this on the receiver to fingerprint
-// a partial file before sending the resume offer.
-func FileImohash(path string) ([ImohashSize]byte, error) {
-	var zero [ImohashSize]byte
-	h, err := imohashHasher.SumFile(path)
-	if err != nil {
-		return zero, fmt.Errorf("imohash %s: %w", path, err)
-	}
-	return h, nil
-}
-
 // PrefixImohash returns the imohash digest of the first prefixLen bytes
 // of a file, computed as if those bytes were the whole file. Used on the
 // sender to validate the receiver's claim that "I have a partial that

--- a/internal/uxlog/glyphs.go
+++ b/internal/uxlog/glyphs.go
@@ -53,9 +53,6 @@ func Info() string { return Marker(gInfo) }
 // Retry returns the retry glyph (↻ or [RETRY]).
 func Retry() string { return Marker(gRetry) }
 
-// Spin returns the inert spinner glyph used on non-TTYs.
-func Spin() string { return Marker(gSpin) }
-
 func glyphForKind(k glyphKind) (utf8, ascii, color string) {
 	switch k {
 	case gCheck:

--- a/internal/uxlog/glyphs_test.go
+++ b/internal/uxlog/glyphs_test.go
@@ -17,7 +17,6 @@ func TestMarker_NonTTYFallback(t *testing.T) {
 		{Warn, "Warn", "[!]"},
 		{Info, "Info", "[i]"},
 		{Retry, "Retry", "[~]"},
-		{Spin, "Spin", "[*]"},
 	}
 	for _, c := range cases {
 		if got := c.fn(); got != c.want {


### PR DESCRIPTION
## Summary

Production-readiness audit follow-ups (see #30 / chat thread).

- **retry**: `IsTransient` recognises the `Application error 0x...` shape quic-go renders when a peer closes abruptly. A receiver killed mid-transfer used to surface as **E099** "please file an issue" instead of being retried with resume from `.fsend-partial`.
- **docs**: `usage.md`, `self-hosting.md`, `development.md` referenced `config.toml` and `~/.config/fsend/...` on macOS — actual file is `config.json` and macOS resolves via xdg to `~/Library/Application Support/fsend/`.
- **cleanup**: drop four genuinely unreferenced helpers and their dedicated tests — `fserrors.IsWarning`, `uxlog.Spin`, `transfer.FileImohash`, `connpath.Info.Short`. Production paths unchanged (the live animated spinner uses `Marker(gSpin)` from `spinner.go`, not the deleted `Spin()` helper).
- **caddyfile**: flip the inverted comment about `X-Real-IP` — Caddy doesn't set it by default, which is exactly why the next line does.
- **ci**: add a `deadcode -test ./...` step so the B1-style unreachable-symbol regressions get caught up front. Distinct from golangci-lint's `unused` (already enabled via `default: standard`), which keeps test-only callers alive.

Net: +85 / −102 across 15 files.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run --timeout=5m ./...` — `0 issues.`
- [x] `go test -race -timeout 180s ./...` — all pkgs pass
- [x] `deadcode -test ./...` — clean
- [x] 3 new test cases in `internal/retry/retry_test.go` cover the QUIC peer-abort shape (remote, local, with-message)
- [ ] CI matrix on Linux/macOS/Windows + cross-compile

🤖 Generated with [Claude Code](https://claude.com/claude-code)