### PR TITLE
docs: correct accuracy nits in comparison, security, self-hosting, usage

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -133,7 +133,7 @@ guarantee differs in three ways.
 | End-to-end encrypted         | ✓                                                                             | ✓                                                             |
 | PAKE protocol                | SPAKE2 (RFC 9382, IETF-standardized)                                          | `schollz/pake` (Boneh-Shoup textbook construction)            |
 | Defense-in-depth layers      | **Two** independent — TLS 1.3 (QUIC) **+** SPAKE2 channel-bound to the TLS handshake (RFC 5705) | **One** — AEAD keyed directly from PAKE        |
-| AEAD                         | TLS 1.3 ciphers (AES-128-GCM, ChaCha20-Poly1305, AES-256-GCM)                 | AES-256-GCM or XChaCha20-Poly1305 (selectable)                |
+| AEAD                         | TLS 1.3 ciphers (AES-128-GCM, ChaCha20-Poly1305, AES-256-GCM)                 | AES-256-GCM (default; XChaCha20-Poly1305 exists internally)    |
 | Key derivation               | TLS 1.3 KDF + SPAKE2 + RFC 5705 exporter binding                              | PBKDF2-SHA256 (100 iterations) or Argon2id (64 MiB)           |
 | Post-quantum forward secrecy | ✓ X25519 + ML-KEM-768 hybrid (NIST FIPS 203)                                  | ✗ Classical elliptic-curve only                               |
 | MITM defense                 | TLS catches a network MITM; SPAKE2 binding catches a TLS-handshake MITM       | Single layer — PAKE only                                      |
@@ -160,17 +160,18 @@ For the full threat-model discussion, see [Security](security.md).
 | Format           | `abc-defg-jkm` (3-4-3 letters)       | `1234-curious-iron-yellow` (PIN + words)    |
 | Alphabet         | 23 letters (excludes `i`, `l`, `o`)  | digits + mnemonic wordlist                  |
 | Entropy          | ~45 bits (log₂(23¹⁰))                | ~45 bits (10⁴ PIN + 32-bit mnemonic)        |
-| One-shot         | ✓ — same code can't be reused        | Not documented                              |
+| One-shot         | ✓ — same code can't be reused        | ✓ for auto codes; reusable via `--code`     |
 | Server-side TTL  | 1 h unclaimed / 10 min after pairing | None documented                             |
 | Custom secret    | `--pass` for a persistent password   | `--code` for a custom phrase (min 6 chars)  |
 
-The codes carry comparable entropy. The operational difference is
-fsend's documented one-shot semantics and bounded server-side TTL: a
-leaked code is useful for at most one receiver, lives only as long as
+The codes carry comparable entropy. Both tools document one-shot
+auto-generated codes. The operational difference is fsend's bounded
+server-side TTL and the fact that its code is always system-generated:
+a leaked code is useful for at most one receiver, lives only as long as
 the sender keeps the process running, and is hard-capped at one hour by
-the server. croc's README and source do not specify equivalent
-server-side guarantees, and `--code` lets a sender reuse a chosen
-phrase across many invocations.
+the server. croc's README does not specify an equivalent server-side
+TTL, and its `--code` flag lets a sender reuse a chosen phrase across
+many invocations.
 
 ## Feature parity
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -108,8 +108,9 @@ excluded for legibility). Codes are:
   receiver pairs, or after ten minutes once a receiver has paired. Ctrl-C
   on the sender invalidates the code immediately.
 - **Rate-limited** — the public pairing server caps new sessions at 30
-  per minute per source IP, making online brute-force against the
-  ~45-bit code space infeasible.
+  per minute per source IP (IPv4 keyed on the full address, IPv6 on the
+  /64 prefix), making online brute-force against the ~45-bit code space
+  infeasible.
 - **Not the encryption key** — the code authenticates the SPAKE2 handshake;
   the actual session key is derived from that handshake plus the TLS 1.3
   channel binding, so the code itself never traverses the wire in the clear.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -102,8 +102,8 @@ with `fsend --connect default`.
   log level is `info` — lifecycle events only. No per-transfer lines,
   no IPs, no share codes.
 - **Update.** `docker compose pull && docker compose up -d`. The image
-  is pinned to `poliuscorp/fsend:latest`; switch to a specific tag if
-  you want immutable upgrades.
+  defaults to the floating `poliuscorp/fsend:latest` tag; pin a specific
+  version tag if you want immutable, reproducible upgrades.
 - **Backup.** Nothing to back up. Pairing state lives in RAM and evicts
   within an hour. Cert state lives in the `caddy_data` Docker volume —
   Caddy reissues automatically if you lose it.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -96,7 +96,7 @@ Config is at `~/.config/fsend/config.json` (Linux),
 |---|---|
 | `--quiet` | Suppress non-error output. |
 | `--debug` | Verbose logging to stderr. Also `FSEND_DEBUG=1`. |
-| `--uninstall` | Remove the binary and `~/.config/fsend`. `--yes` skips confirmation. |
+| `--uninstall` | Remove the binary and the fsend config directory (see [`--connect`](#choosing-a-server---connect) for the per-OS path). `--yes` skips confirmation. |
 | `--help` / `-h` | Show inline help. |
 | `--version` / `-v` | Print version. |
 


### PR DESCRIPTION
Five empirically-verified documentation fixes found during a full docs audit. **Docs-only — no code touched.** Every change was cross-checked against the fsend code (and, for the croc claims, against croc's primary source).

## Changes

| File | Fix |
|---|---|
| `comparison.md` | croc one-shot codes **are** documented (auto codes are used-once between two parties). Changed *"Not documented"* → *"✓ for auto codes; reusable via `--code`"* and reworded the prose — the real distinction is fsend's bounded **server-side TTL** and always-system-generated code, not whether one-shot is documented. |
| `comparison.md` | Dropped misleading *"(selectable)"* on croc's AEAD. AES-256-GCM is the default and only CLI-exposed cipher; XChaCha20-Poly1305 exists only as an internal code variant. |
| `self-hosting.md` | `:latest` is a **floating** tag, not "pinned" (the bullet then recommends pinning a specific tag — self-contradictory). Reworded. |
| `usage.md` | `--uninstall` removes the **per-OS** config directory, not the Linux-only `~/.config/fsend`. Now links to the `--connect` per-OS path table. |
| `security.md` | Rate limit is keyed on the IPv4 address or the IPv6 **/64 prefix** (`rateLimitKey`, `server.go`), not strictly "per source IP". |

## Verification

- All other verifiable doc claims checked out against code: the 28 error codes + E099 match `usage.md` exactly, ports (`:8080`/`:443`), mDNS 300 ms, TTLs (1 h / 10 min), health response shape, code entropy (~45 bits), and the crypto stack.
- croc claims confirmed against primary source: `PBKDF2-SHA256` / 100 iterations (`crypt.go`), ports 9009–9013 and `croc.schollz.com` (`constants.go`), no NAT hole-punching, no post-quantum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)