### PR TITLE
audit: post-release hardening (symlink, --connect, server, dead code)

### DIFF
--- a/cmd/fsend/connect.go
+++ b/cmd/fsend/connect.go
@@ -14,10 +14,10 @@ import (
 
 // runConnect implements `fsend --connect ...`:
 //
-//	fsend --connect                    → print current config + default
-//	fsend --connect default            → revert to compiled-in default
-//	fsend --connect <host[:port]>      → set custom server (port optional)
-//	fsend --connect <host[:port]> <pw> → set custom server + password
+//	fsend --connect                       → print current config + default
+//	fsend --connect default               → revert to compiled-in default
+//	fsend --connect <host[:port]>         → set custom server (port optional)
+//	fsend --connect <host[:port]>,<pw>    → set custom server + password
 func runConnect(f *flags) error {
 	cfg, _ := config.Load() // ignore corruption error — we're about to overwrite anyway
 
@@ -138,7 +138,7 @@ func printCurrentServer(cfg *config.Config) {
 	if cfg.IsDefault() {
 		fmt.Fprintln(os.Stderr, "  Current server:", config.DefaultServer, "(default)")
 		fmt.Fprintln(os.Stderr)
-		fmt.Fprintln(os.Stderr, "  Set a custom server:  fsend --connect <host[:port]> [password]")
+		fmt.Fprintln(os.Stderr, "  Set a custom server:  fsend --connect <host[:port]>[,<password>]")
 	} else {
 		tag := "custom"
 		if cfg.ServerPassword != "" {
@@ -148,7 +148,7 @@ func printCurrentServer(cfg *config.Config) {
 		fmt.Fprintln(os.Stderr, "  Default server:", config.DefaultServer)
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "  Revert to the default:  fsend --connect default")
-		fmt.Fprintln(os.Stderr, "  Set a new server:       fsend --connect <host[:port]> [password]")
+		fmt.Fprintln(os.Stderr, "  Set a new server:       fsend --connect <host[:port]>[,<password>]")
 	}
 	fmt.Fprintln(os.Stderr)
 }

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -80,46 +80,35 @@ func normalizePassArgs(args []string) []string {
 
 // normalizeConnectArgs rewrites `--connect VALUE` to `--connect=VALUE` so
 // the value rides with the flag instead of falling through as a
-// positional. Subsequent positionals (e.g. an optional password) are
-// concatenated with a comma — StringSliceVar handles that natively.
+// positional. Anything that looks like a flag boundary (next token
+// starts with "-", or there's no next token) is left alone so bare
+// `fsend --connect` keeps triggering the "show current server" path
+// via NoOptDefVal.
 //
-// The transformation is conservative: anything that looks like a flag
-// boundary (next token starts with "-", or there's no next token) is
-// left alone so `fsend --connect` keeps triggering the bare-flag "show
-// current server" path via NoOptDefVal.
+// We deliberately do NOT glue a second positional onto the flag. The
+// previous greedy form silently swallowed a file path as the password
+// (e.g. `fsend --connect host:port file.pdf` saved "file.pdf" as the
+// password). For the host+password form use comma-separated:
+// `--connect host:port,password` (StringSliceVar splits natively).
 func normalizeConnectArgs(args []string) []string {
 	out := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		a := args[i]
-		// Already in `--connect=...` form, or any non-target flag.
 		if a != "--connect" {
 			out = append(out, a)
 			continue
 		}
-		// Bare `--connect` at end → keep as-is (show current server).
 		if i+1 >= len(args) {
 			out = append(out, a)
 			continue
 		}
 		next := args[i+1]
-		// Next token is another flag → bare form intended.
 		if len(next) > 0 && next[0] == '-' {
 			out = append(out, a)
 			continue
 		}
-		// Consume the next positional as the value. If a second
-		// positional follows that isn't a flag, glue it on too so
-		// `--connect host:port password` works.
-		joined := next
+		out = append(out, a+"="+next)
 		i++
-		if i+1 < len(args) {
-			peek := args[i+1]
-			if len(peek) > 0 && peek[0] != '-' {
-				joined = joined + "," + peek
-				i++
-			}
-		}
-		out = append(out, a+"="+joined)
 	}
 	return out
 }

--- a/cmd/fsend/main_test.go
+++ b/cmd/fsend/main_test.go
@@ -62,8 +62,14 @@ func TestNormalizeConnectArgs(t *testing.T) {
 		{[]string{"fsend", "--connect", "--quiet"}, []string{"fsend", "--connect", "--quiet"}},
 		// One value glued onto the flag.
 		{[]string{"fsend", "--connect", "default"}, []string{"fsend", "--connect=default"}},
-		// host:port + password get comma-joined for StringSliceVar.
-		{[]string{"fsend", "--connect", "host:443", "secret"}, []string{"fsend", "--connect=host:443,secret"}},
+		// Second positional is NOT glued: it stays a positional so the
+		// dispatcher can flag `--connect host:port file.pdf` as a usage
+		// error instead of silently saving "file.pdf" as the password.
+		// For host+password use the explicit comma form below.
+		{[]string{"fsend", "--connect", "host:443", "secret"}, []string{"fsend", "--connect=host:443", "secret"}},
+		{[]string{"fsend", "--connect", "host:443", "/tmp/file.pdf"}, []string{"fsend", "--connect=host:443", "/tmp/file.pdf"}},
+		// Comma form passes through untouched — pflag splits it.
+		{[]string{"fsend", "--connect=host:443,secret"}, []string{"fsend", "--connect=host:443,secret"}},
 		// Existing --connect=value form passes through untouched.
 		{[]string{"fsend", "--connect=host:443"}, []string{"fsend", "--connect=host:443"}},
 		// Unrelated flags pass through.

--- a/cmd/fsend/password.go
+++ b/cmd/fsend/password.go
@@ -14,6 +14,9 @@ import (
 	"github.com/polius/fsend/internal/fserrors"
 )
 
+// stdinIsTTY is a seam so tests can simulate piped stdin without faking fds.
+var stdinIsTTY = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
+
 // readPasswordHidden prompts on stderr and reads a single line from the
 // controlling terminal without echo. Falls back to plain stdin when
 // stdin is not a TTY (e.g. inside a pipeline) — callers that need
@@ -58,6 +61,14 @@ func readPasswordHidden(prompt string) (string, error) {
 func resolvePassword(f *flags, sender bool) error {
 	if f.passArg != passPromptSentinel {
 		return nil
+	}
+	// Bare --pass needs a TTY: the sender prompt echoes a suggestion the
+	// user accepts with Enter; the receiver prompt reads no-echo. Either
+	// way, doing it on a piped stdin reads the file's first line as the
+	// password and breaks the transfer. FSEND_PASS is the documented
+	// non-interactive path.
+	if !stdinIsTTY() {
+		return fmt.Errorf("%w: bare --pass needs a terminal; use --pass <value> or FSEND_PASS", fserrors.ErrUsage)
 	}
 	if sender {
 		pw, err := promptPasswordWithSuggestion()

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -202,8 +202,9 @@ COMMON FLAGS
 
 ADVANCED FLAGS
   --connect              Show current server
-  --connect <host:port> [password]
-                         Set the server (persisted)
+  --connect <host:port>  Set the server (persisted)
+  --connect <host:port>,<password>
+                         Set the server + shared password
   --connect default      Revert to the compiled-in default server
   --send / --receive     Force mode (skip code/path auto-detect)
   --debug                Verbose logging to stderr (also: FSEND_DEBUG=1)
@@ -250,6 +251,14 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 			if cmd.Flags().Changed(conflict) {
 				return fmt.Errorf("%w: --connect cannot be combined with --%s", fserrors.ErrUsage, conflict)
 			}
+		}
+		// Positionals after --connect are a usage error — without this,
+		// `fsend --connect host:port file.pdf` would silently fall through
+		// to the send path with --connect already consumed.
+		if len(f.posArgs) > 0 {
+			return fmt.Errorf("%w: --connect cannot be combined with positional arguments (got %q); "+
+				"to set a server password use --connect host:port,password",
+				fserrors.ErrUsage, f.posArgs[0])
 		}
 		return runConnect(f)
 	}
@@ -346,8 +355,15 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 // applyEnvFallbacks fills in flags from environment variables when the
 // user did not pass the corresponding flag. Used for secrets we'd
 // rather not see on argv.
+//
+// Bare --pass (collapsed to passPromptSentinel) counts as "the user said
+// they want a password, but didn't supply one" — so we still consult
+// FSEND_PASS. Doing it the other way around (env wins only when the
+// flag is absent entirely) silently ignored FSEND_PASS for users who
+// typed `--pass` to opt in.
 func applyEnvFallbacks(f *flags, cmd *cobra.Command) {
-	if !cmd.Flags().Changed("pass") {
+	bare := f.passArg == passPromptSentinel
+	if !cmd.Flags().Changed("pass") || bare {
 		if v := os.Getenv("FSEND_PASS"); v != "" {
 			f.passArg = v
 		}

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -53,6 +53,14 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 			[]string{"--text="},
 			"--text requires a non-empty string",
 		},
+		{
+			// Regression: previously `fsend --connect host:port file.pdf`
+			// silently glued file.pdf onto --connect and saved it as the
+			// server password.
+			"connect_with_positional",
+			[]string{"--connect=host:443", "file.pdf"},
+			"--connect cannot be combined with positional arguments",
+		},
 	}
 	for _, c := range cases {
 		c := c

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -102,6 +102,12 @@ func runServer() error {
 		Addr:              cfg.httpAddr,
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
+		// /wait long-polls hold the connection for up to 25s; IdleTimeout
+		// has to clear that bar comfortably. ReadTimeout is intentionally
+		// not set — it would also cap handler body reads. WriteTimeout
+		// stays zero for the same reason.
+		IdleTimeout:    120 * time.Second,
+		MaxHeaderBytes: 16 << 10,
 	}
 
 	sigCh := make(chan os.Signal, 1)

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -36,8 +36,13 @@ func runUninstall(f *flags) error {
 	if err != nil {
 		return fmt.Errorf("locating fsend binary: %w", err)
 	}
-	resolved, err := filepath.EvalSymlinks(binPath)
-	if err == nil {
+	// Resolve symlinks so we hit the actual binary, but also remember the
+	// raw path. A `~/.local/bin/fsend → /opt/fsend/fsend` install needs
+	// both removed; without the raw cleanup the on-PATH name survives as
+	// a dangling link.
+	resolved, _ := filepath.EvalSymlinks(binPath)
+	rawPath := binPath
+	if resolved != "" {
 		binPath = resolved
 	}
 
@@ -54,6 +59,14 @@ func runUninstall(f *flags) error {
 		return nil
 	}
 	fmt.Fprintf(os.Stderr, "  %s Removed binary: %s\n", uxlog.Check(), binPath)
+
+	// If the on-PATH name was a symlink, drop the dangling link too.
+	if rawPath != binPath {
+		if err := os.Remove(rawPath); err == nil {
+			fmt.Fprintf(os.Stderr, "  %s Removed symlink: %s\n", uxlog.Check(), rawPath)
+		}
+	}
+
 	fmt.Fprintln(os.Stderr, "  fsend uninstalled.")
 	return nil
 }

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -118,7 +118,7 @@ with `fsend --connect default`.
 | Caddy logs show "obtain certificate failed" (ACME error) | DNS A-record not yet pointing at this VM, or `80/tcp` blocked at the firewall. |
 | `curl` to `/v1/health` works but clients hit `E001` on cross-network transfers | `443/udp` blocked at the firewall — many setups open TCP only and forget UDP. |
 | Pairing starts but the transfer hangs or drops | A reverse proxy in front of fsend (not the bundled Caddy) is buffering long-poll signaling. Caddy is configured for 30s read/write; nginx/Traefik need the same. |
-| Clients hit `E028` ("pairing server requires a password") | You set `FSEND_SERVER_PASSWORD` on the server. Clients must connect with `fsend --connect host:443 <password>`. |
+| Clients hit `E028` ("pairing server requires a password") | You set `FSEND_SERVER_PASSWORD` on the server. Clients must connect with `fsend --connect host:443,<password>`. |
 
 ## LAN-only / dev mode
 
@@ -142,7 +142,7 @@ All optional; defaults shown. Set under the `environment:` block in
 |---|---|---|
 | `FSEND_HTTP_ADDR` | `:8080` | TCP signaling listener. |
 | `FSEND_UDP_ADDR` | `:443` | UDP relay listener. The server tells clients to dial `<request-host>:<this port>`, so no separate public-address knob is needed. |
-| `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret. When set, every endpoint except `/v1/health` requires it. Clients pass it via `fsend --connect <host> <password>`. |
+| `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret. When set, every endpoint except `/v1/health` requires it. Clients pass it via `fsend --connect <host>,<password>`. |
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
 | `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -80,7 +80,7 @@ not guaranteed. Switch any time:
 
 ```sh
 fsend --connect fs.example.com:443           # persisted
-fsend --connect fs.example.com:443 mySecret  # password-gated server
+fsend --connect fs.example.com:443,mySecret  # password-gated server
 fsend --connect default                      # back to the public default
 fsend --connect                              # show current
 ```

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -293,7 +293,7 @@ var catalog = map[error]Entry{
 		Code: "E028", Exit: 28,
 		Message: "The server requires a password.",
 		Action: "Set it with:\n" +
-			"    fsend --connect <host:port> <password>\n" +
+			"    fsend --connect <host:port>,<password>\n" +
 			"  Ask the server operator for the password if you don't have it.",
 	},
 	ErrRelayIdleTimeout: {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -341,6 +341,22 @@ func (s *Server) evict(now time.Time) {
 			}
 		}
 	}
+	// Drop rate-limit buckets whose stamps have all aged out. Without
+	// this, every IP that ever connected lives in ipBucket forever — the
+	// allowNewSession write path only creates entries.
+	cutoff := now.Add(-time.Minute)
+	for key, b := range s.ipBucket {
+		keep := b.stamps[:0]
+		for _, t := range b.stamps {
+			if t.After(cutoff) {
+				keep = append(keep, t)
+			}
+		}
+		b.stamps = keep
+		if len(b.stamps) == 0 {
+			delete(s.ipBucket, key)
+		}
+	}
 }
 
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -599,6 +599,46 @@ func TestRateLimit_V6BypassClosed(t *testing.T) {
 	}
 }
 
+// TestEvict_PrunesIPBucket locks in the cleanup contract: rate-limit
+// buckets whose stamps have all aged out must be evicted, so the map
+// doesn't grow unbounded as new IPs touch the server.
+func TestEvict_PrunesIPBucket(t *testing.T) {
+	s := New(Config{
+		ServerVersion:        "0.0.0-test",
+		UnpairedTTL:          time.Hour,
+		PairedTTL:            time.Hour,
+		MaxSessionsPerIP:     100,
+		MaxNewSessionsPerMin: 100,
+	})
+	// Seed buckets directly (the public path requires HTTP requests, but
+	// the eviction contract is on the data structure).
+	now := time.Now()
+	s.mu.Lock()
+	s.ipBucket["fresh"] = &rateBucket{stamps: []time.Time{now.Add(-10 * time.Second)}}
+	s.ipBucket["stale"] = &rateBucket{stamps: []time.Time{now.Add(-2 * time.Minute)}}
+	s.ipBucket["mixed"] = &rateBucket{stamps: []time.Time{
+		now.Add(-2 * time.Minute),
+		now.Add(-5 * time.Second),
+	}}
+	s.mu.Unlock()
+
+	s.evict(now)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.ipBucket["fresh"]; !ok {
+		t.Error("fresh bucket should still be present")
+	}
+	if _, ok := s.ipBucket["stale"]; ok {
+		t.Error("stale bucket should have been evicted")
+	}
+	if b, ok := s.ipBucket["mixed"]; !ok {
+		t.Error("mixed bucket should still be present")
+	} else if len(b.stamps) != 1 {
+		t.Errorf("mixed bucket stamps = %d, want 1 (the stale one pruned)", len(b.stamps))
+	}
+}
+
 func itoaHex(n int) string {
 	const hex = "0123456789abcdef"
 	if n == 0 {

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -100,9 +100,6 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 		if ft == wire.TypeTransferComplete {
 			break
 		}
-		if ft == wire.TypeAbort {
-			return fserrors.ErrConnectFailed
-		}
 		if ft == wire.TypeError {
 			// Re-read with payload — we already consumed the header.
 			// Simplification: treat any TypeError as protocol abort.
@@ -224,6 +221,15 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 	// next attempt can resume from, and a successful target file is
 	// always fully verified.
 	partial := target + partialSuffix
+
+	// Lstat the partial before OpenFile so a pre-planted symlink can't
+	// redirect chunk writes outside TargetDir.
+	if st, err := os.Lstat(partial); err == nil && !st.Mode().IsRegular() {
+		_ = wire.WriteControl(s.Control, wire.TypeError, &wire.ErrorFrame{
+			Code: wire.ErrCodeProtocolError, Message: "partial sidecar not a regular file",
+		})
+		return fmt.Errorf("%w: partial %s is not a regular file", fserrors.ErrWriteFailed, partial)
+	}
 
 	// Resume detection: if a partial exists and lines up on a chunk
 	// boundary below the source size, elect ActionResume so the sender
@@ -464,10 +470,10 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 		return nil
 	}
 
-	// Promote partial → target. Close first so Windows doesn't refuse
-	// the rename, and remove any existing target so POSIX and Windows
-	// behave identically.
-	_ = os.Remove(target)
+	// Promote partial → target. os.Rename replaces atomically on POSIX
+	// and (since Go 1.5) on Windows too. The previous Remove+Rename pair
+	// left a TOCTOU window where a racing writer could resurrect target
+	// between the two calls and the verified bytes would be lost.
 	if err := os.Rename(partial, target); err != nil {
 		return fmt.Errorf("%w: finalize: %v", fserrors.ErrWriteFailed, err)
 	}
@@ -561,7 +567,7 @@ func tryReadPeerError(r io.Reader) error {
 	switch ef.Code {
 	case wire.ErrCodePartialMismatch:
 		return fserrors.ErrPartialMismatch
-	case wire.ErrCodeFileHashMismatch, wire.ErrCodeChunkHashMismatch:
+	case wire.ErrCodeFileHashMismatch:
 		return fserrors.ErrHashMismatch
 	default:
 		return fmt.Errorf("%w: peer reported %d: %s", fserrors.ErrProtocolError, ef.Code, ef.Message)

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -63,7 +63,6 @@ func Send(ctx context.Context, s *Streams, opts SendOptions) error {
 		TransferKind:    opts.TransferKind,
 		TotalFiles:      totalFiles,
 		HasPassword:     opts.Password != "",
-		CompressionHint: 1,
 		DisplayName:     opts.DisplayName,
 	}
 	for _, it := range opts.Items {

--- a/internal/transfer/symlink_security_test.go
+++ b/internal/transfer/symlink_security_test.go
@@ -123,3 +123,99 @@ func TestRecv_RefusesSymlinkPointingOutsideTargetDir(t *testing.T) {
 	// The receiver should have returned a path-traversal error somewhere.
 	t.Logf("recv returned: %v", recvErr)
 }
+
+// TestRecv_RefusesPreplantedPartialSymlink locks in the Lstat gate on
+// the .fsend-partial sidecar. Without it, a process with write access
+// to TargetDir can plant the sidecar as a symlink and have chunk writes
+// land on the link's target — outside TargetDir, on any file the
+// receiver process can write.
+//
+// Uses a payload larger than the victim so the "stale partial — discard"
+// branch in recv can't mask the bug.
+func TestRecv_RefusesPreplantedPartialSymlink(t *testing.T) {
+	dstDir := t.TempDir()
+	victimDir := t.TempDir()
+	victim := filepath.Join(victimDir, "secret.txt")
+	original := []byte("VICTIM_ORIGINAL_DATA")
+	if err := os.WriteFile(victim, original, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Pre-plant the sidecar as a symlink to the victim.
+	partial := filepath.Join(dstDir, "payload.bin"+partialSuffix)
+	if err := os.Symlink(victim, partial); err != nil {
+		t.Fatal(err)
+	}
+
+	sender, receiver := pipePair()
+	hello := &wire.SenderHello{
+		ProtocolVersion: wire.ProtocolVersion,
+		TransferKind:    wire.TransferSingleFile,
+		TotalFiles:      1,
+	}
+
+	payload := make([]byte, len(original)+64)
+	for i := range payload {
+		payload[i] = byte(i)
+	}
+	root := blakeHash32(payload)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var recvErr error
+	go func() {
+		defer wg.Done()
+		recvErr = Recv(context.Background(), &receiver, RecvOptions{
+			TargetDir: dstDir,
+			Accept:    func(_ wire.SenderHello) bool { return true },
+		})
+		_ = receiver.Control.Close()
+		_ = receiver.Data.Close()
+	}()
+
+	go func() {
+		defer wg.Done()
+		defer sender.Control.Close()
+		defer sender.Data.Close()
+		_ = wire.WriteControl(sender.Control, wire.TypeHello, hello)
+		var ack wire.ReceiverHello
+		_, _ = wire.ReadControl(sender.Control, &ack)
+		if !ack.Accepts {
+			return
+		}
+		_ = wire.WriteControl(sender.Control, wire.TypeFileInfo, &wire.FileInfo{
+			Index:        0,
+			RelativePath: "payload.bin",
+			Size:         uint64(len(payload)),
+			Mode:         0o644,
+			Blake3Root:   root,
+			Resumable:    true,
+		})
+		// Drain FILE_ACCEPT or ERROR; verdict is the victim's contents.
+		var d wire.FileAcceptDecision
+		_, _ = wire.ReadControl(sender.Control, &d)
+		_ = wire.WriteChunk(sender.Data, &wire.Chunk{
+			FileIndex:  0,
+			ChunkIndex: 0,
+			Flags:      wire.FlagLastChunk,
+			Blake3Hash: blakeHash32(payload),
+			Payload:    payload,
+		})
+		_ = wire.WriteControl(sender.Control, wire.TypeTransferComplete, nil)
+	}()
+
+	wg.Wait()
+
+	got, err := os.ReadFile(victim)
+	if err != nil {
+		t.Fatalf("victim disappeared: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Fatalf("SECURITY: victim file was modified through pre-planted symlink\n  before: %q\n  after:  %q", original, got)
+	}
+	if recvErr == nil {
+		t.Fatalf("expected receiver to surface an error, got nil")
+	}
+	t.Logf("recv returned: %v", recvErr)
+}

--- a/internal/wire/payloads.go
+++ b/internal/wire/payloads.go
@@ -17,7 +17,6 @@ type SenderHello struct {
 	TotalFiles      uint32       // 1 for single, N for multi/dir, 0 if unknown
 	TotalBytes      uint64       // sum of file sizes (0 if unknown, e.g. stdin)
 	HasPassword     bool         // true → expect PASSWORD_CHALLENGE after HELLO_ACK
-	CompressionHint uint8        // 0=none, 1=zstd-auto-per-chunk
 
 	// DisplayName is a peer-facing label the receiver renders in its
 	// accept block: the filename for single-file, the folder name for

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -42,7 +42,6 @@ const (
 	TypeTransferAck       FrameType = 0x08 // receiver → sender
 	TypePasswordVerified  FrameType = 0x09 // sender → receiver (positive ack of password)
 	TypeError             FrameType = 0xFE
-	TypeAbort             FrameType = 0xFF
 )
 
 // Data-stream frame types.
@@ -79,20 +78,15 @@ const (
 // ErrorCode is the catalog of error codes carried in TypeError frames.
 type ErrorCode uint16
 
-// ErrorCode values reported in TypeError frames. ErrCodePartialMismatch
-// and ErrCodeTargetExists are the two codes the receiver acts on by
-// removing or preserving the destination; everything else is informational.
+// ErrorCode values reported in TypeError frames. Only the codes a peer
+// actually emits live here — the receiver's switch in tryReadPeerError
+// is the source of truth for what gets mapped to a user-facing error.
+// Numeric values are kept stable so a peer running an older fsend can
+// still recognise them; new codes get fresh numbers.
 const (
-	ErrCodeUnsupportedVersion ErrorCode = 1
-	ErrCodeWrongPassword      ErrorCode = 2
-	ErrCodeReceiverRejected   ErrorCode = 3
-	ErrCodeDiskFull           ErrorCode = 4
-	ErrCodeWriteFailed        ErrorCode = 5
-	ErrCodeReadFailed         ErrorCode = 6
-	ErrCodeChunkHashMismatch  ErrorCode = 7
-	ErrCodeFileHashMismatch   ErrorCode = 8
-	ErrCodeTimeout            ErrorCode = 9
-	ErrCodeProtocolError      ErrorCode = 10
+	ErrCodeWrongPassword    ErrorCode = 2
+	ErrCodeFileHashMismatch ErrorCode = 8
+	ErrCodeProtocolError    ErrorCode = 10
 	// ErrCodePartialMismatch — receiver offered to resume from a prefix
 	// whose imohash does not match the source's prefix at the same length.
 	// Almost always means the source file changed since the previous

--- a/internal/wire/wire_test.go
+++ b/internal/wire/wire_test.go
@@ -18,7 +18,6 @@ func TestControl_HelloRoundtrip(t *testing.T) {
 		TransferKind:    TransferSingleFile,
 		TotalFiles:      1,
 		TotalBytes:      4404019,
-		CompressionHint: 1,
 	}
 	var buf bytes.Buffer
 	if err := WriteControl(&buf, TypeHello, &want); err != nil {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,12 +112,15 @@ download() {
 
 resolve_latest() {
     api="https://api.github.com/repos/${REPO}/releases/latest"
+    # Same hardened TLS as download(): explicit https+TLS 1.2+ so a
+    # downgrade can't feed us a tampered tag and the rest of the install
+    # follows.
     if command -v curl >/dev/null 2>&1; then
-        curl -fsSL "$api" \
+        curl -fsSL --proto '=https' --tlsv1.2 "$api" \
             | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' \
             | head -n1
     else
-        wget -qO- "$api" \
+        wget -q --secure-protocol=TLSv1_2 -O- "$api" \
             | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' \
             | head -n1
     fi

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -152,7 +152,7 @@ func TestServer_PasswordGate(t *testing.T) {
 
 	// --- Step 2: with the matching password the full pair succeeds ---
 	xdg := h.newXDG(t)
-	if _, _, code := h.runFsend(t, xdg, "--connect", addr, "swordfish"); code != 0 {
+	if _, _, code := h.runFsend(t, xdg, "--connect", addr+",swordfish"); code != 0 {
 		t.Fatalf("--connect with pw exit %d", code)
 	}
 


### PR DESCRIPTION
## Summary

Followup pass after the deeper production-readiness audit. Three reproduced local-attack vectors, several MAJOR server/CLI bugs, and dead code cleanup.

### Security
- **`internal/transfer/recv.go`** — Lstat the `.fsend-partial` sidecar before `OpenFile`. A pre-planted symlink in `TargetDir` previously redirected chunk writes outside the target dir, overwriting any file the receiver process could write. Reproduced empirically: a 100-byte transfer overwrote a victim file via the symlinked partial. Regression test added.
- **`internal/transfer/recv.go`** — drop `os.Remove(target)` before `os.Rename`. Closed a TOCTOU window where a racing writer could resurrect target between the two calls and the verified bytes would be lost. `os.Rename` replaces atomically on POSIX and (since Go 1.5) on Windows too.

### CLI
- **`cmd/fsend/main.go,root.go`** — stop greedy-gluing a second positional onto `--connect`. The previous form silently swallowed file paths as the server password (`fsend --connect host:port file.pdf` saved `"file.pdf"` as the password). Use comma form for host+password: `--connect host:port,password`. Dispatcher now rejects any leftover positional after `--connect`.
- **`cmd/fsend/uninstall.go`** — also remove the on-PATH symlink, not just its resolved target. Previously left a dangling link on `$PATH`.
- **`cmd/fsend/password.go`** — refuse bare `--pass` when stdin is not a TTY. Previously read the piped file's first line as the password.
- **`cmd/fsend/root.go`** — bare `--pass` (the prompt sentinel) now consults `FSEND_PASS`, matching the documented "flag empty → env wins" contract.

### Server
- **`cmd/fsend/server.go`** — set `IdleTimeout: 120s` (above the 25s long-poll) and `MaxHeaderBytes: 16 KiB` on the HTTP listener.
- **`internal/server/server.go`** — prune `ipBucket` entries whose stamps have aged out. Previously the rate-limit map only ever grew.

### Dead code
- **`internal/wire`** — drop `TypeAbort`, `ErrCodeChunkHashMismatch`, and the five other `ErrorCode` constants that were never emitted. Drop `SenderHello.CompressionHint` (set but never read).

### Install
- **`scripts/install.sh`** — pin TLS 1.2+/https on `resolve_latest`. Every other curl call was already hardened; this one was the outlier.

## Test plan

- [x] `go test -race -count=1 -timeout 300s ./...` clean
- [x] `golangci-lint run ./...` clean
- [x] `staticcheck -checks=all ./...` clean
- [x] `govulncheck ./...` clean
- [x] `deadcode -test ./...` clean
- [x] Symlink write-through reproducer: post-fix the victim file is unchanged and the receiver returns E009 instead of silently writing outside `TargetDir`.
- [x] `fsend --connect host:port /path/to/file` now returns E024 with a clear remediation message instead of saving the path as the server password.
- [x] Uninstall with `bin/fsend → src/fsend`: post-fix both are removed.
- [x] Bare `--pass` + piped stdin: post-fix returns E024 with the FSEND_PASS hint; previously consumed the payload's first line as the password.
- [x] `FSEND_PASS=… fsend --pass …` (bare): post-fix the env value is used; previously ignored.
- [x] LAN, direct, and relay end-to-end transfers all succeed against a local server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)