### PR TITLE
audit: pre-release fixes

### DIFF
--- a/cmd/fsend/connect.go
+++ b/cmd/fsend/connect.go
@@ -83,12 +83,25 @@ func runConnect(f *flags) error {
 //   - "host:port"  → returned as-is (after port-range check)
 //   - "host"       → port filled in implicitly: 443 for DNS hostnames,
 //     80 for IP literals and "localhost"
+//   - "http(s)://host[:port][/]" → scheme stripped, then treated as above
 //
 // The default mirrors web convention — domain names ride HTTPS on 443,
 // while bare IPs / loopback ride HTTP on 80 (IPs rarely carry trusted
 // TLS certs). Users on a non-default port still type it explicitly.
 func normalizeServer(s string) (string, error) {
 	s = strings.TrimSpace(s)
+	if s == "" {
+		return "", fmt.Errorf("server address is empty")
+	}
+	// Without scheme stripping, `--connect http://host:8080` (the form
+	// the self-hosting LAN-only docs used to show) lands as the corrupt
+	// `[http://host:8080]:443` and breaks every transfer with E001.
+	s = strings.TrimSuffix(s, "/")
+	if rest, ok := strings.CutPrefix(s, "http://"); ok {
+		s = rest
+	} else if rest, ok := strings.CutPrefix(s, "https://"); ok {
+		s = rest
+	}
 	if s == "" {
 		return "", fmt.Errorf("server address is empty")
 	}

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -224,6 +224,14 @@ func TestNormalizeServer(t *testing.T) {
 		{"::1", "[::1]:80"},
 		{"[::1]", "[::1]:80"},
 		{"  fs.example.com  ", "fs.example.com:443"},
+		// URL form: scheme is stripped so the documented LAN-only
+		// self-hosting form (`fsend --connect http://host:8080`) lands
+		// on a usable host:port instead of `[http://host:8080]:443`.
+		{"http://localhost:8080", "localhost:8080"},
+		{"https://fs.example.com:443", "fs.example.com:443"},
+		{"https://fs.example.com", "fs.example.com:443"},
+		{"http://127.0.0.1:8080", "127.0.0.1:8080"},
+		{"http://localhost:8080/", "localhost:8080"},
 	} {
 		got, err := normalizeServer(tc.in)
 		if err != nil {
@@ -234,7 +242,7 @@ func TestNormalizeServer(t *testing.T) {
 			t.Errorf("normalizeServer(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
-	for _, bad := range []string{"", "   ", ":443", "host:0", "host:99999", "host:abc"} {
+	for _, bad := range []string{"", "   ", ":443", "host:0", "host:99999", "host:abc", "http://", "https://"} {
 		if _, err := normalizeServer(bad); err == nil {
 			t.Errorf("normalizeServer(%q) accepted bad input", bad)
 		}

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -376,6 +376,8 @@ func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code 
 		}); err != nil {
 		return err
 	}
+	// Flush bar before summary; see receive.go for the streaming-stdin reason.
+	closeProg()
 	printRecvSummary(f, displayPath(outDir), recvBytes(), time.Since(start), pathInfo)
 	return nil
 }

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -143,6 +143,10 @@ func runReceive(f *flags, c string) error {
 		return err
 	}
 
+	// Flush the bar before the summary so the "Saved to ..." line lands
+	// below the terminal " done" frame on streaming items (stdin), where
+	// SetTotal+Done would otherwise fire later via the deferred call.
+	closeProg()
 	printRecvSummary(f, displayPath(outDir), recvBytes(), time.Since(start), pathInfo)
 	return nil
 }

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -8,6 +8,7 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -439,14 +440,21 @@ func newReceiverProgress(f *flags, outDir string, pathInfo connpath.Info) (
 		bar.Add(int64(d))
 		total += int64(d)
 	}
+	// Idempotent: callers can flush the bar explicitly before printing
+	// the summary, then leave the deferred call as a no-op safety net.
+	// Without that, stdin transfers (streamingTotal=true) print the
+	// summary above the bar's terminal frame.
+	var closeOnce sync.Once
 	closeFn = func() {
-		if bar == nil {
-			return
-		}
-		if streamingTotal && total > 0 {
-			bar.SetTotal(total, true)
-		}
-		bar.Done()
+		closeOnce.Do(func() {
+			if bar == nil {
+				return
+			}
+			if streamingTotal && total > 0 {
+				bar.SetTotal(total, true)
+			}
+			bar.Done()
+		})
 	}
 	if !f.yes {
 		confirmOverwrite = func(relPath string, existing int64, incoming uint64) bool {

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -84,10 +84,11 @@ func runServer() error {
 		MaxBytesPerSession: cfg.maxBytesPerSession,
 		Logger:             logger,
 	})
-	// External address: the operator should set FSEND_PUBLIC_ADDR to the
-	// host:port clients dial. Default to udpAddr (only sensible on dev).
-	publicAddr := envOr("FSEND_PUBLIC_ADDR", cfg.udpAddr)
-	s.WithRelay(relaySrv, publicAddr)
+	udpPort, err := udpPortFromAddr(cfg.udpAddr)
+	if err != nil {
+		return fmt.Errorf("FSEND_UDP_ADDR %q: %w", cfg.udpAddr, err)
+	}
+	s.WithRelay(relaySrv, udpPort)
 	relayCtx, relayCancel := context.WithCancel(ctx)
 	defer relayCancel()
 	go func() {
@@ -95,7 +96,7 @@ func runServer() error {
 			logger.Error("relay loop ended", "err", err)
 		}
 	}()
-	logger.Info("relay UDP listener up", "addr", cfg.udpAddr, "public", publicAddr)
+	logger.Info("relay UDP listener up", "addr", cfg.udpAddr, "udp_port", udpPort)
 
 	httpSrv := &http.Server{
 		Addr:              cfg.httpAddr,
@@ -166,6 +167,21 @@ func envOr(name, def string) string {
 		return v
 	}
 	return def
+}
+
+// udpPortFromAddr extracts the port from a listen-style address like
+// ":443" or "0.0.0.0:18443". The host half is irrelevant — we only
+// care about the port the relay listens on.
+func udpPortFromAddr(addr string) (int, error) {
+	_, portStr, err := net.SplitHostPort(addr)
+	if err != nil {
+		return 0, err
+	}
+	p, err := strconv.Atoi(portStr)
+	if err != nil || p < 1 || p > 65535 {
+		return 0, fmt.Errorf("port out of range")
+	}
+	return p, nil
 }
 
 func envInt(name string, def int) int {
@@ -274,7 +290,6 @@ CONFIGURATION (environment variables — all optional)
   FSEND_MAX_SESSIONS_PER_IP             Default 5
   FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN Default 30
   FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MiB (accepts e.g. "100MiB", "500m", "104857600")
-  FSEND_PUBLIC_ADDR                     host:port clients dial for relay; defaults to FSEND_UDP_ADDR
   FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every endpoint except
                                         /v1/health requires the X-Fsend-Auth header to match.
                                         Clients set theirs with: fsend --connect <host:port> <password>.

--- a/cmd/fsend/server_lifecycle_unix_test.go
+++ b/cmd/fsend/server_lifecycle_unix_test.go
@@ -36,7 +36,6 @@ func TestServerLifecycle(t *testing.T) {
 	udpAddr := fmt.Sprintf("127.0.0.1:%d", udpPort)
 	t.Setenv("FSEND_HTTP_ADDR", httpAddr)
 	t.Setenv("FSEND_UDP_ADDR", udpAddr)
-	t.Setenv("FSEND_PUBLIC_ADDR", udpAddr)
 	t.Setenv("FSEND_LOG_LEVEL", "error")
 
 	sink := make(chan os.Signal, 1)

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -125,7 +125,6 @@ func clearServerEnv(t *testing.T) {
 	for _, k := range []string{
 		"FSEND_HTTP_ADDR",
 		"FSEND_UDP_ADDR",
-		"FSEND_PUBLIC_ADDR",
 		"FSEND_LOG_LEVEL",
 		"FSEND_MAX_SESSIONS_PER_IP",
 		"FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN",

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -18,9 +18,13 @@ services:
     ports:
       - "443:443/udp"
     environment:
-      # All env vars are optional; defaults shown.
       FSEND_HTTP_ADDR: ":8080"
       FSEND_UDP_ADDR: ":443"
+      # host:port clients dial for the relay fallback. Bound to the
+      # public DNS name set via FSEND_DOMAIN — required for any
+      # cross-internet deployment, since the default falls back to
+      # FSEND_UDP_ADDR (`:443`) which has no addressable host.
+      FSEND_PUBLIC_ADDR: "${FSEND_DOMAIN:?required, e.g. fs.example.com}:443"
       FSEND_LOG_LEVEL: "info"
       # Abuse limits — tune to your bandwidth budget.
       FSEND_MAX_RELAY_BYTES_PER_SESSION: "100MiB"

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -18,13 +18,9 @@ services:
     ports:
       - "443:443/udp"
     environment:
+      # All env vars are optional; defaults shown.
       FSEND_HTTP_ADDR: ":8080"
       FSEND_UDP_ADDR: ":443"
-      # host:port clients dial for the relay fallback. Bound to the
-      # public DNS name set via FSEND_DOMAIN — required for any
-      # cross-internet deployment, since the default falls back to
-      # FSEND_UDP_ADDR (`:443`) which has no addressable host.
-      FSEND_PUBLIC_ADDR: "${FSEND_DOMAIN:?required, e.g. fs.example.com}:443"
       FSEND_LOG_LEVEL: "info"
       # Abuse limits — tune to your bandwidth budget.
       FSEND_MAX_RELAY_BYTES_PER_SESSION: "100MiB"

--- a/docs/development.md
+++ b/docs/development.md
@@ -70,20 +70,17 @@ server. To exercise the full client↔server↔client path:
 ```sh
 FSEND_HTTP_ADDR=":18080" \
 FSEND_UDP_ADDR=":18443" \
-FSEND_PUBLIC_ADDR="127.0.0.1:18443" \
 FSEND_LOG_LEVEL=debug \
 /tmp/fsend server
 ```
 
 Ports `18080`/`18443` are chosen to avoid the privileged-port requirement
 of `:443` (would need root) and the common port collision on `:8080`.
-`FSEND_PUBLIC_ADDR` is what the server advertises to clients for relay —
-must be dialable from the client side.
 
 Point a client at it (persists to the config file — see "Isolated config" below for the path):
 
 ```sh
-/tmp/fsend --connect http://127.0.0.1:18080
+/tmp/fsend --connect 127.0.0.1:18080
 ```
 
 Reset to the public default:
@@ -104,7 +101,6 @@ FSEND_HTTP_ADDR=":18080" /tmp/fsend server --health-check
 |---|---|---|
 | `FSEND_HTTP_ADDR` | `:8080` | Signaling listener |
 | `FSEND_UDP_ADDR` | `:443` | Relay listener (UDP) |
-| `FSEND_PUBLIC_ADDR` | = `FSEND_UDP_ADDR` | What clients see |
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
 | `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MiB` | |
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -76,7 +76,7 @@ carrier moving sealed envelopes. It moves the parcel; it can't open it.
 | File contents                                     | ✗ never         |
 | File names, sizes, hashes                         | ✗ never         |
 | Ciphertext (on the relay-fallback path)           | ✓ as opaque bytes — not decryptable, not even by the server's operator |
-| The 10-letter share code and your IP              | ✓ briefly, in memory only, for pairing — never written to disk |
+| The share code and your IP                        | ✓ briefly, in memory only, for pairing — never written to disk |
 
 End-to-end encryption means even the operator of the server can't
 decrypt traffic that goes through it. The encryption keys never leave

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -141,8 +141,7 @@ All optional; defaults shown. Set under the `environment:` block in
 | Variable | Default | Notes |
 |---|---|---|
 | `FSEND_HTTP_ADDR` | `:8080` | TCP signaling listener. |
-| `FSEND_UDP_ADDR` | `:443` | UDP relay listener. |
-| `FSEND_PUBLIC_ADDR` | = `FSEND_UDP_ADDR` | `host:port` clients dial for relay. Set this whenever the public address differs from the bind (the common case: bind is `:443`, public is `your.domain:443`). The default falls back to `FSEND_UDP_ADDR`, which only works on dev boxes. |
+| `FSEND_UDP_ADDR` | `:443` | UDP relay listener. The server tells clients to dial `<request-host>:<this port>`, so no separate public-address knob is needed. |
 | `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret. When set, every endpoint except `/v1/health` requires it. Clients pass it via `fsend --connect <host> <password>`. |
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -128,7 +128,8 @@ To skip TLS entirely for local testing on a trusted network:
 docker run -p 443:443/udp -p 8080:8080/tcp poliuscorp/fsend server
 ```
 
-Clients connect with `fsend --connect http://host:8080`. **Do not**
+Clients connect with `fsend --connect host:8080` — the client picks
+HTTP automatically for IPs and `localhost`, HTTPS otherwise. **Do not**
 expose this to the public internet — signaling carries share codes and
 bearer tokens in cleartext.
 
@@ -141,7 +142,7 @@ All optional; defaults shown. Set under the `environment:` block in
 |---|---|---|
 | `FSEND_HTTP_ADDR` | `:8080` | TCP signaling listener. |
 | `FSEND_UDP_ADDR` | `:443` | UDP relay listener. |
-| `FSEND_PUBLIC_ADDR` | = `FSEND_UDP_ADDR` | `host:port` clients dial for relay. Set when public ≠ bind (NAT, dev box). |
+| `FSEND_PUBLIC_ADDR` | = `FSEND_UDP_ADDR` | `host:port` clients dial for relay. Set this whenever the public address differs from the bind (the common case: bind is `:443`, public is `your.domain:443`). The default falls back to `FSEND_UDP_ADDR`, which only works on dev boxes. |
 | `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret. When set, every endpoint except `/v1/health` requires it. Clients pass it via `fsend --connect <host> <password>`. |
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -99,10 +100,11 @@ type Server struct {
 	ipBucket map[string]*rateBucket // new-session rate limiter per source IP
 
 	// Relay-fallback wiring (optional). When non-nil, the server exposes
-	// POST /v1/relay/allocate and returns RelayPublicAddr as the address
-	// clients should send framed datagrams to.
-	relayAllocator  RelayAllocator
-	relayPublicAddr string
+	// POST /v1/relay/allocate and returns "host(request.Host):relayUDPPort"
+	// — the same hostname the client used to reach signaling, paired with
+	// the configured UDP port. No operator config needed for stock setups.
+	relayAllocator RelayAllocator
+	relayUDPPort   int
 }
 
 // RelayAllocator is the minimal interface internal/relay.Server exposes
@@ -114,12 +116,24 @@ type RelayAllocator interface {
 	MaxBytesPerSession() uint64
 }
 
-// WithRelay wires a relay allocator and its public address into the
-// signaling layer. publicAddr is the host:port string clients dial.
-func (s *Server) WithRelay(allocator RelayAllocator, publicAddr string) *Server {
+// WithRelay wires a relay allocator into the signaling layer.
+// udpPort is the UDP port the relay listens on; the public address
+// advertised to clients is host(request.Host):udpPort.
+func (s *Server) WithRelay(allocator RelayAllocator, udpPort int) *Server {
 	s.relayAllocator = allocator
-	s.relayPublicAddr = publicAddr
+	s.relayUDPPort = udpPort
 	return s
+}
+
+// relayAddrFor builds the host:port to advertise to a client by pairing
+// the request's Host header (what the client used to reach signaling)
+// with the relay's UDP port.
+func (s *Server) relayAddrFor(r *http.Request) string {
+	host := r.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	return net.JoinHostPort(host, strconv.Itoa(s.relayUDPPort))
 }
 
 // New constructs a Server with defaults filled in.
@@ -285,7 +299,7 @@ func (s *Server) allocateRelay(w http.ResponseWriter, r *http.Request) {
 	relayTok := sess.relayToken
 	s.mu.Unlock()
 	writeJSON(w, http.StatusOK, RelayAllocateResponse{
-		RelayAddr:    s.relayPublicAddr,
+		RelayAddr:    s.relayAddrFor(r),
 		SessionToken: relayTok.String(),
 		TTLSeconds:   600,
 	})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -444,7 +444,7 @@ func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 				reason:   c.reason,
 				maxBytes: 100 * 1024 * 1024,
 			}
-			s.WithRelay(alloc, "127.0.0.1:9999")
+			s.WithRelay(alloc, 9999)
 			ts := httptest.NewServer(s.Handler())
 			defer ts.Close()
 

--- a/internal/signaling/client.go
+++ b/internal/signaling/client.go
@@ -20,9 +20,11 @@ import (
 	"github.com/polius/fsend/internal/server"
 )
 
-// DefaultRequestTimeout caps individual HTTP requests; longer-polling
-// endpoints set their own timeouts via context.
-const DefaultRequestTimeout = 30 * time.Second
+// DefaultRequestTimeout is the http.Client ceiling applied to every
+// request. Must stay comfortably above the server's LongPollTimeout
+// (25s) so /wait long-polls complete via a server-side 204 rather than
+// a client-side transport timeout that wastes the round-trip.
+const DefaultRequestTimeout = 40 * time.Second
 
 // Client talks to a fsend signaling endpoint.
 type Client struct {

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -371,7 +371,13 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 		plain := c.Payload
 		if c.Flags&wire.FlagCompressed != 0 {
 			if dec == nil {
-				dec, err = zstd.NewReader(nil)
+				// Cap per-decode memory so an authenticated-but-misbehaving
+				// peer can't RAM-bomb us with a high-ratio chunk. A single
+				// frame can hold at most MaxChunkSize of plaintext (the
+				// sender's invariant); 2× gives headroom for zstd's own
+				// scratch buffers without admitting GB-scale balloons that
+				// the klauspost default (1 GiB) allows.
+				dec, err = zstd.NewReader(nil, zstd.WithDecoderMaxMemory(2*wire.MaxChunkSize))
 				if err != nil {
 					return fmt.Errorf("recv: zstd reader: %w", err)
 				}
@@ -379,6 +385,11 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 			plain, err = dec.DecodeAll(c.Payload, nil)
 			if err != nil {
 				return fmt.Errorf("recv: zstd decode: %w", err)
+			}
+			// Belt-and-braces against a sender that crafts a frame the
+			// decoder accepts but whose plaintext exceeds the wire bound.
+			if len(plain) > wire.MaxChunkSize {
+				return fmt.Errorf("%w: decompressed chunk %d > limit %d", fserrors.ErrProtocolError, len(plain), wire.MaxChunkSize)
 			}
 		}
 

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -108,7 +108,6 @@ func startHarness() (*harness, error) {
 	hh.serverCmd.Env = append(os.Environ(),
 		"FSEND_HTTP_ADDR=:"+strconv.Itoa(hh.httpPort),
 		"FSEND_UDP_ADDR=:"+strconv.Itoa(hh.udpPort),
-		"FSEND_PUBLIC_ADDR=127.0.0.1:"+strconv.Itoa(hh.udpPort),
 		"FSEND_LOG_LEVEL=warn",
 		// Both peers in this harness come from 127.0.0.1, so a single
 		// pair burns two slots against one bucket. The suite runs

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -115,7 +115,6 @@ func TestServer_PasswordGate(t *testing.T) {
 	cmd.Env = append(os.Environ(),
 		"FSEND_HTTP_ADDR=:"+strconv.Itoa(httpPort),
 		"FSEND_UDP_ADDR=:"+strconv.Itoa(udpPort),
-		"FSEND_PUBLIC_ADDR=127.0.0.1:"+strconv.Itoa(udpPort),
 		"FSEND_LOG_LEVEL=warn",
 		"FSEND_SERVER_PASSWORD=swordfish",
 		"FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN=10000",


### PR DESCRIPTION
## Summary

Six audit findings fixed plus one design simplification surfaced during review. All in scope of a v1 polish pass; no behavior changes for the happy path.

- **`--connect http(s)://host[:port][/]`** — scheme is stripped instead of stored as `[http://host]:443`. Self-hosting docs literally told users to type this; the silent corruption then surfaced as E001 on every transfer. (`cmd/fsend/connect.go`, tests in `helpers_test.go`)
- **stdin-receive bar ordering** — flush the bar before printing the "Saved to" summary so the terminal `done` frame lands above the summary, not below. Guarded by `sync.Once` so the existing `defer` stays a safety net. (`cmd/fsend/{send,receive,internet}.go`)
- **zstd decoder memory** — bound `DecodeAll` to `2 × MaxChunkSize` via `WithDecoderMaxMemory`, plus a post-decode size check. Closes the "authenticated peer RAM-bombs receiver" surface the klauspost default (1 GiB) leaves open. (`internal/transfer/recv.go`)
- **Signaling client timeout** — bump `http.Client.Timeout` 30s → 40s so `/wait` long-polls land via server-side 204 (25s) instead of racing the 30s ceiling. (`internal/signaling/client.go`)
- **`FSEND_PUBLIC_ADDR` removed** — server now derives the relay's public address from each request's `Host` header paired with the configured UDP port. Same model as croc: the client already knows the public hostname (it's what they used for `--connect`), no operator-visible knob needed. `WithRelay` signature collapses to `(allocator, udpPort)`. (`internal/server/server.go`, `cmd/fsend/server.go`, tests, docs, help template)
- **Docs accuracy pass** — drop `http://` from the LAN-only client example (no longer needed after the scheme fix), drop "10-letter" code framing from the visibility table. (`docs/self-hosting.md`, `docs/development.md`, `docs/security.md`)

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `golangci-lint run` — 0 issues
- [x] `staticcheck ./...` — 0 issues
- [x] `deadcode -test ./...` — 0 findings
- [x] `go test -race -count=1 ./...` — all 17 unit packages + 39 e2e tests pass
- [x] Manual e2e against a local \`fsend server\`: \`--connect http://localhost:18080\` now stores \`localhost:18080\` and a relay-forced round-trip completes
- [x] Manual e2e: stdin transfer prints \`done\` bar frame above \`Saved to ...\`, not below
- [x] Manual e2e: \`fsend server\` boots with neither \`FSEND_PUBLIC_ADDR\` nor any compose-stack change; a 127.0.0.1 client successfully uses the relay-path

🤖 Generated with [Claude Code](https://claude.com/claude-code)