### PR TITLE
audit: fix auth-bypass + LAN code leak, harden CLI/server, correct docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ fsend lets any two computers transfer files **directly** to each other — no ac
 - **End-to-end encrypted** — two independent layers; even the fallback relay never sees the file
 - **No ports to open** — works on any network, no router or firewall setup
 - **Send anything** — files, folders, multiple at once, stdin streams, or literal text
-- **Resumable** — connection drops? Rerun the same code and fsend picks up where it stopped
+- **Resumable** — connection drops? Rerun the same command and fsend picks up where it stopped
 - **Password-protected** — gate any transfer with `--pass`; receiver supplies it to unlock
 - **Post-quantum** — X25519 + ML-KEM-768 (NIST); future quantum computers can't decrypt today's transfer
 - **Self-hostable** — very lightweight and simple to deploy

--- a/cmd/fsend/connect.go
+++ b/cmd/fsend/connect.go
@@ -12,6 +12,34 @@ import (
 	"github.com/polius/fsend/internal/uxlog"
 )
 
+// warnIfConfigCorrupted prints the E016 warning to stderr when
+// config.Load reported a corrupt file. config.Load still returns a usable
+// zero-value Config in that case, so the caller proceeds on defaults —
+// this just makes the silent fallback visible. No-op when quiet or when
+// err is nil/not a corruption error.
+func warnIfConfigCorrupted(err error, quiet bool) {
+	if err == nil || quiet {
+		return
+	}
+	entry, ok := fserrors.Lookup(err)
+	if !ok {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "%s [%s] %s\n", uxlog.Warn(), entry.Code, entry.Message)
+	if entry.Action != "" {
+		fmt.Fprintf(os.Stderr, "  %s\n", entry.Action)
+	}
+}
+
+// loadConfig loads the persisted config, surfacing the E016 corruption
+// warning (unless quiet). Used by the send/receive flows, which need the
+// configured server but should not fail just because the file is invalid.
+func loadConfig(quiet bool) *config.Config {
+	cfg, err := config.Load()
+	warnIfConfigCorrupted(err, quiet)
+	return cfg
+}
+
 // runConnect implements `fsend --connect ...`:
 //
 //	fsend --connect                       → print current config + default
@@ -19,7 +47,10 @@ import (
 //	fsend --connect <host[:port]>         → set custom server (port optional)
 //	fsend --connect <host[:port]>,<pw>    → set custom server + password
 func runConnect(f *flags) error {
-	cfg, _ := config.Load() // ignore corruption error — we're about to overwrite anyway
+	// A set/revert overwrites the file, so corruption there is moot. But
+	// the show path (no args) must warn — otherwise a corrupt config that
+	// silently reverts to the default reads as "you're on the default".
+	cfg, loadErr := config.Load()
 
 	// Strip the bare-flag sentinel cobra synthesised when the user
 	// typed `fsend --connect` with no value. After filtering, an empty
@@ -33,6 +64,7 @@ func runConnect(f *flags) error {
 	}
 
 	if len(args) == 0 {
+		warnIfConfigCorrupted(loadErr, false)
 		printCurrentServer(cfg)
 		return nil
 	}

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -634,10 +635,10 @@ func TestReadLine_BasicCases(t *testing.T) {
 
 func TestPromptAccept_QuietRequiresYes(t *testing.T) {
 	h := wire.SenderHello{TransferKind: wire.TransferSingleFile, DisplayName: "x", TotalBytes: 1}
-	if promptAccept(&flags{quiet: true}, h, "/tmp", mustLANInfo()) {
+	if promptAccept(context.Background(), &flags{quiet: true}, h, "/tmp", mustLANInfo()) {
 		t.Error("quiet without --yes must decline")
 	}
-	if !promptAccept(&flags{quiet: true, yes: true}, h, "/tmp", mustLANInfo()) {
+	if !promptAccept(context.Background(), &flags{quiet: true, yes: true}, h, "/tmp", mustLANInfo()) {
 		t.Error("quiet + --yes must accept")
 	}
 }
@@ -652,7 +653,7 @@ func TestPromptAccept_YesAcceptsAcrossKinds(t *testing.T) {
 	} {
 		got := captureStderr(t, func() {
 			h := wire.SenderHello{TransferKind: k, DisplayName: "x", TotalBytes: 1, TotalFiles: 1}
-			if !promptAccept(&flags{yes: true}, h, "/tmp", mustLANInfo()) {
+			if !promptAccept(context.Background(), &flags{yes: true}, h, "/tmp", mustLANInfo()) {
 				t.Errorf("--yes must accept kind %v", k)
 			}
 		})
@@ -670,7 +671,7 @@ func TestPromptAccept_PasswordChipRendered(t *testing.T) {
 			TotalBytes:   1,
 			HasPassword:  true,
 		}
-		_ = promptAccept(&flags{yes: true}, h, "/tmp", mustLANInfo())
+		_ = promptAccept(context.Background(), &flags{yes: true}, h, "/tmp", mustLANInfo())
 	})
 	if !strings.Contains(got, "password required") {
 		t.Errorf("expected password chip, got:\n%s", got)

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -36,7 +36,7 @@ const iceBudget = 15 * time.Second
 //
 // HTTPS is the default for non-local addresses; HTTP for localhost so dev
 // loops work without a cert. If the user has configured a per-server
-// password (via `fsend --connect <host:port> <password>`), the client
+// password (via `fsend --connect <host:port>,<password>`), the client
 // carries it through; the server matches against FSEND_SERVER_PASSWORD.
 func signalingClient(cfg *config.Config) (*signaling.Client, string) {
 	addr := cfg.EffectiveServer()
@@ -366,7 +366,7 @@ func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code 
 		}
 	}
 
-	closeProg, accept, confirmOverwrite, progressFn, recvBytes := newReceiverProgress(f, outDir, pathInfo)
+	closeProg, accept, confirmOverwrite, progressFn, recvBytes := newReceiverProgress(ctx, f, outDir, pathInfo)
 	defer closeProg()
 
 	start := time.Now()
@@ -374,6 +374,11 @@ func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code 
 		func(attempt int) error {
 			return runReceiverOneAttempt(ctx, tr, outDir, f, accept, confirmOverwrite, progressFn, code)
 		}); err != nil {
+		// A Ctrl-C at an interactive prompt cancels ctx but surfaces as a
+		// decline/target-exists error; report it as a cancellation (E026).
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return err
 	}
 	// Flush bar before summary; see receive.go for the streaming-stdin reason.
@@ -411,7 +416,7 @@ func runReceiverOneAttempt(ctx context.Context, tr *quic.Transport, outDir strin
 		Overwrite:        f.overwrite,
 		Accept:           accept,
 		Password:         f.passArg,
-		PromptPass:       receiverPasswordPrompt(f),
+		PromptPass:       receiverPasswordPrompt(ctx, f),
 		ConfirmOverwrite: confirmOverwrite,
 		ProgressFn:       progressFn,
 	})

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -56,6 +56,13 @@ func normalizePassArgs(args []string) []string {
 	out := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		a := args[i]
+		// Everything after the `--` end-of-flags marker is a positional,
+		// even if it spells a flag — copy the rest verbatim so a file
+		// literally named "--pass" survives `fsend -- --pass file`.
+		if a == "--" {
+			out = append(out, args[i:]...)
+			break
+		}
 		if a != "--pass" {
 			out = append(out, a)
 			continue
@@ -94,6 +101,10 @@ func normalizeConnectArgs(args []string) []string {
 	out := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
 		a := args[i]
+		if a == "--" {
+			out = append(out, args[i:]...)
+			break
+		}
 		if a != "--connect" {
 			out = append(out, a)
 			continue
@@ -136,7 +147,8 @@ func renderError(err error, debug bool) int {
 	if known && (errors.Is(err, fserrors.ErrUsage) ||
 		errors.Is(err, fserrors.ErrSourceNotFound) ||
 		errors.Is(err, fserrors.ErrRelayCapHit) ||
-		errors.Is(err, fserrors.ErrRelayIdleTimeout)) {
+		errors.Is(err, fserrors.ErrRelayIdleTimeout) ||
+		errors.Is(err, fserrors.ErrServerStartup)) {
 		if extra := extractDetail(err.Error()); extra != "" {
 			detail = extra
 		}

--- a/cmd/fsend/main_test.go
+++ b/cmd/fsend/main_test.go
@@ -41,6 +41,11 @@ func TestNormalizePassArgs(t *testing.T) {
 			in:   []string{"fsend", "report.pdf"},
 			want: []string{"fsend", "report.pdf"},
 		},
+		{
+			name: "stops at -- so a file named --pass survives",
+			in:   []string{"fsend", "--send", "--", "--pass", "a.txt"},
+			want: []string{"fsend", "--send", "--", "--pass", "a.txt"},
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -74,6 +79,8 @@ func TestNormalizeConnectArgs(t *testing.T) {
 		{[]string{"fsend", "--connect=host:443"}, []string{"fsend", "--connect=host:443"}},
 		// Unrelated flags pass through.
 		{[]string{"fsend", "report.pdf"}, []string{"fsend", "report.pdf"}},
+		// Stops at -- so a file named --connect survives as a positional.
+		{[]string{"fsend", "--", "--connect", "f"}, []string{"fsend", "--", "--connect", "f"}},
 	}
 	for _, c := range cases {
 		got := normalizeConnectArgs(c.in)

--- a/cmd/fsend/password.go
+++ b/cmd/fsend/password.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"errors"
 	"fmt"
@@ -14,7 +15,8 @@ import (
 	"github.com/polius/fsend/internal/fserrors"
 )
 
-// stdinIsTTY is a seam so tests can simulate piped stdin without faking fds.
+// stdinIsTTY reports whether stdin is an interactive terminal. A var (not
+// a plain call) so it can be swapped out in tests without faking fds.
 var stdinIsTTY = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 
 // readPasswordHidden prompts on stderr and reads a single line from the
@@ -45,6 +47,37 @@ func readPasswordHidden(prompt string) (string, error) {
 		}
 	}
 	return "", fmt.Errorf("%w: password cannot be empty", fserrors.ErrUsage)
+}
+
+// readPasswordHiddenCtx is readPasswordHidden that also aborts on ctx
+// cancellation (Ctrl-C at the prompt), returning context.Canceled. The
+// abandoned ReadPassword goroutine cannot run its own deferred terminal
+// restore, so we capture the terminal state up front and restore it here.
+func readPasswordHiddenCtx(ctx context.Context, prompt string) (string, error) {
+	fd := int(os.Stdin.Fd())
+	var oldState *term.State
+	if term.IsTerminal(fd) {
+		oldState, _ = term.GetState(fd)
+	}
+	type result struct {
+		pw  string
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		pw, err := readPasswordHidden(prompt)
+		ch <- result{pw, err}
+	}()
+	select {
+	case <-ctx.Done():
+		if oldState != nil {
+			_ = term.Restore(fd, oldState)
+			fmt.Fprintln(os.Stderr)
+		}
+		return "", context.Canceled
+	case r := <-ch:
+		return r.pw, r.err
+	}
 }
 
 // resolvePassword expands the bare --pass sentinel into a concrete

--- a/cmd/fsend/prompts.go
+++ b/cmd/fsend/prompts.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"io"
 	"os"
 	"strings"
@@ -23,6 +24,21 @@ func readLine(r io.Reader) string {
 	br := bufio.NewReader(r)
 	line, _ := br.ReadString('\n')
 	return strings.ToLower(strings.TrimSpace(line))
+}
+
+// readLineCtx reads one line from os.Stdin but returns ok=false if ctx is
+// cancelled first — e.g. Ctrl-C while the prompt is waiting for input.
+// The blocked read goroutine is abandoned; that is harmless because a
+// cancelled ctx means the process is on its way down.
+func readLineCtx(ctx context.Context) (line string, ok bool) {
+	ch := make(chan string, 1)
+	go func() { ch <- readLine(os.Stdin) }()
+	select {
+	case <-ctx.Done():
+		return "", false
+	case s := <-ch:
+		return s, true
+	}
 }
 
 // stdinReader returns the process-wide bufio.Reader over os.Stdin.

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -12,7 +13,6 @@ import (
 	"unicode"
 
 	"github.com/polius/fsend/internal/code"
-	"github.com/polius/fsend/internal/config"
 	"github.com/polius/fsend/internal/connpath"
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/landisc"
@@ -58,11 +58,11 @@ func runReceive(f *flags, c string) error {
 		// from here through Join + ICE/relay setup, replacing what used
 		// to be a sequence of brief flashes. runReceiveOverInternet
 		// owns its lifetime and stops it just before printPath.
+		cfg := loadConfig(f.quiet)
 		var spin *uxlog.Spinner
 		if !f.quiet {
 			spin = uxlog.StartSpinner("Connecting")
 		}
-		cfg, _ := config.Load()
 		return runReceiveOverInternet(ctx, f, c, cfg, spin)
 	}
 
@@ -97,16 +97,16 @@ func runReceive(f *flags, c string) error {
 		if !f.quiet {
 			fmt.Fprintln(os.Stderr, uxlog.Info(), "Local sender unreachable — falling back to server.")
 		}
+		cfg := loadConfig(f.quiet)
 		var connSpin *uxlog.Spinner
 		if !f.quiet {
 			connSpin = uxlog.StartSpinner("Connecting")
 		}
-		cfg, _ := config.Load()
 		return runReceiveOverInternet(ctx, f, c, cfg, connSpin)
 	}
 
 	pathInfo := connpath.FromLAN()
-	closeProg, accept, confirmOverwrite, progressFn, recvBytes := newReceiverProgress(f, outDir, pathInfo)
+	closeProg, accept, confirmOverwrite, progressFn, recvBytes := newReceiverProgress(ctx, f, outDir, pathInfo)
 	defer closeProg()
 
 	start := time.Now()
@@ -135,11 +135,17 @@ func runReceive(f *flags, c string) error {
 				Overwrite:        f.overwrite,
 				Accept:           accept,
 				Password:         f.passArg,
-				PromptPass:       receiverPasswordPrompt(f),
+				PromptPass:       receiverPasswordPrompt(ctx, f),
 				ConfirmOverwrite: confirmOverwrite,
 				ProgressFn:       progressFn,
 			})
 		}); err != nil {
+		// A Ctrl-C at an interactive prompt cancels ctx but surfaces as a
+		// decline/target-exists error from the engine; report it as a
+		// cancellation (E026) rather than that incidental error.
+		if ctx.Err() != nil {
+			return ctx.Err()
+		}
 		return err
 	}
 
@@ -164,13 +170,13 @@ func runReceive(f *flags, c string) error {
 // Timing: the progress bar is constructed lazily on first byte (see
 // newReceiverProgress), so this prompt fires before any bar exists —
 // no risk of mpb rendering on top of the password input line.
-func receiverPasswordPrompt(f *flags) func() (string, error) {
+func receiverPasswordPrompt(ctx context.Context, f *flags) func() (string, error) {
 	if f.quiet {
 		return nil
 	}
 	return func() (string, error) {
 		fmt.Fprintln(os.Stderr)
-		return readPasswordHidden("  Password required by sender: ")
+		return readPasswordHiddenCtx(ctx, "  Password required by sender: ")
 	}
 }
 
@@ -190,7 +196,7 @@ func receiverPasswordPrompt(f *flags) func() (string, error) {
 // is needed to (a) render the save target and (b) detect a single-file
 // collision so we can surface it inline instead of asking a second
 // question after the user has already said yes.
-func promptAccept(f *flags, h wire.SenderHello, outDir string, pathInfo connpath.Info) bool {
+func promptAccept(ctx context.Context, f *flags, h wire.SenderHello, outDir string, pathInfo connpath.Info) bool {
 	if f.quiet {
 		return f.yes
 	}
@@ -209,7 +215,12 @@ func promptAccept(f *flags, h wire.SenderHello, outDir string, pathInfo connpath
 		return true
 	}
 	fmt.Fprintf(os.Stderr, "  Save to %s? [Y/n] ", saveTargetLabel(outDir))
-	switch readLine(os.Stdin) {
+	// Decline on Ctrl-C; the caller maps a cancelled ctx to E026.
+	line, ok := readLineCtx(ctx)
+	if !ok {
+		return false
+	}
+	switch line {
 	case "n", "no":
 		return false
 	default:
@@ -228,7 +239,9 @@ func renderArtifact(w io.Writer, h wire.SenderHello, outDir string, alreadyOverw
 	}
 	switch h.TransferKind {
 	case wire.TransferSingleFile:
-		name := h.DisplayName
+		// DisplayName is peer-supplied; sanitize it like the hostname so a
+		// crafted filename can't inject ANSI/bidi into the accept prompt.
+		name := sanitizeForDisplay(h.DisplayName, 128)
 		if name == "" {
 			name = "file"
 		}
@@ -242,7 +255,7 @@ func renderArtifact(w io.Writer, h wire.SenderHello, outDir string, alreadyOverw
 			}
 		}
 	case wire.TransferDirectory:
-		name := h.DisplayName
+		name := sanitizeForDisplay(h.DisplayName, 128)
 		if name == "" {
 			name = "directory"
 		}
@@ -273,14 +286,12 @@ func saveTargetLabel(outDir string) string {
 	return displayPath(outDir) + "/"
 }
 
-// sanitizeRemote removes control characters, ANSI sequences, and Unicode
-// format / bidirectional-override characters from peer-supplied strings
-// before display, then strips the mDNS ".local" suffix that macOS / many
-// Linuxes tack onto Bonjour hostnames. Without the bidi filter, a peer
-// can render a misleading hostname using U+202E "RIGHT-TO-LEFT OVERRIDE"
-// and friends, which is the textbook display-spoofing trick.
-func sanitizeRemote(s string) string {
-	const maxLen = 64
+// sanitizeForDisplay strips control characters, Unicode format and
+// bidirectional-override characters from peer-supplied text and caps it at
+// maxLen runes. Shared guard for any untrusted string we print: without
+// the bidi filter a peer can spoof display order with U+202E "RIGHT-TO-
+// LEFT OVERRIDE" and friends — the textbook display-spoofing trick.
+func sanitizeForDisplay(s string, maxLen int) string {
 	out := make([]rune, 0, len(s))
 	for _, r := range s {
 		switch {
@@ -296,7 +307,14 @@ func sanitizeRemote(s string) string {
 			break
 		}
 	}
-	clean := strings.TrimSuffix(string(out), ".local")
+	return string(out)
+}
+
+// sanitizeRemote sanitizes a peer-supplied hostname for display, then
+// strips the mDNS ".local" suffix that macOS / many Linuxes tack onto
+// Bonjour hostnames, falling back to a neutral placeholder when empty.
+func sanitizeRemote(s string) string {
+	clean := strings.TrimSuffix(sanitizeForDisplay(s, 64), ".local")
 	if clean == "" {
 		// "peer" reads as a neutral placeholder instead of "(unknown)",
 		// which can scan as "fsend failed to detect something". The

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -299,6 +299,11 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		return runSend(f, f.posArgs)
 	}
 	if f.forceReceive {
+		// --text is a send-side flag; combined with --receive it would
+		// otherwise be silently ignored. Reject rather than drop it.
+		if cmd.Flags().Changed("text") {
+			return fmt.Errorf("%w: --text cannot be combined with --receive", fserrors.ErrUsage)
+		}
 		if len(f.posArgs) != 1 {
 			return fmt.Errorf("%w: --receive requires exactly one positional argument (the code)", fserrors.ErrUsage)
 		}

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/polius/fsend/internal/code"
-	"github.com/polius/fsend/internal/config"
 	"github.com/polius/fsend/internal/connpath"
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/transfer"
@@ -70,7 +69,7 @@ func runSend(f *flags, paths []string) error {
 	// 300 ms mDNS query misses, so same-LAN receivers always win the
 	// race against the server path, and cross-network receivers don't
 	// wait on any timer.
-	cfg, _ := config.Load()
+	cfg := loadConfig(f.quiet)
 	return runSendParallel(ctx, f, items, kind, totalFiles, label, c, cfg, waitSpin)
 }
 
@@ -154,7 +153,10 @@ func containsDirectory(paths []string) (bool, error) {
 			if os.IsNotExist(err) {
 				return false, fmt.Errorf("%w: %s", fserrors.ErrSourceNotFound, p)
 			}
-			return false, err
+			// EACCES, ELOOP, ENOTDIR, … on an existing path: a routine local
+			// problem (usually permissions), not an internal bug. Map to
+			// E010 instead of letting it fall through to the E099 catchall.
+			return false, fmt.Errorf("%w: %s: %v", fserrors.ErrReadFailed, p, err)
 		}
 		if st.IsDir() {
 			return true, nil
@@ -375,7 +377,7 @@ func newSenderProgress(f *flags, items []transfer.SourceItem) (closeFn func(), p
 //   - Deferring also means a rejected transfer (Accept false, wrong
 //     password, sender abort before any chunk) leaves no half-rendered
 //     bar on screen — closeFn is a no-op if the bar was never created.
-func newReceiverProgress(f *flags, outDir string, pathInfo connpath.Info) (
+func newReceiverProgress(ctx context.Context, f *flags, outDir string, pathInfo connpath.Info) (
 	closeFn func(),
 	accept func(wire.SenderHello) bool,
 	confirmOverwrite func(relPath string, existing int64, incoming uint64) bool,
@@ -394,7 +396,7 @@ func newReceiverProgress(f *flags, outDir string, pathInfo connpath.Info) (
 
 	if f.quiet {
 		closeFn = func() {}
-		accept = func(h wire.SenderHello) bool { return promptAccept(f, h, outDir, pathInfo) }
+		accept = func(h wire.SenderHello) bool { return promptAccept(ctx, f, h, outDir, pathInfo) }
 		progressFn = func(fi uint32, b uint64) {
 			d := b - prev[fi]
 			prev[fi] = b
@@ -414,7 +416,7 @@ func newReceiverProgress(f *flags, outDir string, pathInfo connpath.Info) (
 	// count so the trailing " done" suffix prints instead of "aborted".
 	var streamingTotal bool
 	accept = func(h wire.SenderHello) bool {
-		ok := promptAccept(f, h, outDir, pathInfo)
+		ok := promptAccept(ctx, f, h, outDir, pathInfo)
 		if !ok {
 			return false
 		}
@@ -465,7 +467,12 @@ func newReceiverProgress(f *flags, outDir string, pathInfo connpath.Info) (
 			fmt.Fprintf(os.Stderr, "  %s already exists  ·  local %s  ·  incoming %s\n",
 				relPath, uxlog.HumanBytes(existing), uxlog.HumanBytes(int64(incoming)))
 			fmt.Fprint(os.Stderr, "  Overwrite? [y/N] ")
-			switch readLine(os.Stdin) {
+			// Decline on Ctrl-C; the caller maps a cancelled ctx to E026.
+			line, ok := readLineCtx(ctx)
+			if !ok {
+				return false
+			}
+			switch line {
 			case "y", "yes":
 				return true
 			default:
@@ -550,7 +557,9 @@ func displayPath(p string) string {
 }
 
 // signalContext wires Ctrl-C / SIGTERM to ctx cancellation so transfers
-// can be cleanly aborted.
+// can be cleanly aborted. After the first signal it stops intercepting,
+// so a second Ctrl-C reverts to the default disposition and terminates
+// the process outright — a safety valve if graceful teardown ever hangs.
 func signalContext() (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ch := make(chan os.Signal, 1)
@@ -558,6 +567,7 @@ func signalContext() (context.Context, context.CancelFunc) {
 	go func() {
 		<-ch
 		cancel()
+		signal.Stop(ch)
 	}()
 	return ctx, cancel
 }

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -137,7 +137,7 @@ func pairOverInternet(ctx context.Context, f *flags, code string, cfg *config.Co
 	// From here on we own a server-side session and must Delete it on
 	// every error path. We use a fresh ctx for Delete because the parent
 	// ctx may already be cancelled (e.g., the LAN path won the race).
-	deleteSession := func() { _ = client.Delete(context.Background(), created.SessionID) }
+	deleteSession := func() { _ = client.Delete(context.Background(), created.SessionID, created.RoleToken) }
 
 	// Long-poll indefinitely until the receiver pairs, the user
 	// cancels, or the server reaps the session. The server's per-call

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/relay"
 	"github.com/polius/fsend/internal/server"
 	"github.com/polius/fsend/internal/version"
@@ -32,9 +33,16 @@ func serverCmd() *cobra.Command {
 	var healthCheckFlag bool
 
 	c := &cobra.Command{
-		Use:           "server",
-		Short:         "Run the fsend pairing + relay server",
-		Args:          cobra.NoArgs,
+		Use:   "server",
+		Short: "Run the fsend pairing + relay server",
+		// Map a stray positional to E024 rather than cobra's default error,
+		// which would fall through to the E099 "file an issue" catchall.
+		Args: func(_ *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return fmt.Errorf("%w: server takes no positional arguments (got %q)", fserrors.ErrUsage, args[0])
+			}
+			return nil
+		},
 		SilenceUsage:  true,
 		SilenceErrors: true,
 		RunE: func(_ *cobra.Command, _ []string) error {
@@ -77,7 +85,7 @@ func runServer() error {
 
 	udpListener, err := net.ListenPacket("udp", cfg.udpAddr)
 	if err != nil {
-		return fmt.Errorf("relay UDP listen on %s: %w", cfg.udpAddr, err)
+		return fmt.Errorf("%w: relay UDP listen on %s: %v", fserrors.ErrServerStartup, cfg.udpAddr, err)
 	}
 	defer func() { _ = udpListener.Close() }()
 	relaySrv := relay.NewServer(udpListener, relay.ServerConfig{
@@ -86,7 +94,7 @@ func runServer() error {
 	})
 	udpPort, err := udpPortFromAddr(cfg.udpAddr)
 	if err != nil {
-		return fmt.Errorf("FSEND_UDP_ADDR %q: %w", cfg.udpAddr, err)
+		return fmt.Errorf("%w: FSEND_UDP_ADDR %q: %v", fserrors.ErrServerStartup, cfg.udpAddr, err)
 	}
 	s.WithRelay(relaySrv, udpPort)
 	relayCtx, relayCancel := context.WithCancel(ctx)
@@ -124,7 +132,7 @@ func runServer() error {
 		logger.Info("shutdown requested")
 	case err := <-errCh:
 		if !errors.Is(err, http.ErrServerClosed) {
-			return fmt.Errorf("http server: %w", err)
+			return fmt.Errorf("%w: http listen on %s: %v", fserrors.ErrServerStartup, cfg.httpAddr, err)
 		}
 	}
 
@@ -281,7 +289,7 @@ USAGE
 
 EXAMPLE
   Local-network test (no TLS — do not expose to the internet):
-    docker run -p 443:443/udp -p 8080:8080/tcp poliuscorp/fsend
+    docker run -p 443:443/udp -p 8080:8080/tcp poliuscorp/fsend server
 
   Internet-exposed: put a TLS-terminating reverse proxy in front of :8080.
   File data over UDP/443 is already end-to-end encrypted, but the HTTP
@@ -298,7 +306,7 @@ CONFIGURATION (environment variables — all optional)
   FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MiB (accepts e.g. "100MiB", "500m", "104857600")
   FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every endpoint except
                                         /v1/health requires the X-Fsend-Auth header to match.
-                                        Clients set theirs with: fsend --connect <host:port> <password>.
+                                        Clients set theirs with: fsend --connect <host:port>,<password>.
 
 LEARN MORE
   https://github.com/polius/fsend

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -26,7 +26,7 @@ services:
       FSEND_MAX_RELAY_BYTES_PER_SESSION: "100MiB"
       FSEND_MAX_SESSIONS_PER_IP: "5"
       FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN: "30"
-      # Password to restrict server access (empty = open); clients use `fsend --connect <domain> <password>`.
+      # Password to restrict server access (empty = open); clients use `fsend --connect <domain>,<password>`.
       FSEND_SERVER_PASSWORD: ""
     healthcheck:
       test: ["CMD", "/fsend", "server", "--health-check"]

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -12,10 +12,12 @@ networks** — the common case, and where the two designs diverge.
 - **Across the internet, fsend goes directly between the two computers
   when it can; croc always goes through a relay.** This changes
   throughput, network reach, and what a third-party server can observe.
-- **fsend uses QUIC over a single UDP port (UDP/443).** croc uses TCP
-  over a five-port range (9009–9013). One UDP port is easier to get past
-  a corporate firewall, and UDP/443 is allowed almost everywhere because
-  it's the port HTTP/3 uses.
+- **fsend uses QUIC; its server listens on a single UDP port (UDP/443).**
+  Direct transfers use hole-punched ephemeral ports, but the only
+  fixed destination is UDP/443. croc uses TCP over a five-port range
+  (9009–9013). One UDP port is easier to get past a corporate firewall,
+  and UDP/443 is allowed almost everywhere because it's the port HTTP/3
+  uses.
 - **fsend has two independent crypto layers** (TLS 1.3 + SPAKE2) with
   **post-quantum** key exchange. croc has a single AEAD keyed from PAKE.
 
@@ -106,9 +108,9 @@ nothing at all.
 |                       | fsend                                  | croc                                       |
 |-----------------------|----------------------------------------|--------------------------------------------|
 | Transport             | QUIC over UDP                          | TCP                                        |
-| Default port(s)       | UDP/443                                | TCP/9009–9013                              |
+| Default port(s)       | UDP/443 (server); ephemeral for direct | TCP/9009–9013                              |
 | Parallelism           | QUIC streams multiplex over one socket | One TCP connection per relay port          |
-| Firewall footprint    | One UDP port                           | Five TCP ports                             |
+| Firewall footprint    | One server-side UDP port               | Five TCP ports                             |
 | IPv6                  | ✓                                      | ✓ (IPv6-first with IPv4 fallback)          |
 
 Both designs parallelize for throughput, just differently. fsend rides
@@ -221,7 +223,7 @@ Day-to-day, the surface is very similar:
 | **Server sees ciphertext**           | Only on relay fallback                             | Every cross-network transfer                      |
 | **Same-LAN transfer**                | Direct via mDNS                                    | Direct via multicast peer discovery               |
 | **Transport**                        | QUIC over UDP                                      | TCP                                               |
-| **Firewall footprint**               | One UDP port (UDP/443)                             | Five TCP ports (9009–9013)                        |
+| **Firewall footprint**               | One server-side UDP port (UDP/443)                | Five TCP ports (9009–9013)                        |
 | **PAKE**                             | SPAKE2 (RFC 9382)                                  | `schollz/pake`                                    |
 | **Defense-in-depth layers**          | Two (TLS 1.3 + SPAKE2, channel-bound)              | One (AEAD)                                        |
 | **Post-quantum forward secrecy**     | ✓ X25519 + ML-KEM-768                              | ✗                                                 |

--- a/docs/development.md
+++ b/docs/development.md
@@ -118,4 +118,4 @@ XDG_CONFIG_HOME=/tmp/fsend-dev /tmp/fsend --connect http://127.0.0.1:18080
 
 Config lives at `~/.config/fsend/config.json` (Linux),
 `~/Library/Application Support/fsend/config.json` (macOS), or
-`%APPDATA%\fsend\config.json` (Windows).
+`%LOCALAPPDATA%\fsend\config.json` (Windows).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -92,7 +92,7 @@ fsend --connect fs.example.com:443
 
 Persists to `~/.config/fsend/config.json` (Linux),
 `~/Library/Application Support/fsend/config.json` (macOS), or
-`%APPDATA%\fsend\config.json` (Windows). Revert to the public default
+`%LOCALAPPDATA%\fsend\config.json` (Windows). Revert to the public default
 with `fsend --connect default`.
 
 ## Operations
@@ -128,10 +128,12 @@ To skip TLS entirely for local testing on a trusted network:
 docker run -p 443:443/udp -p 8080:8080/tcp poliuscorp/fsend server
 ```
 
-Clients connect with `fsend --connect host:8080` — the client picks
-HTTP automatically for IPs and `localhost`, HTTPS otherwise. **Do not**
-expose this to the public internet — signaling carries share codes and
-bearer tokens in cleartext.
+The client only speaks plain HTTP to loopback (`localhost`, `127.0.0.1`,
+`::1`); every other host is assumed to be HTTPS. So a no-TLS server is
+reachable from the same machine with `fsend --connect 127.0.0.1:8080`,
+but clients on other hosts need TLS in front of it (see above). **Do
+not** expose a no-TLS server to the public internet — signaling carries
+share codes and bearer tokens in cleartext.
 
 ## Configuration
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -18,7 +18,7 @@ help, run `fsend --help` or `fsend server --help`.
 | Reset to default server | `fsend --connect default` |
 | Show current server | `fsend --connect` |
 
-`fsend` picks send or receive automatically — a `abc-defg-jkm` shape
+`fsend` picks send or receive automatically — an `abc-defg-jkm` shape
 means receive, anything else means send. If an arg is both a valid code
 and a real path, you'll be asked. Use `--send` / `--receive` to commit
 up front in scripts.
@@ -87,13 +87,14 @@ fsend --connect                              # show current
 
 Config is at `~/.config/fsend/config.json` (Linux),
 `~/Library/Application Support/fsend/config.json` (macOS), or
-`%APPDATA%\fsend\config.json` (Windows). See
+`%LOCALAPPDATA%\fsend\config.json` (Windows). See
 [Self-hosting](self-hosting.md) to run your own.
 
 ## Shared flags
 
 | Flag | Purpose |
 |---|---|
+| `--send` / `--receive` | Force mode instead of auto-detecting from the argument. Mutually exclusive; handy in scripts. |
 | `--quiet` | Suppress non-error output. |
 | `--debug` | Verbose logging to stderr. Also `FSEND_DEBUG=1`. |
 | `--uninstall` | Remove the binary and the fsend config directory (see [`--connect`](#choosing-a-server---connect) for the per-OS path). `--yes` skips confirmation. |
@@ -171,8 +172,12 @@ failure.
 | `27`  | `E027` — could not open the local-network port (port in use, mDNS init failed). |
 | `28`  | `E028` — pairing server requires a password (missing or wrong). |
 | `29`  | `E029` — server closed the connection because no data was flowing. |
+| `30`  | `E030` — `fsend server` could not start (port in use or no permission to bind). |
 | `99`  | `E099` — unexpected error. Run with `--debug` and file an issue. |
 | `130` | `E026` — cancelled by user (Ctrl-C / SIGTERM). |
+
+`5` and `16` are intentionally absent: `E005` is unused, and `E016`
+(corrupt config) is a non-fatal warning that exits `0`.
 
 ## Share codes
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,7 +3,7 @@
 // Location follows XDG conventions:
 //   - Linux:   $XDG_CONFIG_HOME/fsend/config.json (default ~/.config/fsend/...)
 //   - macOS:   ~/Library/Application Support/fsend/config.json
-//   - Windows: %AppData%\fsend\config.json
+//   - Windows: %LOCALAPPDATA%\fsend\config.json
 //
 // The file is JSON for human-debuggability and is written with mode 0600
 // because it may contain a relay shared password.

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -94,6 +94,11 @@ var (
 	// for ~60s. Distinct from E020 so the user knows the server tore
 	// the slot down (peer went away), not their own network.
 	ErrRelayIdleTimeout = errors.New("relay session idle-timed out")
+	// E030 — `fsend server` failed to start: a listener couldn't bind
+	// (port already in use, or :443 without privileges) or the env-var
+	// config was invalid. An operator error, not an fsend bug, so it does
+	// not route through the E099 "file an issue" catchall.
+	ErrServerStartup = errors.New("server failed to start")
 )
 
 // Entry is one row of the user-facing error catalog.
@@ -133,7 +138,7 @@ func (e Entry) Render() string {
 // Exit codes are kept in lockstep with the Exxx number (E001 → exit 1,
 // E024 → exit 24, etc.) so scripts can match on either. The only
 // exceptions are E016 (a non-fatal warning, exit 0) and E026 (Ctrl-C,
-// exit 130 by shell convention). Codes are stable from v1.0 onward.
+// exit 130 by shell convention). Codes are stable from v0.1.0 onward.
 //
 // Placeholders like {addr}, {code}, {path} are filled in by the caller via
 // fmt.Sprintf when known; we use plain text so unknown contexts still render.
@@ -235,7 +240,7 @@ var catalog = map[error]Entry{
 		Message: "The default server (fsend.alzina.dev) has been retired.",
 		Action: "Switch to a different server with:\n" +
 			"    fsend --connect <host:port>\n" +
-			"  Or self-host: https://github.com/polius/fsend#self-hosting",
+			"  Or self-host: https://github.com/polius/fsend/blob/main/docs/self-hosting.md",
 	},
 	ErrPartialMismatch: {
 		Code: "E019", Exit: 19,
@@ -300,6 +305,12 @@ var catalog = map[error]Entry{
 		Code: "E029", Exit: 29,
 		Message: "The server closed the connection because no data was flowing. Transfer aborted.",
 		Action:  "The other side likely went away. Try again.",
+	},
+	ErrServerStartup: {
+		Code: "E030", Exit: 30,
+		Message: "The server could not start.",
+		Action: "Check that the ports are free and you have permission to bind them\n" +
+			"  (FSEND_HTTP_ADDR, FSEND_UDP_ADDR). Binding :443 may need elevated privileges.",
 	},
 }
 

--- a/internal/landisc/landisc.go
+++ b/internal/landisc/landisc.go
@@ -1,8 +1,9 @@
 // Package landisc handles same-LAN peer discovery via mDNS.
 //
-// The sender announces a service name derived from the code
-// (`fsend-<code>.local`) and a TXT-like payload of host:port. The receiver
-// queries for the same name and gets back the sender's LAN address.
+// The sender announces a service name derived from a hash of the code
+// (`fsend-<hash>.local`); the receiver queries for the same name and gets
+// back the sender's LAN address. The code is hashed rather than embedded
+// directly so it is not multicast in cleartext to the broadcast domain.
 //
 // This package only does discovery — the actual connection is established
 // via internal/quicconn after we have an address.
@@ -13,6 +14,8 @@ package landisc
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"net"
 	"time"
@@ -25,10 +28,13 @@ import (
 // serviceName builds the mDNS name we publish/query for a given code.
 //
 // We use `.local` so the name lives in the .local domain that every mDNS
-// stack on the planet honors. The host part is derived from the code,
-// which is unique per session.
+// stack on the planet honors. The host part is a SHA-256 hash of the
+// code, not the code itself: the name is multicast across the LAN, and
+// the code is the PAKE secret, so it must not travel in cleartext. Both
+// peers hash identically, so announce and query still line up.
 func serviceName(code string) string {
-	return "fsend-" + code + ".local"
+	sum := sha256.Sum256([]byte("fsend-landisc-v1:" + code))
+	return "fsend-" + hex.EncodeToString(sum[:16]) + ".local"
 }
 
 // Announce publishes the given local address under the code-derived service

--- a/internal/landisc/landisc_test.go
+++ b/internal/landisc/landisc_test.go
@@ -32,15 +32,19 @@ func TestPortForCode_InRange(t *testing.T) {
 
 // TestServiceName keeps the announce/query naming aligned. A drift here
 // would silently desync the two peers — they'd both run cleanly and
-// never find each other.
+// never find each other. The code must NOT appear in the name: it is the
+// PAKE secret and the name is multicast across the LAN.
 func TestServiceName(t *testing.T) {
 	const code = "abc-defg-jkm"
 	got := serviceName(code)
 	if !strings.HasSuffix(got, ".local") {
 		t.Errorf("serviceName(%q) = %q; missing .local suffix", code, got)
 	}
-	if !strings.Contains(got, code) {
-		t.Errorf("serviceName(%q) = %q; missing code substring", code, got)
+	if strings.Contains(got, code) {
+		t.Errorf("serviceName(%q) = %q leaks the code in cleartext", code, got)
+	}
+	if got != serviceName(code) {
+		t.Errorf("serviceName(%q) is not deterministic", code)
 	}
 }
 

--- a/internal/quicconn/auth.go
+++ b/internal/quicconn/auth.go
@@ -25,22 +25,48 @@ const (
 	maxPakeMsgLen = 1024
 )
 
+// role identifies which end of the transfer is authenticating. It is
+// folded into the confirmation tag so the two directions carry distinct
+// values — see authenticatePeer.
+type role uint8
+
+const (
+	roleSender role = iota
+	roleReceiver
+)
+
+// Direction labels mixed into the confirmation HMAC. Distinct per
+// direction so a tag one side sends can never be replayed back as the
+// tag the other side expects.
+const (
+	dirSenderToReceiver = "fsend-confirm-sender"
+	dirReceiverToSender = "fsend-confirm-receiver"
+)
+
 // authenticatePeer runs symmetric SPAKE2 over the control stream and
 // verifies that both peers derived the same key AND observed the same
-// TLS session. The latter half — mixing the TLS RFC 5705 exporter into
-// an HMAC tag — is the channel binding that makes a relay/MITM attempt
-// fail: an attacker terminating one TLS session with each side ends up
-// with two different exporters, so the tags can never match.
+// TLS session. It mixes the TLS RFC 5705 exporter into an HMAC tag —
+// the channel binding that defeats a relay/MITM: an attacker terminating
+// one TLS session with each side gets two different exporters, so the
+// tags can never match.
+//
+// The tag is also direction-separated (sender and receiver compute
+// different tags) and bound to the SPAKE2 transcript. Direction
+// separation closes a reflection attack: without it both sides send and
+// accept the same tag, so a peer that never learned the code could read
+// the honest tag off the stream and echo it back to authenticate.
 //
 // Must be called immediately after the QUIC handshake and the control
 // stream are up, before any application data flows. On mismatch (wrong
-// code, MITM, or wire tampering) returns fserrors.ErrPeerAuthFailed.
-func authenticatePeer(conn *quic.Conn, control io.ReadWriter, code string) error {
+// code, MITM, reflection, or wire tampering) returns
+// fserrors.ErrPeerAuthFailed.
+func authenticatePeer(conn *quic.Conn, control io.ReadWriter, code string, r role) error {
 	p := pake.New(code)
 
 	// Both sides write first, then read. QUIC bidi streams are full-duplex,
 	// so this is deadlock-free regardless of which side is "sender".
-	if err := writeFramed(control, p.Start()); err != nil {
+	myMsg := p.Start()
+	if err := writeFramed(control, myMsg); err != nil {
 		return fmt.Errorf("auth: send pake: %w", err)
 	}
 	peerMsg, err := readFramed(control, maxPakeMsgLen)
@@ -57,9 +83,14 @@ func authenticatePeer(conn *quic.Conn, control io.ReadWriter, code string) error
 	if err != nil {
 		return fmt.Errorf("auth: tls exporter: %w", err)
 	}
-	mac := hmac.New(sha256.New, key)
-	mac.Write(exporter)
-	myTag := mac.Sum(nil)
+
+	// Order the transcript by role so both peers hash the same bytes.
+	senderMsg, receiverMsg := myMsg, peerMsg
+	if r == roleReceiver {
+		senderMsg, receiverMsg = peerMsg, myMsg
+	}
+	myTag := confirmTag(key, exporter, r, senderMsg, receiverMsg)
+	wantTag := confirmTag(key, exporter, otherRole(r), senderMsg, receiverMsg)
 
 	if _, err := control.Write(myTag); err != nil {
 		return fmt.Errorf("auth: send tag: %w", err)
@@ -68,10 +99,40 @@ func authenticatePeer(conn *quic.Conn, control io.ReadWriter, code string) error
 	if _, err := io.ReadFull(control, peerTag[:]); err != nil {
 		return fmt.Errorf("auth: recv tag: %w", err)
 	}
-	if subtle.ConstantTimeCompare(myTag, peerTag[:]) != 1 {
+	if subtle.ConstantTimeCompare(wantTag, peerTag[:]) != 1 {
 		return fserrors.ErrPeerAuthFailed
 	}
 	return nil
+}
+
+func otherRole(r role) role {
+	if r == roleSender {
+		return roleReceiver
+	}
+	return roleSender
+}
+
+// confirmTag binds the confirmation HMAC to the derived key, the TLS
+// session (exporter), the direction, and the full SPAKE2 transcript.
+// Messages are length-prefixed so the concatenation is unambiguous.
+func confirmTag(key, exporter []byte, r role, senderMsg, receiverMsg []byte) []byte {
+	dir := dirSenderToReceiver
+	if r == roleReceiver {
+		dir = dirReceiverToSender
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(exporter)
+	mac.Write([]byte(dir))
+	writeLenPrefixed(mac, senderMsg)
+	writeLenPrefixed(mac, receiverMsg)
+	return mac.Sum(nil)
+}
+
+func writeLenPrefixed(w io.Writer, b []byte) {
+	var hdr [4]byte
+	binary.BigEndian.PutUint32(hdr[:], uint32(len(b)))
+	_, _ = w.Write(hdr[:]) // hash.Hash.Write never errors
+	_, _ = w.Write(b)
 }
 
 func writeFramed(w io.Writer, msg []byte) error {

--- a/internal/quicconn/auth_reflect_test.go
+++ b/internal/quicconn/auth_reflect_test.go
@@ -1,0 +1,103 @@
+package quicconn
+
+import (
+	"context"
+	"encoding/binary"
+	"errors"
+	"io"
+	"testing"
+	"time"
+
+	"github.com/quic-go/quic-go"
+
+	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/pake"
+)
+
+// A peer that never learned the code must not be able to authenticate by
+// reflecting the honest side's confirmation tag back at it. Direction
+// separation in confirmTag is what closes this; this test guards it.
+func TestHandshake_TagReflectionRejected(t *testing.T) {
+	const honestCode = "abc-defg-jkm"
+	const attackerCode = "zzz-zzzz-zzz"
+
+	tlsSrv, err := SenderTLSConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln, err := quic.ListenAddr("127.0.0.1:0", tlsSrv, QuicConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	honestErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		c, err := ln.Accept(ctx)
+		if err != nil {
+			honestErr <- err
+			return
+		}
+		ctrl, err := c.OpenStreamSync(ctx)
+		if err != nil {
+			honestErr <- err
+			return
+		}
+		honestErr <- authenticatePeer(c, ctrl, honestCode, roleSender)
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	c, err := quic.DialAddr(ctx, ln.Addr().String(), ReceiverTLSConfig(), QuicConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctrl, err := c.AcceptStream(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Malicious receiver: complete a valid SPAKE2 round with the wrong
+	// code (so the honest Finish succeeds), then reflect the honest tag.
+	if _, err := readReflectFrame(ctrl); err != nil {
+		t.Fatal(err)
+	}
+	if err := writeReflectFrame(ctrl, pake.New(attackerCode).Start()); err != nil {
+		t.Fatal(err)
+	}
+	var tag [tagLen]byte
+	if _, err := io.ReadFull(ctrl, tag[:]); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := ctrl.Write(tag[:]); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := <-honestErr; !errors.Is(err, fserrors.ErrPeerAuthFailed) {
+		t.Fatalf("reflected tag was accepted (got %v); auth bypass", err)
+	}
+}
+
+func writeReflectFrame(w io.Writer, msg []byte) error {
+	var hdr [2]byte
+	binary.BigEndian.PutUint16(hdr[:], uint16(len(msg)))
+	if _, err := w.Write(hdr[:]); err != nil {
+		return err
+	}
+	_, err := w.Write(msg)
+	return err
+}
+
+func readReflectFrame(r io.Reader) ([]byte, error) {
+	var hdr [2]byte
+	if _, err := io.ReadFull(r, hdr[:]); err != nil {
+		return nil, err
+	}
+	buf := make([]byte, binary.BigEndian.Uint16(hdr[:]))
+	if _, err := io.ReadFull(r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}

--- a/internal/quicconn/quicconn.go
+++ b/internal/quicconn/quicconn.go
@@ -161,9 +161,14 @@ func SenderHandshake(ctx context.Context, c *quic.Conn, code string) (*AcceptRes
 	if err != nil {
 		return nil, fmt.Errorf("quicconn: open control: %w", err)
 	}
-	if err := authenticatePeer(c, ctrl, code); err != nil {
+	// Bound the handshake reads so a peer that connects and then stalls
+	// can't pin this side until the 30s QUIC idle timeout. Cleared on
+	// success so the transfer's own control reads are not capped.
+	_ = ctrl.SetReadDeadline(time.Now().Add(HandshakeTimeout))
+	if err := authenticatePeer(c, ctrl, code, roleSender); err != nil {
 		return nil, err
 	}
+	_ = ctrl.SetReadDeadline(time.Time{})
 	data, err := c.OpenUniStreamSync(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("quicconn: open data: %w", err)
@@ -216,9 +221,12 @@ func ReceiverHandshake(ctx context.Context, c *quic.Conn, code string) (*AcceptR
 	if err != nil {
 		return nil, fmt.Errorf("quicconn: accept control: %w", err)
 	}
-	if err := authenticatePeer(c, ctrl, code); err != nil {
+	// Bound the handshake reads (see SenderHandshake); cleared on success.
+	_ = ctrl.SetReadDeadline(time.Now().Add(HandshakeTimeout))
+	if err := authenticatePeer(c, ctrl, code, roleReceiver); err != nil {
 		return nil, err
 	}
+	_ = ctrl.SetReadDeadline(time.Time{})
 	data, err := c.AcceptUniStream(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("quicconn: accept data: %w", err)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -635,11 +635,19 @@ func (s *Server) pullCandidates(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 	id := r.PathValue("id")
+	tok := bearerToken(r)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	sess, ok := s.byID[id]
 	if !ok {
 		writeJSONError(w, http.StatusNotFound, "session not found")
+		return
+	}
+	// Gate on the role token like every other {id} endpoint: a session ID
+	// alone (it travels over the pairing channel) must not let a third
+	// party tear down someone else's session.
+	if _, ok := sess.sideForToken(tok); !ok {
+		writeJSONError(w, http.StatusUnauthorized, "missing or invalid role token")
 		return
 	}
 	delete(s.byID, id)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -321,7 +321,19 @@ func TestDeleteSession(t *testing.T) {
 	var c CreateSessionResponse
 	_ = json.NewDecoder(create.Body).Decode(&c)
 
+	// Delete without the role token must be rejected.
+	noTok, _ := http.NewRequest(http.MethodDelete, srv.URL+"/v1/session/"+c.SessionID, nil)
+	noTokResp, err := http.DefaultClient.Do(noTok)
+	if err != nil {
+		t.Fatal(err)
+	}
+	noTokResp.Body.Close()
+	if noTokResp.StatusCode != 401 {
+		t.Errorf("delete without token: status = %d, want 401", noTokResp.StatusCode)
+	}
+
 	req, _ := http.NewRequest(http.MethodDelete, srv.URL+"/v1/session/"+c.SessionID, nil)
+	req.Header.Set("Authorization", "Bearer "+c.RoleToken)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -56,10 +56,10 @@ type JoinSessionResponse struct {
 	RoleToken          string   `json:"role_token"`
 }
 
-// WaitRequest is the body of POST /v1/session/<code>/wait.
-type WaitRequest struct {
-	Since string `json:"since,omitempty"` // optional resume marker
-}
+// WaitRequest is the body of POST /v1/session/<code>/wait. It carries no
+// fields today — the code in the path is the only input — but is kept as
+// a named type so the wire shape has somewhere to grow.
+type WaitRequest struct{}
 
 // WaitResponse is the body the sender sees once a receiver pairs.
 type WaitResponse struct {
@@ -76,7 +76,6 @@ type CandidatesPushRequest struct {
 type CandidatesPullResponse struct {
 	Candidates []string `json:"candidates"`
 	NextSince  int      `json:"next_since"`
-	Ended      bool     `json:"ended"`
 }
 
 // RelayAllocateRequest is the body of POST /v1/relay/allocate.

--- a/internal/signaling/client.go
+++ b/internal/signaling/client.go
@@ -118,9 +118,12 @@ func (c *Client) PullCandidates(ctx context.Context, sessionID, roleToken string
 	return &out, nil
 }
 
-// Delete cleans up a session after a successful handshake.
-func (c *Client) Delete(ctx context.Context, sessionID string) error {
-	return c.do(ctx, http.MethodDelete, "/v1/session/"+sessionID, nil, nil, nil)
+// Delete cleans up a session after a successful handshake. roleToken
+// authenticates the caller as a party to the session — the server gates
+// the delete on it so a third party who learns a session ID can't tear
+// down someone else's session.
+func (c *Client) Delete(ctx context.Context, sessionID, roleToken string) error {
+	return c.do(ctx, http.MethodDelete, "/v1/session/"+sessionID, nil, nil, withAuth(roleToken))
 }
 
 // AllocateRelay asks the server for a relay token for this session.

--- a/internal/signaling/client_test.go
+++ b/internal/signaling/client_test.go
@@ -142,8 +142,21 @@ func TestClient_Delete(t *testing.T) {
 	ctx := context.Background()
 
 	created, _ := c.Create(ctx, "")
-	if err := c.Delete(ctx, created.SessionID); err != nil {
+	if err := c.Delete(ctx, created.SessionID, created.RoleToken); err != nil {
 		t.Errorf("Delete: %v", err)
+	}
+}
+
+// Delete without the session's role token must be rejected, so a third
+// party who learns a session ID can't tear down someone else's session.
+func TestClient_Delete_RejectsWrongToken(t *testing.T) {
+	url, _ := setupServer(t)
+	c := New(url, "test")
+	ctx := context.Background()
+
+	created, _ := c.Create(ctx, "")
+	if err := c.Delete(ctx, created.SessionID, "not-the-token"); err == nil {
+		t.Error("Delete with a bogus role token should fail")
 	}
 }
 

--- a/internal/transfer/archive.go
+++ b/internal/transfer/archive.go
@@ -107,6 +107,14 @@ func BuildArchive(paths []string, excludes []string) (*ArchiveResult, error) {
 		return nil, errors.New("archive: no paths provided")
 	}
 	matcher := newExcludeMatcher(excludes)
+	// Reject malformed globs (e.g. an unclosed "[") up front. match()
+	// discards filepath.Match errors, so a bad pattern would otherwise
+	// silently match nothing and ship the files the user meant to exclude.
+	for _, pat := range matcher.patterns {
+		if _, err := filepath.Match(pat, ""); err != nil {
+			return nil, fmt.Errorf("%w: invalid --exclude pattern %q: %v", fserrors.ErrUsage, pat, err)
+		}
+	}
 
 	tmp, err := os.CreateTemp("", "fsend-archive-*.tar")
 	if err != nil {
@@ -302,9 +310,23 @@ func ExtractArchive(tarPath, targetDir string, overwrite bool) error {
 			if err := os.MkdirAll(clean, os.FileMode(hdr.Mode)&os.ModePerm); err != nil {
 				return fmt.Errorf("extract: mkdir %s: %w", clean, err)
 			}
+			if err := assertWithinTarget(clean, absTarget); err != nil {
+				return err
+			}
 		case tar.TypeReg:
 			if err := os.MkdirAll(filepath.Dir(clean), 0o755); err != nil {
 				return fmt.Errorf("extract: mkdir parent %s: %w", clean, err)
+			}
+			// Guard the write against a symlinked parent component, or a
+			// symlink planted at the destination, redirecting it outside
+			// the target. --overwrite skips preflightExtract, so without
+			// this an attacker who can write into the output dir could
+			// clobber an arbitrary file via O_CREATE following the link.
+			if err := assertWithinTarget(filepath.Dir(clean), absTarget); err != nil {
+				return err
+			}
+			if err := removePreexistingSymlink(clean); err != nil {
+				return fmt.Errorf("extract: clear %s: %w", clean, err)
 			}
 			out, err := os.OpenFile(clean, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&os.ModePerm)
 			if err != nil {
@@ -312,7 +334,7 @@ func ExtractArchive(tarPath, targetDir string, overwrite bool) error {
 			}
 			if _, err := io.Copy(out, tr); err != nil {
 				_ = out.Close()
-				return fmt.Errorf("extract: write %s: %w", clean, err)
+				return classifyWriteErr("extract "+clean, err)
 			}
 			if err := out.Close(); err != nil {
 				return fmt.Errorf("extract: close %s: %w", clean, err)
@@ -418,4 +440,42 @@ func safeJoin(base, rel string) (string, error) {
 		return "", fmt.Errorf("extract: refused to write outside target: %q", rel)
 	}
 	return absJoined, nil
+}
+
+// assertWithinTarget verifies that path, after resolving any symlinks,
+// still lives under target. safeJoin only sanitizes the lexical entry
+// name; this catches a symlinked directory component (planted in the
+// output dir by a local attacker or a stale prior run) that would
+// redirect an otherwise-clean path outside the tree.
+//
+// A path that doesn't resolve (not yet created, unreadable) is treated as
+// in-bounds: there is nothing to follow out. target is resolved too so a
+// symlinked target root (e.g. macOS /tmp -> /private/tmp) doesn't trip it.
+func assertWithinTarget(path, target string) error {
+	resolved, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		return nil
+	}
+	resolvedTarget, err := filepath.EvalSymlinks(target)
+	if err != nil {
+		resolvedTarget = target
+	}
+	if !pathIsUnder(resolved, resolvedTarget) {
+		return fmt.Errorf("%w: %q resolves outside target dir", fserrors.ErrPathTraversal, path)
+	}
+	return nil
+}
+
+// removePreexistingSymlink unlinks a symlink sitting exactly at path, so a
+// following O_CREATE writes a fresh regular file in place instead of
+// following the link. No-op when nothing is there or it is a real file.
+func removePreexistingSymlink(path string) error {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		return os.Remove(path)
+	}
+	return nil
 }

--- a/internal/transfer/archive_test.go
+++ b/internal/transfer/archive_test.go
@@ -244,6 +244,77 @@ func TestExtractArchive_RejectsAbsoluteSymlinkSlip(t *testing.T) {
 	}
 }
 
+// TestExtractArchive_RejectsPreexistingSymlinkOnOverwrite guards the
+// --overwrite path (which skips preflightExtract): a symlink pre-planted
+// in the output dir — by a local process or a stale prior run — must not
+// be followed when a regular-file entry lands on the same name. Both the
+// symlink-at-destination and symlinked-parent shapes are covered.
+func TestExtractArchive_RejectsPreexistingSymlinkOnOverwrite(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		plant   func(target, victim string) // pre-creates the hostile symlink
+		entry   string                      // tar regular-file entry name
+		written func(victim string) string  // path that would be clobbered on a follow
+	}{
+		{
+			name: "symlink at destination",
+			plant: func(target, victim string) {
+				_ = os.Symlink(filepath.Join(victim, "secret"), filepath.Join(target, "clash"))
+			},
+			entry:   "clash",
+			written: func(victim string) string { return filepath.Join(victim, "secret") },
+		},
+		{
+			name:    "symlinked parent dir",
+			plant:   func(target, victim string) { _ = os.Symlink(victim, filepath.Join(target, "sub")) },
+			entry:   "sub/clash",
+			written: func(victim string) string { return filepath.Join(victim, "clash") },
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			target := filepath.Join(root, "target")
+			victim := filepath.Join(root, "victim")
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			if err := os.MkdirAll(victim, 0o755); err != nil {
+				t.Fatal(err)
+			}
+			tc.plant(target, victim)
+
+			tarPath := filepath.Join(root, "evil.tar")
+			f, err := os.Create(tarPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			tw := tar.NewWriter(f)
+			body := []byte("PWNED")
+			if err := tw.WriteHeader(&tar.Header{
+				Typeflag: tar.TypeReg, Name: tc.entry, Mode: 0o644, Size: int64(len(body)),
+			}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := tw.Write(body); err != nil {
+				t.Fatal(err)
+			}
+			if err := tw.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if err := f.Close(); err != nil {
+				t.Fatal(err)
+			}
+
+			// overwrite=true skips the preflight; the write itself must not
+			// follow the planted link out of target.
+			_ = ExtractArchive(tarPath, target, true)
+			if b, err := os.ReadFile(tc.written(victim)); err == nil && string(b) == "PWNED" {
+				t.Fatalf("wrote through symlink to %s, outside target", tc.written(victim))
+			}
+		})
+	}
+}
+
 // TestExtractArchive_ConflictWithoutOverwrite verifies that without
 // overwrite=true, a single conflicting file inside the archive causes the
 // whole extract to refuse — and that nothing landed on disk in the

--- a/internal/transfer/imohash.go
+++ b/internal/transfer/imohash.go
@@ -14,21 +14,19 @@ import (
 // just to size a struct field. Must match imohash.Size.
 const ImohashSize = imohash.Size
 
-// imohashHasher is a single shared hasher with the library's default
-// parameters (16 KiB samples, 128 KiB threshold). Below the threshold a
-// file is hashed in full; above it, only the head, middle, and tail are
-// sampled. This is what gives the ~constant-time behavior on huge files.
-//
-// The default is appropriate for fsend's resume use case: collisions on
-// small files cost a re-transfer of a small file (cheap); on large files
-// the chance of an accidental collision is ~2^-64 (low enough not to
-// worry about for non-adversarial resumes).
-var imohashHasher = imohash.New()
-
 // PrefixImohash returns the imohash digest of the first prefixLen bytes
 // of a file, computed as if those bytes were the whole file. Used on the
 // sender to validate the receiver's claim that "I have a partial that
 // starts at byte 0 and ends at prefixLen."
+//
+// A fresh imohash.Imohash is used per call rather than a shared instance:
+// its SumSectionReader mutates an internal murmur3 state, so a shared
+// value would race if PrefixImohash were ever called concurrently. The
+// constructor is cheap. The library defaults (16 KiB samples, 128 KiB
+// threshold) suit the resume use case — below the threshold a file is
+// hashed in full; above it only head/middle/tail are sampled, which gives
+// the ~constant-time behavior on huge files. An accidental collision on a
+// large file is ~2^-64, low enough for non-adversarial resumes.
 //
 // We avoid copying the prefix into memory by handing imohash an
 // io.SectionReader over the open file.
@@ -40,7 +38,8 @@ func PrefixImohash(path string, prefixLen int64) ([ImohashSize]byte, error) {
 	}
 	defer func() { _ = f.Close() }()
 	sr := io.NewSectionReader(f, 0, prefixLen)
-	h, err := imohashHasher.SumSectionReader(sr)
+	hasher := imohash.New()
+	h, err := hasher.SumSectionReader(sr)
 	if err != nil {
 		return zero, fmt.Errorf("imohash prefix %s: %w", path, err)
 	}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"syscall"
 	"time"
 
 	"github.com/klauspost/compress/zstd"
@@ -16,6 +17,18 @@ import (
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/wire"
 )
+
+// classifyWriteErr maps a filesystem write failure to the right catalog
+// error: a full disk gets E008 (ErrDiskFull) with its "free up space"
+// hint, everything else falls back to E009 (ErrWriteFailed). op names the
+// operation for the debug detail line.
+func classifyWriteErr(op string, err error) error {
+	base := fserrors.ErrWriteFailed
+	if errors.Is(err, syscall.ENOSPC) {
+		base = fserrors.ErrDiskFull
+	}
+	return fmt.Errorf("%w: %s: %v", base, op, err)
+}
 
 // RecvOptions configures one receive invocation.
 type RecvOptions struct {
@@ -416,7 +429,7 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 
 		if len(plain) > 0 {
 			if _, err := f.Write(plain); err != nil {
-				return fmt.Errorf("%w: write: %v", fserrors.ErrWriteFailed, err)
+				return classifyWriteErr("write", err)
 			}
 			// blake3.Hasher.Write never returns an error — it just
 			// appends bytes to an internal buffer. The errcheck nag is

--- a/internal/transfer/walk.go
+++ b/internal/transfer/walk.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/zeebo/blake3"
 
+	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/wire"
 )
 
@@ -61,6 +62,11 @@ func Walk(paths []string) ([]SourceItem, error) {
 			})
 		case info.IsDir():
 			return nil, fmt.Errorf("walk: %s is a directory — directories must be sent through BuildArchive", raw)
+		case !info.Mode().IsRegular():
+			// Named pipes, devices, and sockets have no finite content to
+			// hash or stream — reading one blocks forever. Reject up front
+			// with a usage error instead of hanging silently on the hash.
+			return nil, fmt.Errorf("%w: %s is not a regular file (named pipes, devices, and sockets can't be sent)", fserrors.ErrUsage, raw)
 		default:
 			hash, err := blake3FileHash(abs)
 			if err != nil {

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -29,8 +29,6 @@ import (
 type Progress struct {
 	mp  *mpb.Progress
 	bar *mpb.Bar
-	tty bool
-	w   io.Writer
 }
 
 // barWidth caps the progress bar at a fixed column count. 40 leaves room
@@ -54,7 +52,7 @@ const rateThreshold = 1 << 20
 // a percentage, ETA, or rate chip.
 func New(totalBytes int64) *Progress {
 	tty := IsTTY(os.Stderr)
-	p := &Progress{tty: tty, w: os.Stderr}
+	p := &Progress{}
 
 	opts := []mpb.ContainerOption{
 		mpb.WithOutput(os.Stderr),


### PR DESCRIPTION
Full security/correctness audit follow-up. Every finding was reproduced before fixing and is covered by a test or empirical check; the full suite passes under `-race` (including the e2e LAN transfer through the new hashed mDNS name and hardened handshake).

## Critical / High
- **Peer-auth bypass (`internal/quicconn/auth.go`)** — the post-SPAKE2 confirmation tag was a single symmetric HMAC, identical in both directions, so a peer that never learned the code could read the honest tag off the stream and reflect it back to authenticate (full MITM / malicious-relay bypass — the exact threat the channel binding was meant to stop). The tag is now direction-separated (sender/receiver derive distinct tags) and bound to the SPAKE2 transcript. Regression test added.
- **Share code leaked on the LAN (`internal/landisc`)** — the code was embedded verbatim in the multicast mDNS service name. It is now hashed (`fsend-<sha256>.local`); both peers hash identically so discovery still lines up.
- **SIGINT swallowed at prompts (`cmd/fsend`)** — accept/overwrite/password prompts blocked on stdin and ignored ctx cancellation, disabling Ctrl-C for the rest of the process. Prompts are now cancellable (Ctrl-C → E026, verified exit 130 in ~7 ms); a second signal reverts to default termination.

## Medium
- Corrupt config now surfaces the **E016** warning instead of silently reverting to the public default server.
- Archive `--overwrite` no longer follows a symlinked parent dir or a pre-planted destination symlink (write-outside-target). Tests for both shapes.
- `--` end-of-flags now honoured by the `--pass`/`--connect` rewriters; permission-denied sources map to **E010** (not the E099 catchall); FIFOs/devices are rejected up front instead of hanging silently; peer-supplied `DisplayName` is sanitized before display; `--text` + `--receive` is rejected instead of silently dropped.
- `DELETE /v1/session` is now gated on the role token like every other `{id}` endpoint; `fsend server <junk>` maps to **E024** and startup/bind failures to the new **E030** (no "file a bug" framing).

## Low / cleanup
- ENOSPC → **E008** (`ErrDiskFull`); per-call imohash instance removes a latent shared-state race; malformed `--exclude` globs rejected; handshake reads bounded by a read deadline.
- Removed dead code (`CandidatesPullResponse.Ended`, `WaitRequest.Since`, `Progress.w/.tty`); fixed a stale comment.

## Docs
- Corrected the Windows config path (`%LOCALAPPDATA%`), the LAN HTTP/HTTPS behaviour, the `--connect` password syntax (comma form) in help + compose, the docker `server` example, the E018 link, and the version-stability note.
- Added **E030** and the "5/16 intentionally absent" note to the exit-code table; documented `--send`/`--receive`; clarified the UDP/443 firewall claim.

## Test plan
- `go build ./...`, `go vet ./...`, `gofmt` — clean
- `go test -race -count=1 ./...` — all packages pass, including `test/e2e`
- New tests: tag-reflection rejection, pre-existing-symlink overwrite (both shapes), `Delete` token gating, `--` separator handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)