### PR TITLE
audit: fix tar-slip, PAKE panic, --text drop, mode-bit parity

### DIFF
--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -312,6 +312,11 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		if f.textArg == "" {
 			return fmt.Errorf("%w: --text requires a non-empty string", fserrors.ErrUsage)
 		}
+		// Don't silently drop files the user also listed; runSend's own
+		// guard never sees them otherwise (we'd pass nil).
+		if len(f.posArgs) > 0 {
+			return fmt.Errorf("%w: --text cannot be combined with file arguments", fserrors.ErrUsage)
+		}
 		return runSend(f, nil)
 	}
 

--- a/internal/quicconn/auth.go
+++ b/internal/quicconn/auth.go
@@ -93,6 +93,11 @@ func readFramed(r io.Reader, max int) ([]byte, error) {
 		return nil, err
 	}
 	n := int(binary.BigEndian.Uint16(hdr[:]))
+	if n == 0 {
+		// A crafted peer can send a zero-length frame; the SPAKE2 Finish
+		// indexes msg[0] and would panic. Reject as an auth failure.
+		return nil, fmt.Errorf("auth: empty pake msg")
+	}
 	if n > max {
 		return nil, fmt.Errorf("auth: pake msg too large: %d", n)
 	}

--- a/internal/quicconn/auth_test.go
+++ b/internal/quicconn/auth_test.go
@@ -1,7 +1,9 @@
 package quicconn
 
 import (
+	"bytes"
 	"context"
+	"encoding/binary"
 	"errors"
 	"sync"
 	"testing"
@@ -9,6 +11,17 @@ import (
 
 	"github.com/polius/fsend/internal/fserrors"
 )
+
+// A zero-length framed PAKE message must be rejected, not fed into the
+// SPAKE2 Finish (which indexes msg[0] and would panic the process).
+func TestReadFramed_RejectsEmptyFrame(t *testing.T) {
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], 0)
+	_, err := readFramed(bytes.NewReader(hdr[:]), maxPakeMsgLen)
+	if err == nil {
+		t.Fatal("expected error on zero-length frame, got nil")
+	}
+}
 
 // Wrong codes on the two peers must cause SenderHandshake /
 // ReceiverHandshake to fail with ErrPeerAuthFailed, before any

--- a/internal/transfer/archive.go
+++ b/internal/transfer/archive.go
@@ -324,12 +324,14 @@ func ExtractArchive(tarPath, targetDir string, overwrite bool) error {
 			if err := os.MkdirAll(filepath.Dir(clean), 0o755); err != nil {
 				return fmt.Errorf("extract: mkdir parent %s: %w", clean, err)
 			}
-			// Reject symlink targets that resolve outside the target
-			// dir. This is over-strict for absolute symlinks the user
-			// might legitimately want, but the safe default for an
-			// archive received from a remote peer.
-			if _, err := safeJoin(absTarget, filepath.Join(filepath.Dir(hdr.Name), hdr.Linkname)); err != nil {
-				return err
+			// Reject symlinks resolving outside target. Use symlinkEscapes
+			// (same as the single-file path): a safeJoin of the joined
+			// linkname would let an absolute target slip through — Join
+			// strips its leading slash, but os.Symlink keeps the absolute
+			// target, so a later entry writes through it (tar-slip).
+			if symlinkEscapes(absTarget, hdr.Name, hdr.Linkname) {
+				return fmt.Errorf("%w: symlink %q -> %q escapes target dir",
+					fserrors.ErrPathTraversal, hdr.Name, hdr.Linkname)
 			}
 			_ = os.Remove(clean) // symlink fails if target exists
 			if err := os.Symlink(hdr.Linkname, clean); err != nil {

--- a/internal/transfer/archive_test.go
+++ b/internal/transfer/archive_test.go
@@ -192,6 +192,58 @@ func TestExtractArchive_RejectsZipSlip(t *testing.T) {
 	}
 }
 
+// TestExtractArchive_RejectsAbsoluteSymlinkSlip guards against tar-slip via
+// an absolute symlink: a symlink entry pointing at an absolute path outside
+// targetDir, followed by a regular-file entry written *through* that symlink.
+// filepath.Join strips the leading slash of an absolute linkname, so a naive
+// under-target check passes while os.Symlink still stores the absolute target;
+// the follow-up write then lands outside targetDir. Extraction must refuse.
+func TestExtractArchive_RejectsAbsoluteSymlinkSlip(t *testing.T) {
+	root := t.TempDir()
+	target := filepath.Join(root, "target")
+	victim := filepath.Join(root, "victim")
+	if err := os.MkdirAll(target, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(victim, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tarPath := filepath.Join(root, "evil.tar")
+	f, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(f)
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeSymlink, Name: "abslink", Linkname: victim, Mode: 0o777,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("PWNED")
+	if err := tw.WriteHeader(&tar.Header{
+		Typeflag: tar.TypeReg, Name: "abslink/pwned", Mode: 0o644, Size: int64(len(body)),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ExtractArchive(tarPath, target, true); err == nil {
+		t.Fatal("expected extraction to refuse the absolute-symlink slip")
+	}
+	if _, err := os.Stat(filepath.Join(victim, "pwned")); err == nil {
+		t.Fatalf("tar-slip: wrote through symlink to %s, outside target", filepath.Join(victim, "pwned"))
+	}
+}
+
 // TestExtractArchive_ConflictWithoutOverwrite verifies that without
 // overwrite=true, a single conflicting file inside the archive causes the
 // whole extract to refuse — and that nothing landed on disk in the

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -155,7 +155,9 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 
 	// Handle directory entries: just MkdirAll and ACK.
 	if info.IsDir {
-		if err := os.MkdirAll(target, os.FileMode(info.Mode)); err != nil {
+		// Mask to perm bits: don't honor peer-set setuid/setgid/sticky
+		// (parity with the archive path).
+		if err := os.MkdirAll(target, os.FileMode(info.Mode)&os.ModePerm); err != nil {
 			return fmt.Errorf("%w: mkdir %s: %v", fserrors.ErrWriteFailed, target, err)
 		}
 		decision := wire.FileAcceptDecision{Index: info.Index, Action: wire.ActionAcceptFull}
@@ -296,7 +298,7 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 	if action == wire.ActionAcceptFull {
 		flag |= os.O_TRUNC
 	}
-	f, err := os.OpenFile(partial, flag, os.FileMode(info.Mode))
+	f, err := os.OpenFile(partial, flag, os.FileMode(info.Mode)&os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("%w: open partial: %v", fserrors.ErrWriteFailed, err)
 	}


### PR DESCRIPTION
Senior-level audit follow-up. Every Critical/High finding was **reproduced with a failing test before being fixed**, and the full suite + lint + `deadcode` + race detector are green after.

## Fixes

### 🔴 tar-slip via absolute symlink (`internal/transfer/archive.go`) — release-blocking
`ExtractArchive` validated symlink targets with `safeJoin(absTarget, filepath.Join(dir, linkname))`. `filepath.Join` strips the leading `/` of an **absolute** linkname, so it passed the under-target check while `os.Symlink` still stored the absolute target. A malicious sender ships `{symlink "x" → /abs/victim, file "x/pwned"}` and writes **anywhere on the receiver's disk**. Reproduced (wrote outside the target dir), then switched to the same `symlinkEscapes` helper the single-file receive path already uses. The threat model explicitly includes a modified client.

### 🟠 unhandled panic on crafted PAKE frame (`internal/quicconn/auth.go`)
A zero-length framed PAKE message reached `gospake2.Finish`, which indexes `msg[0]` → `index out of range` panic, crashing the process before auth. `readFramed` now rejects empty frames.

### 🟡 `--text` silently dropped file args (`cmd/fsend/root.go`)
`fsend --text "hi" report.pdf` (without `--send`) sent the text and **silently ignored the file** — dispatch passed `nil`, so `runSend`'s existing guard never fired. Now errors with E024, matching the `--send` form.

### 🟡 peer-controlled mode bits (`internal/transfer/recv.go`)
Single-file receive passed raw peer `info.Mode`; masked with `&os.ModePerm` for parity with the archive path (no peer-set setuid/setgid/sticky).

## Tests
Added regression tests for the tar-slip (`TestExtractArchive_RejectsAbsoluteSymlinkSlip`) and the empty-frame panic (`TestReadFramed_RejectsEmptyFrame`).

## Verification
`go build` · `go vet` · `go test -race ./...` · full suite incl. e2e · `golangci-lint` (0 issues) · `deadcode -test ./...` (clean) — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)