### PR TITLE
audit: enforce declared size, pin PQ curve, gate relay-status, drop dead code

### DIFF
--- a/cmd/fsend/connect.go
+++ b/cmd/fsend/connect.go
@@ -39,6 +39,12 @@ func runConnect(f *flags) error {
 
 	switch args[0] {
 	case "default":
+		// `default` reverts to the compiled-in server; it takes no
+		// password. Reject a stray second element rather than silently
+		// dropping it (the user would think they set a password).
+		if len(args) > 1 {
+			return fmt.Errorf("%w: --connect default takes no password", fserrors.ErrUsage)
+		}
 		if cfg.IsDefault() {
 			fmt.Fprintln(os.Stderr, uxlog.Info(), "Already on the default server:", config.DefaultServer)
 			return nil

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -120,7 +120,7 @@ func runReceiveOverInternet(ctx context.Context, f *flags, c string, cfg *config
 	}
 	defer func() { _ = relayConn.Close() }()
 	connSpin.Stop()
-	return classifyRelayDrop(ctx, client, joined.SessionID,
+	return classifyRelayDrop(ctx, client, joined.SessionID, joined.RoleToken,
 		runReceiverQUICOver(ctx, f, relayConn, c, connpath.FromRelay(alloc.RelayAddr)))
 }
 
@@ -129,13 +129,13 @@ func runReceiveOverInternet(ctx context.Context, f *flags, c string, cfg *config
 // the allocation was evicted for a known reason, we promote the error
 // to the corresponding non-transient sentinel so the user sees what
 // actually happened instead of a "retrying…" loop.
-func classifyRelayDrop(ctx context.Context, client *signaling.Client, sessionID string, runErr error) error {
+func classifyRelayDrop(ctx context.Context, client *signaling.Client, sessionID, roleToken string, runErr error) error {
 	if runErr == nil {
 		return nil
 	}
 	probeCtx, cancel := context.WithTimeout(ctx, 3*time.Second)
 	defer cancel()
-	status, err := client.RelayStatus(probeCtx, sessionID)
+	status, err := client.RelayStatus(probeCtx, sessionID, roleToken)
 	if err != nil || status == nil || status.State != "evicted" {
 		return runErr
 	}

--- a/cmd/fsend/internet_test.go
+++ b/cmd/fsend/internet_test.go
@@ -157,7 +157,7 @@ func TestClassifyRelayDrop_MapsReasons(t *testing.T) {
 			}))
 			defer ts.Close()
 			client := signaling.New(ts.URL, "test")
-			got := classifyRelayDrop(context.Background(), client, "sess-1", c.runErr)
+			got := classifyRelayDrop(context.Background(), client, "sess-1", "tok-1", c.runErr)
 			if c.wantSame {
 				if got != c.runErr {
 					t.Errorf("expected runErr unchanged, got %v", got)
@@ -177,7 +177,7 @@ func TestClassifyRelayDrop_MapsReasons(t *testing.T) {
 // A successful transfer (nil runErr) must not get a sentinel pinned on it.
 func TestClassifyRelayDrop_NilStaysNil(t *testing.T) {
 	client := signaling.New("http://127.0.0.1:1", "test") // unreachable; not called
-	if err := classifyRelayDrop(context.Background(), client, "sess-1", nil); err != nil {
+	if err := classifyRelayDrop(context.Background(), client, "sess-1", "tok-1", nil); err != nil {
 		t.Errorf("nil runErr should pass through, got %v", err)
 	}
 }
@@ -186,7 +186,7 @@ func TestClassifyRelayDrop_NilStaysNil(t *testing.T) {
 func TestClassifyRelayDrop_ProbeFailureFallsBackToRunErr(t *testing.T) {
 	client := signaling.New("http://127.0.0.1:1", "test")
 	runErr := errors.New("idle timeout")
-	got := classifyRelayDrop(context.Background(), client, "sess-1", runErr)
+	got := classifyRelayDrop(context.Background(), client, "sess-1", "tok-1", runErr)
 	if got != runErr {
 		t.Errorf("expected runErr to survive a probe failure, got %v", got)
 	}

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -247,7 +247,7 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	// surprised by "I asked for both --connect and --send and only the
 	// first ran."
 	if cmd.Flags().Changed("connect") {
-		for _, conflict := range []string{"send", "receive", "text", "pass", "yes", "out", "overwrite", "name", "uninstall"} {
+		for _, conflict := range []string{"send", "receive", "text", "pass", "yes", "out", "overwrite", "name", "exclude", "mode", "uninstall"} {
 			if cmd.Flags().Changed(conflict) {
 				return fmt.Errorf("%w: --connect cannot be combined with --%s", fserrors.ErrUsage, conflict)
 			}

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -61,6 +61,18 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 			[]string{"--connect=host:443", "file.pdf"},
 			"--connect cannot be combined with positional arguments",
 		},
+		{
+			"connect_with_exclude",
+			[]string{"--connect=host:443", "--exclude=*.tmp"},
+			"--connect cannot be combined with --exclude",
+		},
+		{
+			// `--connect default,<pw>` splits to ["default","<pw>"]; the
+			// stray password must error, not be silently dropped.
+			"connect_default_with_password",
+			[]string{"--connect=default,hunter2"},
+			"--connect default takes no password",
+		},
 	}
 	for _, c := range cases {
 		c := c

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -62,11 +62,12 @@ type internetSenderPairing struct {
 	pathInfo     connpath.Info
 	cleanup      func()
 
-	// sigClient and sessionID let the post-transfer error path probe
-	// the pairing server for a relay eviction reason. Without this,
-	// a 100 MiB-cap-hit looks identical to a flaky network.
+	// sigClient, sessionID, and roleToken let the post-transfer error
+	// path probe the pairing server for a relay eviction reason. Without
+	// this, a 100 MiB-cap-hit looks identical to a flaky network.
 	sigClient *signaling.Client
 	sessionID string
+	roleToken string
 }
 
 // sendPairOutcome is what a pair goroutine reports back.
@@ -184,6 +185,7 @@ func pairOverInternet(ctx context.Context, f *flags, code string, cfg *config.Co
 		pathInfo:     pathInfo,
 		sigClient:    client,
 		sessionID:    created.SessionID,
+		roleToken:    created.RoleToken,
 		cleanup: func() {
 			teardown()
 			deleteSession()
@@ -448,7 +450,7 @@ func runSenderTransferOverInternet(ctx context.Context, f *flags, items []transf
 		return quicconn.SenderHandshake(ctx, qc, pair.code)
 	})
 	if pair.pathInfo.Kind == connpath.KindRelay {
-		return classifyRelayDrop(ctx, pair.sigClient, pair.sessionID, err)
+		return classifyRelayDrop(ctx, pair.sigClient, pair.sessionID, pair.roleToken, err)
 	}
 	return err
 }

--- a/internal/connpath/connpath.go
+++ b/internal/connpath/connpath.go
@@ -123,16 +123,6 @@ func (i Info) Tag() string {
 	}
 }
 
-// Glyph returns the UX glyph for this path: ✓ for direct paths, ⚠ for
-// relay (relay is not a failure, but it is slower and worth flagging).
-// Callers should pair with the ASCII fallback via uxlog.marker.
-func (i Info) Glyph() (utf8, ascii string) {
-	if i.Kind == KindRelay {
-		return "⚠", "[!]"
-	}
-	return "✓", "[OK]"
-}
-
 // Headline is the single line the CLI prints right after the data path
 // is established, e.g.
 //

--- a/internal/connpath/connpath_test.go
+++ b/internal/connpath/connpath_test.go
@@ -94,20 +94,6 @@ func TestTag_CompactForms(t *testing.T) {
 	}
 }
 
-func TestGlyph(t *testing.T) {
-	// Direct paths get a check; relay gets a warning glyph (per spec:
-	// relay is honest disclosure, not an error, but it warrants a flag).
-	if utf8, _ := (Info{Kind: KindLocal}).Glyph(); utf8 != "✓" {
-		t.Errorf("Local glyph = %q, want ✓", utf8)
-	}
-	if utf8, _ := (Info{Kind: KindDirectNAT}).Glyph(); utf8 != "✓" {
-		t.Errorf("DirectNAT glyph = %q, want ✓", utf8)
-	}
-	if utf8, ascii := (Info{Kind: KindRelay}).Glyph(); utf8 != "⚠" || ascii != "[!]" {
-		t.Errorf("Relay glyph = (%q,%q), want (⚠, [!])", utf8, ascii)
-	}
-}
-
 func TestDetail(t *testing.T) {
 	if d := FromICE("srflx", "host").Detail(); d != "srflx → host" {
 		t.Errorf("Detail() = %q, want %q", d, "srflx → host")

--- a/internal/quicconn/auth_test.go
+++ b/internal/quicconn/auth_test.go
@@ -48,7 +48,7 @@ func TestHandshake_WrongCodeRejected(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		time.Sleep(50 * time.Millisecond)
-		_, recvErr = Dial(ctx, ln.LocalAddr().String(), "xyz-pqrs-tuv")
+		_, recvErr = Dial(ctx, ln.ln.Addr().String(), "xyz-pqrs-tuv")
 	}()
 
 	wg.Wait()

--- a/internal/quicconn/quicconn.go
+++ b/internal/quicconn/quicconn.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"io"
 	"math/big"
-	"net"
 	"os"
 	"time"
 
@@ -55,6 +54,14 @@ func init() {
 // Bumping this is a wire-protocol-major event.
 const ALPN = "fsend/1"
 
+// pqCurvePreferences pins the key-exchange groups so the post-quantum
+// X25519MLKEM768 hybrid is always preferred — set explicitly (not via
+// Go's default) so a toolchain default change or GODEBUG=tlsmlkem=0 can't
+// silently downgrade us; TestNegotiatesPostQuantum guards the wire result.
+// Plain X25519 stays as a classically-secure fallback for peers without
+// ML-KEM support.
+var pqCurvePreferences = []tls.CurveID{tls.X25519MLKEM768, tls.X25519}
+
 // HandshakeTimeout caps the time we'll spend on the TLS+QUIC handshake.
 const HandshakeTimeout = 10 * time.Second
 
@@ -84,10 +91,11 @@ func SenderTLSConfig() (*tls.Config, error) {
 		return nil, err
 	}
 	return &tls.Config{
-		Certificates: []tls.Certificate{cert},
-		NextProtos:   []string{ALPN},
-		MinVersion:   tls.VersionTLS13,
-		ClientAuth:   tls.NoClientCert,
+		Certificates:     []tls.Certificate{cert},
+		NextProtos:       []string{ALPN},
+		MinVersion:       tls.VersionTLS13,
+		CurvePreferences: pqCurvePreferences,
+		ClientAuth:       tls.NoClientCert,
 	}, nil
 }
 
@@ -104,6 +112,7 @@ func ReceiverTLSConfig() *tls.Config {
 		InsecureSkipVerify: true,
 		NextProtos:         []string{ALPN},
 		MinVersion:         tls.VersionTLS13,
+		CurvePreferences:   pqCurvePreferences,
 	}
 }
 
@@ -127,9 +136,6 @@ type Listener struct {
 	ln   *quic.Listener
 	code string
 }
-
-// LocalAddr returns the UDP address the listener is bound to.
-func (l *Listener) LocalAddr() net.Addr { return l.ln.Addr() }
 
 // Close stops listening.
 func (l *Listener) Close() error { return l.ln.Close() }

--- a/internal/quicconn/quicconn_test.go
+++ b/internal/quicconn/quicconn_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"crypto/tls"
 	"os"
 	"path/filepath"
 	"sync"
@@ -13,6 +14,55 @@ import (
 	"github.com/polius/fsend/internal/transfer"
 	"github.com/polius/fsend/internal/wire"
 )
+
+// TestNegotiatesPostQuantum locks in the headline property: two fsend
+// peers must land on the X25519MLKEM768 hybrid, not plain X25519. Asserts
+// the wire result so a silent downgrade fails CI.
+func TestNegotiatesPostQuantum(t *testing.T) {
+	ln, err := ListenAddr("127.0.0.1:0", "abc-defg-jkm")
+	if err != nil {
+		t.Fatalf("ListenAddr: %v", err)
+	}
+	defer ln.Close()
+
+	type acceptResult struct {
+		res *AcceptResult
+		err error
+	}
+	// Keep both ends alive until both curves are read — closing the
+	// sender as soon as it captures the curve would race the receiver's
+	// data-stream prime read.
+	acceptCh := make(chan acceptResult, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		res, err := ln.Accept(ctx)
+		acceptCh <- acceptResult{res, err}
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	dialRes, err := Dial(ctx, ln.ln.Addr().String(), "abc-defg-jkm")
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer dialRes.Close()
+
+	acc := <-acceptCh
+	if acc.err != nil {
+		t.Fatalf("Accept: %v", acc.err)
+	}
+	defer acc.res.Close()
+
+	for _, got := range []tls.CurveID{
+		acc.res.Conn.ConnectionState().TLS.CurveID,
+		dialRes.Conn.ConnectionState().TLS.CurveID,
+	} {
+		if got != tls.X25519MLKEM768 {
+			t.Errorf("negotiated curve = %v, want X25519MLKEM768 (post-quantum downgrade!)", got)
+		}
+	}
+}
 
 // TestQUIC_LoopbackTransfer is the load-bearing integration test for the
 // transport: send a 4 MB random file from one in-process goroutine to
@@ -39,7 +89,7 @@ func TestQUIC_LoopbackTransfer(t *testing.T) {
 		t.Fatalf("ListenAddr: %v", err)
 	}
 	defer ln.Close()
-	listenAddr := ln.LocalAddr().String()
+	listenAddr := ln.ln.Addr().String()
 
 	items, err := transfer.Walk([]string{srcPath})
 	if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -232,7 +232,16 @@ func (s *Server) relayStatus(w http.ResponseWriter, r *http.Request) {
 	}
 	s.mu.Lock()
 	sess, ok := s.byID[id]
+	// Bearer-gate the probe with the session's role token, matching
+	// allocateRelay. A missing session and an unauthorized caller both
+	// return "unknown" so this leaks no existence oracle to a third party
+	// who only sniffed the session_id.
 	if !ok || !sess.relayTokenSet {
+		s.mu.Unlock()
+		writeJSON(w, http.StatusOK, RelayStatusResponse{State: "unknown"})
+		return
+	}
+	if _, authed := sess.sideForToken(bearerToken(r)); !authed {
 		s.mu.Unlock()
 		writeJSON(w, http.StatusOK, RelayStatusResponse{State: "unknown"})
 		return

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -469,7 +469,10 @@ func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 				t.Fatalf("allocate: status = %d", alloced.StatusCode)
 			}
 
-			resp, err := http.Get(ts.URL + "/v1/relay/status?session_id=" + cr.SessionID)
+			statusReq, _ := http.NewRequest(http.MethodGet,
+				ts.URL+"/v1/relay/status?session_id="+cr.SessionID, nil)
+			statusReq.Header.Set("Authorization", "Bearer "+cr.RoleToken)
+			resp, err := http.DefaultClient.Do(statusReq)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -488,6 +491,52 @@ func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 				t.Errorf("limit_bytes = %d, want %d", body.LimitBytes, c.wantBytes)
 			}
 		})
+	}
+}
+
+// TestRelayStatus_RequiresRoleToken confirms a caller who knows only the
+// session_id (no role token) can't probe relay state: the handler returns
+// "unknown", indistinguishable from a nonexistent session.
+func TestRelayStatus_RequiresRoleToken(t *testing.T) {
+	s := New(Config{
+		ServerVersion:        "0.0.0-test",
+		UnpairedTTL:          2 * time.Second,
+		PairedTTL:            5 * time.Second,
+		LongPollTimeout:      500 * time.Millisecond,
+		MaxSessionsPerIP:     10,
+		MaxNewSessionsPerMin: 100,
+	})
+	s.WithRelay(&fakeRelay{tok: relay.Token{1, 2, 3, 4}, reason: relay.ReasonCapHit, maxBytes: 1}, 9999)
+	ts := httptest.NewServer(s.Handler())
+	defer ts.Close()
+
+	created := postJSON(t, ts.URL+"/v1/session", CreateSessionRequest{})
+	defer created.Body.Close()
+	var cr CreateSessionResponse
+	if err := json.NewDecoder(created.Body).Decode(&cr); err != nil {
+		t.Fatal(err)
+	}
+	allocReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/relay/allocate",
+		bytes.NewReader(mustJSON(t, RelayAllocateRequest{SessionID: cr.SessionID})))
+	allocReq.Header.Set("Authorization", "Bearer "+cr.RoleToken)
+	alloced, err := http.DefaultClient.Do(allocReq)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alloced.Body.Close()
+
+	// No Authorization header → must not reveal the evicted state.
+	resp, err := http.Get(ts.URL + "/v1/relay/status?session_id=" + cr.SessionID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer resp.Body.Close()
+	var body RelayStatusResponse
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatal(err)
+	}
+	if body.State != "unknown" {
+		t.Errorf("unauthorized status probe = %q, want unknown", body.State)
 	}
 }
 

--- a/internal/signaling/client.go
+++ b/internal/signaling/client.go
@@ -137,25 +137,19 @@ func (c *Client) AllocateRelay(ctx context.Context, sessionID, roleToken string)
 
 // RelayStatus probes the pairing server for the current state of a
 // relay allocation. Used after a relay-path drop to surface the real
-// reason (e.g. cap_hit) instead of looping on retry forever.
+// reason (e.g. cap_hit) instead of looping on retry forever. roleToken
+// authenticates the caller as a party to the session.
 //
 // Network errors are treated as "unknown" — we don't want a probe
 // failure to mask the underlying transfer failure the caller is
 // already handling.
-func (c *Client) RelayStatus(ctx context.Context, sessionID string) (*server.RelayStatusResponse, error) {
+func (c *Client) RelayStatus(ctx context.Context, sessionID, roleToken string) (*server.RelayStatusResponse, error) {
 	var out server.RelayStatusResponse
 	path := "/v1/relay/status?session_id=" + sessionID
-	if err := c.do(ctx, http.MethodGet, path, nil, &out, nil); err != nil {
+	if err := c.do(ctx, http.MethodGet, path, nil, &out, withAuth(roleToken)); err != nil {
 		return nil, err
 	}
 	return &out, nil
-}
-
-// Health pings /v1/health and returns the parsed response.
-func (c *Client) Health(ctx context.Context) (*server.HealthResponse, error) {
-	var out server.HealthResponse
-	err := c.do(ctx, http.MethodGet, "/v1/health", nil, &out, nil)
-	return &out, err
 }
 
 // errNoContent is the sentinel `do` returns when the server replied 204

--- a/internal/signaling/client_test.go
+++ b/internal/signaling/client_test.go
@@ -136,18 +136,10 @@ func TestClient_WaitTimesOut(t *testing.T) {
 	}
 }
 
-func TestClient_HealthAndDelete(t *testing.T) {
+func TestClient_Delete(t *testing.T) {
 	url, _ := setupServer(t)
 	c := New(url, "test")
 	ctx := context.Background()
-
-	h, err := c.Health(ctx)
-	if err != nil {
-		t.Fatalf("Health: %v", err)
-	}
-	if h.Status != "ok" {
-		t.Errorf("health status = %q", h.Status)
-	}
 
 	created, _ := c.Create(ctx, "")
 	if err := c.Delete(ctx, created.SessionID); err != nil {
@@ -157,7 +149,7 @@ func TestClient_HealthAndDelete(t *testing.T) {
 
 func TestClient_UnreachableServer_MapsToFserror(t *testing.T) {
 	c := New("http://127.0.0.1:1", "test") // intentionally bogus port
-	_, err := c.Health(context.Background())
+	_, err := c.RelayStatus(context.Background(), "sess", "")
 	if !errors.Is(err, fserrors.ErrServerUnreachable) {
 		t.Errorf("expected ErrServerUnreachable, got %v", err)
 	}
@@ -236,7 +228,7 @@ func TestClient_TimeoutMapsToServerUnreachable(t *testing.T) {
 	// Shrink the timeout so the test runs fast.
 	c.hc.Timeout = 50 * time.Millisecond
 
-	_, err := c.Health(context.Background())
+	_, err := c.RelayStatus(context.Background(), "sess", "")
 	if !errors.Is(err, fserrors.ErrServerUnreachable) {
 		t.Errorf("expected ErrServerUnreachable, got %v", err)
 	}
@@ -244,7 +236,7 @@ func TestClient_TimeoutMapsToServerUnreachable(t *testing.T) {
 	// CLI can tell "I aborted" apart from "server didn't respond".
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	_, err = c.Health(ctx)
+	_, err = c.RelayStatus(ctx, "sess", "")
 	if !errors.Is(err, context.Canceled) {
 		t.Errorf("cancelled ctx should yield context.Canceled, got %v", err)
 	}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -406,6 +406,14 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 			return fserrors.ErrHashMismatch
 		}
 
+		// Enforce the declared size: a misbehaving peer that never sets
+		// FlagLastChunk could otherwise stream unbounded chunks to the
+		// partial and exhaust disk (the root-hash check only runs after
+		// the loop). Streaming items carry no size and are exempt.
+		if !info.Streaming && bytesWritten+uint64(len(plain)) > info.Size {
+			return fmt.Errorf("%w: received bytes exceed declared size %d", fserrors.ErrProtocolError, info.Size)
+		}
+
 		if len(plain) > 0 {
 			if _, err := f.Write(plain); err != nil {
 				return fmt.Errorf("%w: write: %v", fserrors.ErrWriteFailed, err)


### PR DESCRIPTION
Follow-up to a senior production-readiness audit of the project. Each change is empirically verified — the full `-race` suite, `golangci-lint`, and `deadcode -test` are all green.

## Findings addressed

| # | Sev | Finding | Fix |
|---|-----|---------|-----|
| 1 | MEDIUM | Receiver didn't enforce the sender's declared `FileInfo.Size` | A PAKE-authenticated but misbehaving sender could advertise a small size yet stream unbounded chunks (the root-hash check only runs after the loop), exhausting the receiver's disk. The receive loop now rejects once `bytesWritten + len > info.Size` for non-streaming files; streaming items (stdin/`--text`) stay exempt by design. |
| 3 | LOW | Three production methods with no production caller | Removed `connpath.Info.Glyph` (its logic was duplicated inline in `printPath`), `signaling.Client.Health` (the Docker probe uses a raw `http.Get`), and `quicconn.Listener.LocalAddr`, plus their now-redundant tests. |
| 4 | LOW | `--connect default,<pw>` silently dropped the password | Now returns `E024 — --connect default takes no password`. |
| 5 | LOW | `--connect` conflict list omitted `--exclude` | Added `exclude` and `mode` (both transfer-only) to the conflict list. |
| 6 | LOW | Post-quantum guarantee was unpinned and untested | Pinned `CurvePreferences = {X25519MLKEM768, X25519}` explicitly in both TLS configs so a toolchain default change or `GODEBUG=tlsmlkem=0` can't silently downgrade the advertised PQ exchange. New `TestNegotiatesPostQuantum` asserts two peers land on the hybrid on the wire. |
| 7 | LOW | `/v1/relay/status` lacked per-session auth | Bearer-gated with the session role token, matching `/v1/relay/allocate`. A third party who only sniffed the `session_id` could previously probe eviction state; missing-session and unauthorized callers now both return `"unknown"` (no existence oracle). |

> Finding #2 (the server unconditionally trusts `X-Real-IP`/`X-Forwarded-For` — safe behind the shipped Caddy config, a footgun for direct-exposure self-hosters) is intentionally **not** in this PR; it needs a deployment-policy decision (`TrustProxyHeaders` config vs. docs-only).

## Verification
- `go build` / `go vet` — clean
- `go test -race -count=1 ./...` — all 18 packages pass, **0 races** (incl. the 40s e2e suite)
- `golangci-lint run` — 0 issues
- `deadcode -test ./...` — clean (the CI gate)
- Rebuilt binary: confirmed #4/#5 reject with E024 while legitimate `--connect host,pw` / `--connect default` still work

## Notes
- While wiring #3, swapping the removed `Health()` for `Create()` in two transport-error tests made `internal/signaling` hang under `-race` (a POST-with-body teardown left the test's hanging server handler alive, blocking `httptest.Close`). Switched those to the bodyless `RelayStatus` GET.
- #1 has no bespoke adversarial test: a protocol-faithful malicious sender would be ~100 lines of fragile wire-mirroring, the happy path (no false-trigger) is already covered by every roundtrip/e2e test, and the negative branch is trivially correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)