### PR TITLE
Drop FSEND_SESSION_IDLE_TIMEOUT, hardcode relay idle reap at 60s

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -146,9 +146,6 @@ func classifyRelayDrop(ctx context.Context, client *signaling.Client, sessionID 
 		}
 		return fserrors.ErrRelayCapHit
 	case relay.ReasonIdle:
-		if status.IdleSeconds > 0 {
-			return fmt.Errorf("%w: Server idle window: %s", fserrors.ErrRelayIdleTimeout, uxlog.HumanDuration(time.Duration(status.IdleSeconds)*time.Second))
-		}
 		return fserrors.ErrRelayIdleTimeout
 	}
 	return runErr

--- a/cmd/fsend/internet_test.go
+++ b/cmd/fsend/internet_test.go
@@ -120,14 +120,7 @@ func TestClassifyRelayDrop_MapsReasons(t *testing.T) {
 			wantErr: fserrors.ErrRelayCapHit,
 		},
 		{
-			name:       "idle_with_seconds_includes_value",
-			body:       `{"state":"evicted","reason":"idle","idle_seconds":60}`,
-			runErr:     errors.New("idle timeout"),
-			wantErr:    fserrors.ErrRelayIdleTimeout,
-			wantDetail: "Server idle window: 1m00s",
-		},
-		{
-			name:    "idle_without_seconds_is_bare_sentinel",
+			name:    "idle_is_bare_sentinel",
 			body:    `{"state":"evicted","reason":"idle"}`,
 			runErr:  errors.New("idle timeout"),
 			wantErr: fserrors.ErrRelayIdleTimeout,

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -82,7 +82,6 @@ func runServer() error {
 	defer func() { _ = udpListener.Close() }()
 	relaySrv := relay.NewServer(udpListener, relay.ServerConfig{
 		MaxBytesPerSession: cfg.maxBytesPerSession,
-		SessionIdleTimeout: cfg.sessionIdleTimeout,
 		Logger:             logger,
 	})
 	// External address: the operator should set FSEND_PUBLIC_ADDR to the
@@ -137,7 +136,6 @@ type serverRuntimeConfig struct {
 	maxSessionsPerIP     int
 	maxNewSessionsPerMin int
 	maxBytesPerSession   uint64
-	sessionIdleTimeout   time.Duration
 	serverPassword       string
 }
 
@@ -148,7 +146,6 @@ func loadServerConfig() serverRuntimeConfig {
 		maxSessionsPerIP:     envInt("FSEND_MAX_SESSIONS_PER_IP", 5),
 		maxNewSessionsPerMin: envInt("FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN", 30),
 		maxBytesPerSession:   envBytes("FSEND_MAX_RELAY_BYTES_PER_SESSION", 100*1024*1024),
-		sessionIdleTimeout:   envDuration("FSEND_SESSION_IDLE_TIMEOUT", 60*time.Second),
 		serverPassword:       os.Getenv("FSEND_SERVER_PASSWORD"),
 	}
 	switch strings.ToLower(os.Getenv("FSEND_LOG_LEVEL")) {
@@ -175,17 +172,6 @@ func envInt(name string, def int) int {
 	if v := os.Getenv(name); v != "" {
 		if n, err := strconv.Atoi(v); err == nil {
 			return n
-		}
-	}
-	return def
-}
-
-// envDuration reads a Go-style duration ("60s", "5m") from name, falling
-// back to def on missing or unparseable input.
-func envDuration(name string, def time.Duration) time.Duration {
-	if v := os.Getenv(name); v != "" {
-		if d, err := time.ParseDuration(v); err == nil {
-			return d
 		}
 	}
 	return def
@@ -288,7 +274,6 @@ CONFIGURATION (environment variables — all optional)
   FSEND_MAX_SESSIONS_PER_IP             Default 5
   FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN Default 30
   FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MiB (accepts e.g. "100MiB", "500m", "104857600")
-  FSEND_SESSION_IDLE_TIMEOUT            Default 60s (Go duration: 30s, 5m, 1h)
   FSEND_PUBLIC_ADDR                     host:port clients dial for relay; defaults to FSEND_UDP_ADDR
   FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every endpoint except
                                         /v1/health requires the X-Fsend-Auth header to match.

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -72,26 +72,6 @@ func TestServerEnvInt(t *testing.T) {
 	}
 }
 
-func TestServerEnvDuration(t *testing.T) {
-	const k = "FSEND_TEST_ENV_DURATION"
-	os.Unsetenv(k)
-	if got := envDuration(k, 5*time.Second); got != 5*time.Second {
-		t.Errorf("unset: got %v, want 5s", got)
-	}
-	t.Setenv(k, "30s")
-	if got := envDuration(k, 5*time.Second); got != 30*time.Second {
-		t.Errorf("30s: got %v, want 30s", got)
-	}
-	t.Setenv(k, "1h30m")
-	if got := envDuration(k, 5*time.Second); got != 90*time.Minute {
-		t.Errorf("1h30m: got %v, want 90m", got)
-	}
-	t.Setenv(k, "garbage")
-	if got := envDuration(k, 5*time.Second); got != 5*time.Second {
-		t.Errorf("bad: got %v, want 5s", got)
-	}
-}
-
 func TestServerEnvBytes(t *testing.T) {
 	const k = "FSEND_TEST_ENV_BYTES"
 	const def uint64 = 100
@@ -150,7 +130,6 @@ func clearServerEnv(t *testing.T) {
 		"FSEND_MAX_SESSIONS_PER_IP",
 		"FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN",
 		"FSEND_MAX_RELAY_BYTES_PER_SESSION",
-		"FSEND_SESSION_IDLE_TIMEOUT",
 	} {
 		os.Unsetenv(k)
 	}
@@ -174,9 +153,6 @@ func TestServerLoadConfigDefaults(t *testing.T) {
 	if cfg.maxBytesPerSession != 100*srvMiB {
 		t.Errorf("maxBytesPerSession: got %d, want %d", cfg.maxBytesPerSession, 100*srvMiB)
 	}
-	if cfg.sessionIdleTimeout != 60*time.Second {
-		t.Errorf("sessionIdleTimeout: got %v, want 60s", cfg.sessionIdleTimeout)
-	}
 	if cfg.logLevel != slog.LevelInfo {
 		t.Errorf("logLevel: got %v, want info", cfg.logLevel)
 	}
@@ -189,7 +165,6 @@ func TestServerLoadConfigOverrides(t *testing.T) {
 	t.Setenv("FSEND_MAX_SESSIONS_PER_IP", "12")
 	t.Setenv("FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN", "120")
 	t.Setenv("FSEND_MAX_RELAY_BYTES_PER_SESSION", "250MiB")
-	t.Setenv("FSEND_SESSION_IDLE_TIMEOUT", "90s")
 	cfg := loadServerConfig()
 	if cfg.httpAddr != ":19999" {
 		t.Errorf("httpAddr: got %q", cfg.httpAddr)
@@ -205,9 +180,6 @@ func TestServerLoadConfigOverrides(t *testing.T) {
 	}
 	if cfg.maxBytesPerSession != 250*srvMiB {
 		t.Errorf("maxBytesPerSession: got %d", cfg.maxBytesPerSession)
-	}
-	if cfg.sessionIdleTimeout != 90*time.Second {
-		t.Errorf("sessionIdleTimeout: got %v", cfg.sessionIdleTimeout)
 	}
 }
 

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -26,7 +26,6 @@ services:
       FSEND_MAX_RELAY_BYTES_PER_SESSION: "100MiB"
       FSEND_MAX_SESSIONS_PER_IP: "5"
       FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN: "30"
-      FSEND_SESSION_IDLE_TIMEOUT: "60s"
       # Password to restrict server access (empty = open); clients use `fsend --connect <domain> <password>`.
       FSEND_SERVER_PASSWORD: ""
     healthcheck:

--- a/docs/development.md
+++ b/docs/development.md
@@ -107,7 +107,6 @@ FSEND_HTTP_ADDR=":18080" /tmp/fsend server --health-check
 | `FSEND_PUBLIC_ADDR` | = `FSEND_UDP_ADDR` | What clients see |
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
 | `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MiB` | |
-| `FSEND_SESSION_IDLE_TIMEOUT` | `60s` | |
 
 Full list: `/tmp/fsend server --help`. For deployment, ports, and all
 tunables, see [Self-hosting](self-hosting.md).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -147,4 +147,3 @@ All optional; defaults shown. Set under the `environment:` block in
 | `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
 | `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit. |
 | `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MiB` | Accepts `500m`, `1GiB`, `104857600`. |
-| `FSEND_SESSION_IDLE_TIMEOUT` | `60s` | Go duration. |

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -90,9 +90,9 @@ var (
 	// shared password and the client either didn't send one or sent the
 	// wrong one.
 	ErrServerAuthRequired = errors.New("server password required")
-	// E029 — relay reaped the allocation for inactivity
-	// (FSEND_SESSION_IDLE_TIMEOUT). Distinct from E020 so the user
-	// knows it's a server-set ceiling, not their network.
+	// E029 — relay reaped the allocation because no datagrams flowed
+	// for ~60s. Distinct from E020 so the user knows the server tore
+	// the slot down (peer went away), not their own network.
 	ErrRelayIdleTimeout = errors.New("relay session idle-timed out")
 )
 
@@ -299,9 +299,7 @@ var catalog = map[error]Entry{
 	ErrRelayIdleTimeout: {
 		Code: "E029", Exit: 29,
 		Message: "The server closed the connection because no data was flowing. Transfer aborted.",
-		Action: "The fallback relay drops sessions that go idle for too long.\n" +
-			"  Try again, or self-host (`fsend server`) and raise\n" +
-			"  FSEND_SESSION_IDLE_TIMEOUT.",
+		Action:  "The other side likely went away. Try again.",
 	},
 }
 

--- a/internal/quicconn/quicconn_relay_test.go
+++ b/internal/quicconn/quicconn_relay_test.go
@@ -60,7 +60,6 @@ func TestQUIC_OverRelay(t *testing.T) {
 
 	relaySrv := relay.NewServer(relayConn, relay.ServerConfig{
 		MaxBytesPerSession: 100 * 1024 * 1024,
-		SessionIdleTimeout: 30 * time.Second,
 	})
 	tok, err := relaySrv.Allocate()
 	if err != nil {

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -63,7 +63,6 @@ func TestRelay_EndToEnd(t *testing.T) {
 
 	srv := NewServer(serverConn, ServerConfig{
 		MaxBytesPerSession: 10 * 1024 * 1024,
-		SessionIdleTimeout: 5 * time.Second,
 	})
 	tok, err := srv.Allocate()
 	if err != nil {

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -47,7 +47,6 @@ const TombstoneTTL = 5 * time.Minute
 // ServerConfig holds the per-session tuning.
 type ServerConfig struct {
 	MaxBytesPerSession uint64
-	SessionIdleTimeout time.Duration
 	Logger             *slog.Logger
 }
 
@@ -55,13 +54,16 @@ type ServerConfig struct {
 // allocations. Not exposed in ServerConfig because no caller sets it.
 const janitorInterval = 30 * time.Second
 
+// sessionIdleTimeout is the per-allocation silence ceiling before the
+// janitor evicts. QUIC's own MaxIdleTimeout (30s) fires first in any
+// healthy transfer, so this is a backstop for cleanup, not a knob —
+// raising or lowering it doesn't affect well-behaved sessions.
+const sessionIdleTimeout = 60 * time.Second
+
 // Default fills in zero values.
 func (c *ServerConfig) Default() {
 	if c.MaxBytesPerSession == 0 {
 		c.MaxBytesPerSession = 100 * 1024 * 1024 // 100 MiB
-	}
-	if c.SessionIdleTimeout == 0 {
-		c.SessionIdleTimeout = 60 * time.Second
 	}
 	if c.Logger == nil {
 		c.Logger = slog.Default()
@@ -93,10 +95,10 @@ func NewServer(conn net.PacketConn, cfg ServerConfig) *Server {
 	}
 }
 
-// Limits exposes the configured per-session ceilings so the signaling
-// layer can include them in the relay-status response.
-func (s *Server) Limits() (maxBytes uint64, idleTimeout time.Duration) {
-	return s.cfg.MaxBytesPerSession, s.cfg.SessionIdleTimeout
+// MaxBytesPerSession exposes the configured byte ceiling so the
+// signaling layer can include it in the relay-status response.
+func (s *Server) MaxBytesPerSession() uint64 {
+	return s.cfg.MaxBytesPerSession
 }
 
 // Status returns the eviction reason for a token, or "" if the
@@ -246,7 +248,7 @@ func (s *Server) janitor(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case now := <-t.C:
-			cutoff := now.Add(-s.cfg.SessionIdleTimeout).UnixNano()
+			cutoff := now.Add(-sessionIdleTimeout).UnixNano()
 			nowNanos := now.UnixNano()
 			s.mu.Lock()
 			for tok, a := range s.allocs {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -111,7 +111,7 @@ type Server struct {
 type RelayAllocator interface {
 	Allocate() (relay.Token, error)
 	Status(relay.Token) string
-	Limits() (maxBytes uint64, idleTimeout time.Duration)
+	MaxBytesPerSession() uint64
 }
 
 // WithRelay wires a relay allocator and its public address into the
@@ -231,12 +231,8 @@ func (s *Server) relayStatus(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	resp := RelayStatusResponse{State: "evicted", Reason: reason}
-	maxBytes, idle := s.relayAllocator.Limits()
-	switch reason {
-	case relay.ReasonCapHit:
-		resp.LimitBytes = maxBytes
-	case relay.ReasonIdle:
-		resp.IdleSeconds = int(idle / time.Second)
+	if reason == relay.ReasonCapHit {
+		resp.LimitBytes = s.relayAllocator.MaxBytesPerSession()
 	}
 	writeJSON(w, http.StatusOK, resp)
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -409,26 +409,24 @@ type fakeRelay struct {
 	tok      relay.Token
 	reason   string
 	maxBytes uint64
-	idle     time.Duration
 }
 
-func (f *fakeRelay) Allocate() (relay.Token, error)  { return f.tok, nil }
-func (f *fakeRelay) Status(t relay.Token) string     { return f.reason }
-func (f *fakeRelay) Limits() (uint64, time.Duration) { return f.maxBytes, f.idle }
+func (f *fakeRelay) Allocate() (relay.Token, error) { return f.tok, nil }
+func (f *fakeRelay) Status(t relay.Token) string    { return f.reason }
+func (f *fakeRelay) MaxBytesPerSession() uint64     { return f.maxBytes }
 
-// /v1/relay/status must echo back the operator-set ceiling so the CLI
-// can render a concrete error ("server limit 100 MiB") instead of a
-// generic "limit reached." Cap-hit and idle each carry their own field;
-// the other stays zero (omitempty drops it from the JSON entirely).
+// /v1/relay/status must echo back the operator-set byte ceiling so the
+// CLI can render a concrete error ("server limit 100 MiB") instead of a
+// generic "limit reached." Cap-hit carries the limit; idle just carries
+// the reason (the timeout is fixed, no value to surface).
 func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 	cases := []struct {
-		name        string
-		reason      string
-		wantBytes   uint64
-		wantSeconds int
+		name      string
+		reason    string
+		wantBytes uint64
 	}{
 		{name: "cap_hit", reason: relay.ReasonCapHit, wantBytes: 100 * 1024 * 1024},
-		{name: "idle", reason: relay.ReasonIdle, wantSeconds: 60},
+		{name: "idle", reason: relay.ReasonIdle},
 	}
 	for _, c := range cases {
 		c := c
@@ -445,7 +443,6 @@ func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 				tok:      relay.Token{1, 2, 3, 4},
 				reason:   c.reason,
 				maxBytes: 100 * 1024 * 1024,
-				idle:     60 * time.Second,
 			}
 			s.WithRelay(alloc, "127.0.0.1:9999")
 			ts := httptest.NewServer(s.Handler())
@@ -489,9 +486,6 @@ func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 			}
 			if body.LimitBytes != c.wantBytes {
 				t.Errorf("limit_bytes = %d, want %d", body.LimitBytes, c.wantBytes)
-			}
-			if body.IdleSeconds != c.wantSeconds {
-				t.Errorf("idle_seconds = %d, want %d", body.IdleSeconds, c.wantSeconds)
 			}
 		})
 	}

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -109,15 +109,13 @@ type HealthResponse struct {
 // Reason is set only when State == "evicted"; valid values are
 // relay.ReasonCapHit and relay.ReasonIdle.
 //
-// LimitBytes is populated when Reason == ReasonCapHit; IdleSeconds when
-// Reason == ReasonIdle. Both are omitempty so older servers that don't
-// set them round-trip as zero and the CLI falls back to the generic
-// message instead of saying "0 MiB" / "0s".
+// LimitBytes is populated when Reason == ReasonCapHit. It is omitempty
+// so older servers that don't set it round-trip as zero and the CLI
+// falls back to the generic message instead of saying "0 MiB".
 type RelayStatusResponse struct {
-	State       string `json:"state"`
-	Reason      string `json:"reason,omitempty"`
-	LimitBytes  uint64 `json:"limit_bytes,omitempty"`
-	IdleSeconds int    `json:"idle_seconds,omitempty"`
+	State      string `json:"state"`
+	Reason     string `json:"reason,omitempty"`
+	LimitBytes uint64 `json:"limit_bytes,omitempty"`
 }
 
 // ErrorResponse is the body of any 4xx/5xx response.


### PR DESCRIPTION
## Summary
- The env var let operators tune the relay's idle-allocation reap window, but QUIC's own `MaxIdleTimeout` (30s) closes dead sessions first — so the relay timeout was always just delayed cleanup of an already-dead slot, and E029's "raise the timeout" advice didn't actually fix the root cause.
- Hardcodes `sessionIdleTimeout = 60s` as a package-level const in `internal/relay`. Renames `Limits() → MaxBytesPerSession()` now that the byte cap is the only remaining configurable ceiling.
- Drops `IdleSeconds` from `RelayStatusResponse` and the dynamic "Server idle window: …" suffix in `classifyRelayDrop` — both became dead weight once the value stopped being operator-meaningful. E029's Action becomes "The other side likely went away. Try again."
- Deletes the now-unused `envDuration` helper + unit test. Updates docs and compose. Net: 14 files, +36 / -106.

## Test plan
- [x] `go build ./... && go vet ./...` clean
- [x] `go test ./...` — all packages pass including `internal/relay`, `internal/server`, `cmd/fsend`, and `test/e2e`
- [x] `gofmt -l .` clean
- [ ] Self-host smoke test: run `fsend server` without `FSEND_SESSION_IDLE_TIMEOUT` set; verify a relay-path transfer of a >100 MiB file still produces E023 (cap_hit) with the correct limit value
- [ ] Confirm E029 still surfaces (not a regression) when a peer is killed mid-transfer: receiver's `classifyRelayDrop` returns the bare sentinel and the CLI prints "[E029] … The other side likely went away. Try again."

🤖 Generated with [Claude Code](https://claude.com/claude-code)