### PR TITLE
audit: fix streaming-retry corruption, LAN code leak, panic race + hardening

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+.git
+.github
+docs
+test
+deploy
+scripts
+*.md
+LICENSE

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,19 @@ jobs:
       - run: go vet ./...
       - run: go test -timeout 120s ./...
 
+  # The LAN/direct/relay paths race concurrently in production; data
+  # races only surface under the race detector. Slower than the plain
+  # test job, so it runs on one OS with a wider timeout.
+  race:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache: true
+      - run: go test -race -timeout 300s ./...
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,12 +33,21 @@ jobs:
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+      # Mirrors the goreleaser ldflags so the image doesn't report "fsend dev".
+      - id: buildmeta
+        run: |
+          echo "commit=${GITHUB_SHA::7}" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
       - id: push
         uses: docker/build-push-action@v7
         with:
           context: .
           platforms: linux/amd64,linux/arm64
           push: true
+          build-args: |
+            VERSION=${{ steps.tags.outputs.version }}
+            COMMIT=${{ steps.buildmeta.outputs.commit }}
+            DATE=${{ steps.buildmeta.outputs.date }}
           tags: ${{ steps.tags.outputs.tags }}
           labels: ${{ steps.tags.outputs.labels }}
           cache-from: type=gha,scope=${{ env.IMAGE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 FROM golang:1.25-alpine AS builder
+# Injected by docker.yml so released images don't report "fsend dev".
+ARG VERSION=dev
+ARG COMMIT=unknown
+ARG DATE=unknown
 ENV CGO_ENABLED=0
 WORKDIR /src
 COPY . .
-RUN go build -o /out/fsend ./cmd/fsend
+RUN go build -trimpath -ldflags "-s -w \
+    -X github.com/polius/fsend/internal/version.Version=${VERSION} \
+    -X github.com/polius/fsend/internal/version.Commit=${COMMIT} \
+    -X github.com/polius/fsend/internal/version.Date=${DATE}" \
+    -o /out/fsend ./cmd/fsend
 
 FROM scratch
 COPY --from=builder /out/fsend /fsend

--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ fsend lets any two computers transfer files **directly** to each other — no ac
 curl -fsSL https://getfsend.alzina.dev | sh
 ```
 
-Works on Linux, macOS, FreeBSD, and Windows — x86 and ARM.
+Works on Linux, macOS, FreeBSD, and Windows — x86 and ARM. On Windows, run
+this in a POSIX shell (MSYS / MinGW / Cygwin / Git Bash); the installed
+`fsend.exe` then runs in any terminal once its directory is on your PATH.
 
 <details>
 <summary>Other install methods</summary>

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ fsend abc-defg-jkm               # café Wi-Fi, two continents away
 fsend lets any two computers transfer files **directly** to each other — no accounts, no cloud, no third party storing the file.
 
 - **Peer-to-peer** — bytes go straight from sender to receiver at your own internet speed (relay only as a fallback)
-- **End-to-end encrypted** — two independent layers; even the fallback relay never sees the file
+- **End-to-end encrypted** — TLS 1.3 between the peers, authenticated by the share code (PAKE); even the fallback relay never sees the file
 - **No ports to open** — works on any network, no router or firewall setup
 - **Send anything** — files, folders, multiple at once, stdin streams, or literal text
 - **Resumable** — connection drops? Rerun the same command and fsend picks up where it stopped

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -213,6 +213,8 @@ ADVANCED FLAGS
 ENVIRONMENT
   FSEND_PASS             Used as --pass when the flag is not given
                          (keeps the password out of argv)
+  FSEND_NO_UPDATE_CHECK  Set to 1 to disable the daily check for a newer
+                         fsend release
 
 SELF-HOSTING
   fsend server                 Run your own pairing + relay server

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -314,6 +314,18 @@ func printSendArtifact(f *flags, c string, items []transfer.SourceItem, kind wir
 	return uxlog.StartSpinner("Waiting for receiver")
 }
 
+// hasConsumableReader reports whether any item is backed by a one-shot
+// reader (stdin, --text). Such items cannot be replayed: a retry would
+// resend from wherever the reader was left, so retries must be disabled.
+func hasConsumableReader(items []transfer.SourceItem) bool {
+	for _, it := range items {
+		if it.Reader != nil {
+			return true
+		}
+	}
+	return false
+}
+
 // totalBytes sums the payload bytes across items.
 func totalBytes(items []transfer.SourceItem) int64 {
 	var t int64

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -508,6 +508,7 @@ func printSendSummary(f *flags, bytes int64, elapsed time.Duration, path connpat
 	}
 	parts := summaryParts(bytes, elapsed, path)
 	fmt.Fprintf(os.Stderr, "%s Sent  ·  %s\n", uxlog.Check(), strings.Join(parts, "  ·  "))
+	printUpdateNotice(f)
 }
 
 // printRecvSummary is the receive-side counterpart. The bytes figure is
@@ -526,9 +527,11 @@ func printRecvSummary(f *flags, destLabel string, bytes int64, elapsed time.Dura
 	if destLabel != "" {
 		fmt.Fprintf(os.Stderr, "%s Saved to %s  ·  %s\n",
 			uxlog.Check(), destLabel, strings.Join(parts, "  ·  "))
+		printUpdateNotice(f)
 		return
 	}
 	fmt.Fprintf(os.Stderr, "%s Received  ·  %s\n", uxlog.Check(), strings.Join(parts, "  ·  "))
+	printUpdateNotice(f)
 }
 
 // summaryParts builds the bytes/duration/path/rate sequence that both

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -443,7 +443,12 @@ func runSenderTransferOverLAN(ctx context.Context, f *flags, items []transfer.So
 func runSenderTransferOverInternet(ctx context.Context, f *flags, items []transfer.SourceItem, kind wire.TransferKind, totalFiles uint32, displayName string, pair *internetSenderPairing) error {
 	defer pair.cleanup()
 	err := runSenderTransferLoop(ctx, f, items, kind, totalFiles, displayName, pair.pathInfo, pair.firstRes, func(ctx context.Context) (*quicconn.AcceptResult, error) {
-		qc, err := pair.quicListener.Accept(ctx)
+		// Bounded like the LAN re-accept: if the receiver exited
+		// terminally, an unbounded Accept would hang "retrying…" until
+		// Ctrl-C instead of exhausting the retry budget.
+		acceptCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+		qc, err := pair.quicListener.Accept(acceptCtx)
 		if err != nil {
 			return nil, fmt.Errorf("QUIC accept: %w", err)
 		}
@@ -466,7 +471,13 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 
 	start := time.Now()
 	current := firstRes
-	err := retry.WithBackoff(ctx, retry.Options{OnRetry: retryNoticeFor(f)}, nil,
+	opts := retry.Options{OnRetry: retryNoticeFor(f)}
+	if hasConsumableReader(items) {
+		// A partially-consumed stdin/--text reader would resend from an
+		// arbitrary offset and still pass per-chunk hashes; fail instead.
+		opts.Attempts = 1
+	}
+	err := retry.WithBackoff(ctx, opts, nil,
 		func(attempt int) error {
 			if current == nil {
 				res, err := reaccept(ctx)

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -110,10 +110,14 @@ func runServer() error {
 		Addr:              cfg.httpAddr,
 		Handler:           s.Handler(),
 		ReadHeaderTimeout: 5 * time.Second,
-		// /wait long-polls hold the connection for up to 25s; IdleTimeout
-		// has to clear that bar comfortably. ReadTimeout is intentionally
-		// not set — it would also cap handler body reads. WriteTimeout
-		// stays zero for the same reason.
+		// ReadTimeout also caps handler body reads — wanted: bodies are
+		// ≤16 KiB, and without it a client trickling a declared body one
+		// byte at a time parks a goroutine indefinitely (the rate limiter
+		// only runs after decode). It does not affect response writes, so
+		// /wait long-polls (25s before first byte) are untouched —
+		// WriteTimeout stays zero for them, and IdleTimeout has to clear
+		// the same bar comfortably.
+		ReadTimeout:    15 * time.Second,
 		IdleTimeout:    120 * time.Second,
 		MaxHeaderBytes: 16 << 10,
 	}

--- a/cmd/fsend/update_notice.go
+++ b/cmd/fsend/update_notice.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"golang.org/x/term"
+
+	"github.com/polius/fsend/internal/update"
+	"github.com/polius/fsend/internal/version"
+)
+
+// printUpdateNotice prints a one-line "newer fsend available" hint after a
+// successful transfer, when interactive. It's best-effort and silent on
+// failure (see internal/update); the lookup is cached for a day so most
+// runs do no network I/O.
+//
+// Skipped under --quiet (the stdout contract must stay clean) and when
+// stderr isn't a terminal, so piped/scripted use never triggers the
+// network call or the extra line.
+func printUpdateNotice(f *flags) {
+	if f.quiet || !term.IsTerminal(int(os.Stderr.Fd())) {
+		return
+	}
+	if msg := update.Notice(context.Background(), version.Version); msg != "" {
+		fmt.Fprintf(os.Stderr, "\n  %s\n", msg)
+	}
+}

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -18,8 +18,9 @@ networks** — the common case, and where the two designs diverge.
   (9009–9013). One UDP port is easier to get past a corporate firewall,
   and UDP/443 is allowed almost everywhere because it's the port HTTP/3
   uses.
-- **fsend has two independent crypto layers** (TLS 1.3 + SPAKE2) with
-  **post-quantum** key exchange. croc has a single AEAD keyed from PAKE.
+- **fsend pairs TLS 1.3 encryption with independent SPAKE2 peer
+  authentication** and **post-quantum** key exchange. croc has a single
+  AEAD keyed from PAKE.
 
 ## Same network: no meaningful difference
 
@@ -210,7 +211,7 @@ Day-to-day, the surface is very similar:
 - You're on a network that blocks the croc port range but allows
   UDP/443.
 - You care about long-term confidentiality (post-quantum forward
-  secrecy) or defense-in-depth (two independent crypto layers).
+  secrecy) or MITM resistance (PAKE-authenticated TLS).
 - You want stronger code-handling guarantees: one-shot by design and a
   bounded server-side TTL (1 hour max unclaimed, 10 min after pairing).
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -6,17 +6,19 @@ Files are end-to-end encrypted between sender and receiver. The pairing
 server cannot read filenames, file sizes, hashes, or contents — even
 when it's in the data path as a relay fallback.
 
-The encryption stack uses **two layers** that an attacker has to defeat
-independently:
+The stack pairs an encryption layer with an independent
+peer-authentication layer:
 
-1. **TLS 1.3 over QUIC.** Standard transport security, terminated at the
-   two peers (not at the server).
-2. **SPAKE2 (RFC 9382)** authenticated from the share code, bound to the
-   TLS handshake via the RFC 5705 channel-binding exporter.
+1. **TLS 1.3 over QUIC** carries all file bytes — standard transport
+   security, terminated at the two peers (not at the server).
+2. **SPAKE2 (RFC 9382)**, run from the share code and bound to the TLS
+   handshake via the RFC 5705 channel-binding exporter, proves the
+   other end of that TLS connection is the peer holding the code.
 
-A network MITM is caught by TLS. A TLS-handshake MITM is caught by
-SPAKE2 binding. Compromising a transfer requires breaking **both**, not
-either.
+A network eavesdropper is stopped by TLS. An active MITM that
+terminates TLS itself (including a malicious pairing server or relay)
+ends up with a different channel binding on each side and is caught by
+the SPAKE2 confirmation before any file data flows.
 
 ## Post-quantum forward secrecy
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,8 +107,14 @@ Config is at `~/.config/fsend/config.json` (Linux),
 |---|---|---|
 | `FSEND_PASS` | `--pass` | Supply the transfer password out-of-band. |
 | `FSEND_DEBUG` | `--debug` | `1` enables verbose stderr logging. |
+| `FSEND_NO_UPDATE_CHECK` | — | `1` disables the once-a-day check for a newer release. |
 
 Flags always win when both are set.
+
+After a successful transfer, fsend checks GitHub at most once a day for a
+newer release and, if one exists, prints a one-line upgrade hint. The
+check is skipped when output is piped or `--quiet` is set, and can be
+turned off entirely with `FSEND_NO_UPDATE_CHECK=1`.
 
 ## `fsend server`
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/vbauerster/mpb/v8 v8.12.1
 	github.com/zeebo/blake3 v0.2.4
+	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
 	golang.org/x/term v0.44.0
 	salsa.debian.org/vasudev/gospake2 v0.0.0-20210510093858-d91629950ad1
@@ -35,7 +36,6 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
-	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,16 @@ func Path() (string, error) {
 	return p, nil
 }
 
+// Dir returns the directory that holds the config file, used for other
+// small bits of fsend state too (e.g. the update-check cache).
+func Dir() (string, error) {
+	p, err := Path()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(p), nil
+}
+
 // Load reads the config from disk. A missing file returns a zero-value
 // Config and nil — that's the normal first-run state, not an error.
 //

--- a/internal/iceconn/iceconn.go
+++ b/internal/iceconn/iceconn.go
@@ -71,10 +71,14 @@ type Agent struct {
 	opts  Options
 
 	// localCh receives the string-marshalled form of each gathered local
-	// candidate. It closes when gathering completes (pion signals this
-	// by invoking OnCandidate with nil).
-	localCh   chan string
-	closeOnce sync.Once
+	// candidate. It closes when gathering completes (pion signals this by
+	// invoking OnCandidate with nil) or on Close. localMu serializes sends
+	// against close: pion's gathering goroutine can still deliver a
+	// candidate while Close runs, and a send on a closed channel panics
+	// even inside a select-with-default.
+	localMu     sync.Mutex
+	localClosed bool
+	localCh     chan string
 }
 
 // defaultTimeouts returns fsend's pion ICE agent timings. Kept as a
@@ -133,12 +137,7 @@ func New(opts Options) (*Agent, error) {
 			a.closeLocal()
 			return
 		}
-		// Non-blocking send with a generous buffer; if the caller hasn't
-		// drained, we drop rather than stall pion's internal goroutine.
-		select {
-		case a.localCh <- c.Marshal():
-		default:
-		}
+		a.sendLocal(c.Marshal())
 	}); err != nil {
 		_ = inner.Close()
 		return nil, fmt.Errorf("iceconn: register OnCandidate: %w", err)
@@ -226,6 +225,26 @@ func (a *Agent) SelectedPair() (localType, remoteType string, ok bool) {
 	return pair.Local.Type().String(), pair.Remote.Type().String(), true
 }
 
+// sendLocal delivers a candidate without blocking pion's internal
+// goroutine: if the caller hasn't drained the (generously buffered)
+// channel, we drop rather than stall.
+func (a *Agent) sendLocal(candidate string) {
+	a.localMu.Lock()
+	defer a.localMu.Unlock()
+	if a.localClosed {
+		return
+	}
+	select {
+	case a.localCh <- candidate:
+	default:
+	}
+}
+
 func (a *Agent) closeLocal() {
-	a.closeOnce.Do(func() { close(a.localCh) })
+	a.localMu.Lock()
+	defer a.localMu.Unlock()
+	if !a.localClosed {
+		a.localClosed = true
+		close(a.localCh)
+	}
 }

--- a/internal/landisc/landisc.go
+++ b/internal/landisc/landisc.go
@@ -1,9 +1,13 @@
 // Package landisc handles same-LAN peer discovery via mDNS.
 //
-// The sender announces a service name derived from a hash of the code
+// The sender announces a service name derived from the code
 // (`fsend-<hash>.local`); the receiver queries for the same name and gets
-// back the sender's LAN address. The code is hashed rather than embedded
-// directly so it is not multicast in cleartext to the broadcast domain.
+// back the sender's LAN address. The name is an argon2id stretch of the
+// code, not the code itself: the name is multicast to the whole broadcast
+// domain, the code is the PAKE secret, and the code has only ~45 bits of
+// entropy — a fast hash would let a passive LAN observer recover it by
+// offline brute force. argon2id makes each guess cost ~64 MiB of memory
+// and tens of milliseconds, putting a full sweep out of practical reach.
 //
 // This package only does discovery — the actual connection is established
 // via internal/quicconn after we have an address.
@@ -14,27 +18,49 @@ package landisc
 
 import (
 	"context"
-	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/pion/mdns/v2"
+	"golang.org/x/crypto/argon2"
 	"golang.org/x/net/ipv4"
 	"golang.org/x/net/ipv6"
+)
+
+// derive stretches the code with argon2id and returns 18 key bytes:
+// 16 for the service name, 2 for the port. The salt is a fixed domain
+// label — the peers share no prior state, so a per-session salt is
+// impossible; the memory-hardness is what carries the defense (see the
+// package comment). Memoized because announce/query each need the same
+// key for both the name and the port.
+func derive(code string) []byte {
+	deriveMu.Lock()
+	defer deriveMu.Unlock()
+	if code == derivedCode {
+		return derivedKey
+	}
+	key := argon2.IDKey([]byte(code), []byte("fsend-landisc-v2"), 2, 64*1024, 4, 18)
+	derivedCode, derivedKey = code, key
+	return key
+}
+
+var (
+	deriveMu    sync.Mutex
+	derivedCode string
+	derivedKey  []byte
 )
 
 // serviceName builds the mDNS name we publish/query for a given code.
 //
 // We use `.local` so the name lives in the .local domain that every mDNS
-// stack on the planet honors. The host part is a SHA-256 hash of the
-// code, not the code itself: the name is multicast across the LAN, and
-// the code is the PAKE secret, so it must not travel in cleartext. Both
-// peers hash identically, so announce and query still line up.
+// stack on the planet honors. Both peers derive identically, so announce
+// and query still line up.
 func serviceName(code string) string {
-	sum := sha256.Sum256([]byte("fsend-landisc-v1:" + code))
-	return "fsend-" + hex.EncodeToString(sum[:16]) + ".local"
+	return "fsend-" + hex.EncodeToString(derive(code)[:16]) + ".local"
 }
 
 // Announce publishes the given local address under the code-derived service
@@ -131,11 +157,7 @@ func Query(ctx context.Context, code string, timeout time.Duration) (*QueryResul
 // just without the same-LAN shortcut. A proper fix would require mDNS
 // service-browsing, which pion/mdns doesn't expose today.
 func PortForCode(code string) int {
-	var sum uint32
-	for i := 0; i < len(code); i++ {
-		sum = sum*31 + uint32(code[i])
-	}
-	return 50000 + int(sum%1000)
+	return 50000 + int(binary.BigEndian.Uint16(derive(code)[16:18]))%1000
 }
 
 // openMulticast creates the IPv4 and IPv6 multicast packet conns mDNS needs.

--- a/internal/transfer/archive.go
+++ b/internal/transfer/archive.go
@@ -291,10 +291,20 @@ func ExtractArchive(tarPath, targetDir string, overwrite bool) error {
 	defer func() { _ = f.Close() }()
 	tr := tar.NewReader(f)
 
+	// Directories are created with owner rwx forced — a read-only entry
+	// (0555) extracted at its final mode would block writing the files
+	// inside it. The archived modes are applied after extraction,
+	// children before parents.
+	type dirMode struct {
+		path string
+		mode os.FileMode
+	}
+	var deferredDirs []dirMode
+
 	for {
 		hdr, err := tr.Next()
 		if err == io.EOF {
-			return nil
+			break
 		}
 		if err != nil {
 			return fmt.Errorf("extract: read header: %w", err)
@@ -307,11 +317,20 @@ func ExtractArchive(tarPath, targetDir string, overwrite bool) error {
 
 		switch hdr.Typeflag {
 		case tar.TypeDir:
-			if err := os.MkdirAll(clean, os.FileMode(hdr.Mode)&os.ModePerm); err != nil {
+			perm := os.FileMode(hdr.Mode) & os.ModePerm
+			if err := os.MkdirAll(clean, perm|0o700); err != nil {
 				return fmt.Errorf("extract: mkdir %s: %w", clean, err)
+			}
+			// MkdirAll no-ops on an existing dir (e.g. a previous extract
+			// already applied a read-only mode) — force owner rwx there too.
+			if st, err := os.Stat(clean); err == nil && st.Mode().Perm()&0o700 != 0o700 {
+				_ = os.Chmod(clean, st.Mode().Perm()|0o700)
 			}
 			if err := assertWithinTarget(clean, absTarget); err != nil {
 				return err
+			}
+			if perm != perm|0o700 {
+				deferredDirs = append(deferredDirs, dirMode{clean, perm})
 			}
 		case tar.TypeReg:
 			if err := os.MkdirAll(filepath.Dir(clean), 0o755); err != nil {
@@ -329,6 +348,13 @@ func ExtractArchive(tarPath, targetDir string, overwrite bool) error {
 				return fmt.Errorf("extract: clear %s: %w", clean, err)
 			}
 			out, err := os.OpenFile(clean, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&os.ModePerm)
+			if errors.Is(err, os.ErrPermission) {
+				// Replacing an existing read-only file: O_TRUNC can't open
+				// it, but overwrite consent was already established
+				// (preflight or --overwrite) — remove and recreate.
+				_ = os.Remove(clean)
+				out, err = os.OpenFile(clean, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&os.ModePerm)
+			}
 			if err != nil {
 				return fmt.Errorf("extract: create %s: %w", clean, err)
 			}
@@ -366,6 +392,17 @@ func ExtractArchive(tarPath, targetDir string, overwrite bool) error {
 			// something fsend cares about transporting.
 		}
 	}
+
+	// Children before parents: chmod of a nested path needs search
+	// permission on every ancestor, so restrictive parents go last.
+	sort.Slice(deferredDirs, func(i, j int) bool {
+		return strings.Count(deferredDirs[i].path, string(os.PathSeparator)) >
+			strings.Count(deferredDirs[j].path, string(os.PathSeparator))
+	})
+	for _, d := range deferredDirs {
+		_ = os.Chmod(d.path, d.mode)
+	}
+	return nil
 }
 
 // preflightExtract walks the tar headers without consuming entry data and

--- a/internal/transfer/archive_test.go
+++ b/internal/transfer/archive_test.go
@@ -436,3 +436,59 @@ func readTarNames(t *testing.T, path string) []string {
 	}
 	return names
 }
+
+// TestExtractArchive_ReadOnlyDirAndOverwrite covers two extraction
+// hazards around restrictive modes: a read-only directory entry must not
+// block writing the files inside it (modes are deferred, children before
+// parents), and re-extracting over an existing read-only file with
+// overwrite consent must replace it instead of failing on O_TRUNC.
+func TestExtractArchive_ReadOnlyDirAndOverwrite(t *testing.T) {
+	dir := t.TempDir()
+	tarPath := filepath.Join(dir, "ro.tar")
+	target := t.TempDir()
+
+	f, err := os.Create(tarPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	tw := tar.NewWriter(f)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "ro-dir/", Mode: 0o555, Typeflag: tar.TypeDir,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	body := []byte("inside read-only dir")
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "ro-dir/file.txt", Mode: 0o444, Size: int64(len(body)), Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ExtractArchive(tarPath, target, false); err != nil {
+		t.Fatalf("extract into read-only dir: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(target, "ro-dir", "file.txt"))
+	if err != nil || !bytes.Equal(got, body) {
+		t.Fatalf("file content after extract: %q, %v", got, err)
+	}
+	if st, err := os.Stat(filepath.Join(target, "ro-dir")); err != nil || st.Mode().Perm() != 0o555 {
+		t.Fatalf("dir mode after extract: %v, %v (want 0555)", st.Mode().Perm(), err)
+	}
+
+	// Re-extract over the now read-only file with overwrite consent.
+	if err := ExtractArchive(tarPath, target, true); err != nil {
+		t.Fatalf("re-extract with overwrite over read-only file: %v", err)
+	}
+
+	// Restore writability so t.TempDir cleanup can remove the tree.
+	_ = os.Chmod(filepath.Join(target, "ro-dir"), 0o755)
+}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -169,8 +169,10 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 	// Handle directory entries: just MkdirAll and ACK.
 	if info.IsDir {
 		// Mask to perm bits: don't honor peer-set setuid/setgid/sticky
-		// (parity with the archive path).
-		if err := os.MkdirAll(target, os.FileMode(info.Mode)&os.ModePerm); err != nil {
+		// (parity with the archive path). Owner rwx is forced so a
+		// read-only mode (0555) can't block writing the files inside.
+		if err := os.MkdirAll(target, os.FileMode(info.Mode)&os.ModePerm|0o700); err != nil {
+			declineTransfer(s, wire.ErrCodeWriteFailed, "mkdir failed")
 			return fmt.Errorf("%w: mkdir %s: %v", fserrors.ErrWriteFailed, target, err)
 		}
 		decision := wire.FileAcceptDecision{Index: info.Index, Action: wire.ActionAcceptFull}
@@ -194,10 +196,23 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 		}
 		// Parent must exist.
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			declineTransfer(s, wire.ErrCodeWriteFailed, "mkdir failed")
 			return fmt.Errorf("%w: mkdir parent: %v", fserrors.ErrWriteFailed, err)
 		}
-		// Best-effort: if the platform doesn't support symlinks, log and skip.
-		_ = os.Remove(target) // Symlink fails if target exists
+		// Symlink fails if target exists; removing it needs the same
+		// overwrite consent as a regular file — silently deleting here
+		// previously lost receiver data (and on Windows the replacement
+		// symlink may then fail to be created at all).
+		if st, err := os.Lstat(target); err == nil {
+			confirmed := opts.Overwrite || (opts.ConfirmOverwrite != nil &&
+				opts.ConfirmOverwrite(info.RelativePath, st.Size(), 0))
+			if !confirmed {
+				declineTransfer(s, wire.ErrCodeTargetExists, "target exists")
+				return fserrors.ErrTargetExists
+			}
+			_ = os.Remove(target)
+		}
+		// Best-effort: if the platform doesn't support symlinks, skip.
 		if err := os.Symlink(info.SymlinkTarget, target); err != nil {
 			if runtime.GOOS == "windows" {
 				// Common on Windows non-admin; not fatal.
@@ -217,14 +232,7 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 			confirmed := opts.ConfirmOverwrite != nil &&
 				opts.ConfirmOverwrite(info.RelativePath, st.Size(), info.Size)
 			if !confirmed {
-				_ = wire.WriteControl(s.Control, wire.TypeError, &wire.ErrorFrame{
-					Code: wire.ErrCodeTargetExists, Message: "target exists",
-				})
-				// Symmetric shutdown so the ERROR frame's FIN reaches the
-				// sender before the deferred QUIC close, which would
-				// otherwise surface as E099 "Application error 0x0".
-				_ = s.Control.Close()
-				_, _ = io.Copy(io.Discard, s.Control)
+				declineTransfer(s, wire.ErrCodeTargetExists, "target exists")
 				return fserrors.ErrTargetExists
 			}
 		}
@@ -292,6 +300,7 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 
 	// Parent must exist.
 	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		declineTransfer(s, wire.ErrCodeWriteFailed, "mkdir failed")
 		return fmt.Errorf("%w: mkdir parent: %v", fserrors.ErrWriteFailed, err)
 	}
 
@@ -306,12 +315,25 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 	}
 
 	// Open the partial sidecar (not the target). On full re-download we
-	// O_TRUNC; on resume we keep the existing prefix.
+	// O_TRUNC; on resume we keep the existing prefix. The sidecar is
+	// created owner-private — mirroring a read-only source mode (0444)
+	// would make it unreopenable and permanently break resume — and the
+	// sender's mode is applied at finalize.
 	flag := os.O_RDWR | os.O_CREATE
 	if action == wire.ActionAcceptFull {
 		flag |= os.O_TRUNC
 	}
-	f, err := os.OpenFile(partial, flag, os.FileMode(info.Mode)&os.ModePerm)
+	f, err := os.OpenFile(partial, flag, 0o600)
+	if errors.Is(err, os.ErrPermission) {
+		// Pre-existing partial with a read-only mode (written by an older
+		// fsend). Clear it so transfers self-heal instead of failing on
+		// every attempt; a promised resume prefix is gone, so only the
+		// full-download path retries immediately.
+		_ = os.Remove(partial)
+		if action == wire.ActionAcceptFull {
+			f, err = os.OpenFile(partial, flag, 0o600)
+		}
+	}
 	if err != nil {
 		return fmt.Errorf("%w: open partial: %v", fserrors.ErrWriteFailed, err)
 	}
@@ -461,9 +483,7 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 		_ = os.Remove(partial)
 		// Notify peer so its TRANSFER_ACK read can fail fast instead of
 		// blocking on QUIC idle timeout.
-		_ = wire.WriteControl(s.Control, wire.TypeError, &wire.ErrorFrame{
-			Code: wire.ErrCodeFileHashMismatch, Message: "root hash mismatch",
-		})
+		declineTransfer(s, wire.ErrCodeFileHashMismatch, "root hash mismatch")
 		return fserrors.ErrHashMismatch
 	}
 
@@ -485,8 +505,10 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 		// --overwrite to finish without re-downloading.
 		if err := ExtractArchive(partial, opts.TargetDir, opts.Overwrite); err != nil {
 			if errors.Is(err, fserrors.ErrTargetExists) {
+				declineTransfer(s, wire.ErrCodeTargetExists, "target exists")
 				return err
 			}
+			declineTransfer(s, wire.ErrCodeWriteFailed, "extract failed")
 			return fmt.Errorf("%w: extract archive: %v", fserrors.ErrWriteFailed, err)
 		}
 		_ = os.Remove(partial)
@@ -500,6 +522,10 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 	if err := os.Rename(partial, target); err != nil {
 		return fmt.Errorf("%w: finalize: %v", fserrors.ErrWriteFailed, err)
 	}
+
+	// Apply the sender's mode now that the file is complete (the sidecar
+	// was created owner-private; see the OpenFile above).
+	_ = os.Chmod(target, os.FileMode(info.Mode)&os.ModePerm)
 
 	// Apply modtime.
 	if info.ModTime > 0 {
@@ -568,6 +594,17 @@ func receiverPasswordHandshake(s *Streams, opts RecvOptions) error {
 	default:
 		return fmt.Errorf("%w: expected PASSWORD_VERIFIED, got %v", fserrors.ErrProtocolError, ft)
 	}
+}
+
+// declineTransfer posts an ERROR frame and runs the symmetric shutdown:
+// close our write side so the frame's FIN reaches the sender before the
+// deferred QUIC close tears the connection down. Without the shutdown the
+// sender races the connection-close error against the frame and surfaces
+// a confusing "Application error 0x0" — and then retries pointlessly.
+func declineTransfer(s *Streams, code wire.ErrorCode, msg string) {
+	_ = wire.WriteControl(s.Control, wire.TypeError, &wire.ErrorFrame{Code: code, Message: msg})
+	_ = s.Control.Close()
+	_, _ = io.Copy(io.Discard, s.Control)
 }
 
 // tryReadPeerError reads at most one frame from the control stream and

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/zeebo/blake3"
+	"golang.org/x/crypto/argon2"
 
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/wire"
@@ -103,9 +104,14 @@ func Send(ctx context.Context, s *Streams, opts SendOptions) error {
 	if err := wire.WriteControl(s.Control, wire.TypeTransferComplete, nil); err != nil {
 		return fmt.Errorf("send: complete: %w", err)
 	}
-	ft, err = wire.ReadControl(s.Control, nil)
+	ft, ackBody, err := wire.ReadControlRaw(s.Control)
 	if err != nil {
 		return fmt.Errorf("send: read complete-ack: %w", err)
+	}
+	if ft == wire.TypeError {
+		// Receiver failed after the last byte landed (hash mismatch,
+		// extraction failure, refused overwrite). Surface the real reason.
+		return peerError(ackBody)
 	}
 	if ft != wire.TypeTransferAck {
 		return fmt.Errorf("%w: expected TRANSFER_ACK, got %v", fserrors.ErrProtocolError, ft)
@@ -118,6 +124,25 @@ func Send(ctx context.Context, s *Streams, opts SendOptions) error {
 	return nil
 }
 
+// peerError translates a receiver-reported ERROR frame into the
+// user-visible sentinel the CLI surfaces (rather than a generic
+// "protocol error"). All of these are terminal — retrying won't fix the
+// peer's disk or its verdict.
+func peerError(body []byte) error {
+	var ef wire.ErrorFrame
+	_ = wire.Decode(body, &ef)
+	switch ef.Code {
+	case wire.ErrCodeTargetExists:
+		return fserrors.ErrTargetExists
+	case wire.ErrCodeFileHashMismatch:
+		return fserrors.ErrHashMismatch
+	case wire.ErrCodeWriteFailed:
+		return fmt.Errorf("%w: receiver: %s", fserrors.ErrWriteFailed, ef.Message)
+	default:
+		return fmt.Errorf("%w: peer reported %d: %s", fserrors.ErrProtocolError, ef.Code, ef.Message)
+	}
+}
+
 func sendOneFile(ctx context.Context, s *Streams, it *SourceItem, opts SendOptions) error {
 	if err := wire.WriteControl(s.Control, wire.TypeFileInfo, &it.Info); err != nil {
 		return fmt.Errorf("send: file-info %d: %w", it.Info.Index, err)
@@ -128,17 +153,8 @@ func sendOneFile(ctx context.Context, s *Streams, it *SourceItem, opts SendOptio
 		return fmt.Errorf("send: file-accept: %w", err)
 	}
 	if ft == wire.TypeError {
-		// Receiver declined for a specific reason. Translate the wire
-		// code into a user-visible sentinel so the CLI surfaces it
-		// (rather than a generic "protocol error").
-		var ef wire.ErrorFrame
-		_ = wire.Decode(body, &ef)
-		switch ef.Code {
-		case wire.ErrCodeTargetExists:
-			return fserrors.ErrTargetExists
-		default:
-			return fmt.Errorf("%w: peer reported %d: %s", fserrors.ErrProtocolError, ef.Code, ef.Message)
-		}
+		// Receiver declined for a specific reason.
+		return peerError(body)
 	}
 	if ft != wire.TypeFileAccept {
 		return fmt.Errorf("%w: expected FILE_ACCEPT, got %v", fserrors.ErrProtocolError, ft)
@@ -382,7 +398,7 @@ func (rs *readerSeeker) Seek(offset int64, whence int) (int64, error) {
 // the transfer when --pass is set. Wire flow:
 //
 //	sender → receiver  PASSWORD_CHALLENGE{nonce}
-//	receiver → sender  PASSWORD_RESPONSE{HMAC-SHA256(password, nonce)}
+//	receiver → sender  PASSWORD_RESPONSE{HMAC(argon2id(password, nonce), nonce)}
 //	sender → receiver  PASSWORD_VERIFIED (on match)
 //	                or ERROR{ErrCodeWrongPassword} (on mismatch)
 //
@@ -426,11 +442,15 @@ func senderPasswordHandshake(s *Streams, password string) error {
 	return nil
 }
 
-// hmacPassword is the shared HMAC-SHA256(password, nonce) computation
-// used by both sides. Exposed at package scope so recv.go can reuse it
-// without duplicating the construction.
+// hmacPassword is the shared response-tag computation used by both sides.
+// The password is stretched with argon2id (salted by the session nonce)
+// before keying the HMAC: the receiver computes the tag over a
+// sender-chosen nonce, so anyone who knows the code could harvest a
+// (nonce, tag) pair and grind passwords offline — the stretch makes each
+// such guess cost ~64 MiB of memory and tens of milliseconds.
 func hmacPassword(password string, nonce []byte) []byte {
-	m := hmac.New(sha256.New, []byte(password))
+	key := argon2.IDKey([]byte(password), nonce, 2, 64*1024, 4, 32)
+	m := hmac.New(sha256.New, key)
 	m.Write(nonce)
 	return m.Sum(nil)
 }

--- a/internal/transfer/walk.go
+++ b/internal/transfer/walk.go
@@ -34,6 +34,10 @@ func Walk(paths []string) ([]SourceItem, error) {
 	}
 
 	items := make([]SourceItem, 0, len(paths))
+	// Receivers place every item by its base name, so duplicate base names
+	// (compared case-insensitively — the receiver may be on macOS/Windows)
+	// would silently clobber each other. Reject them up front.
+	seen := make(map[string]string, len(paths))
 	for i, raw := range paths {
 		abs, err := filepath.Abs(raw)
 		if err != nil {
@@ -44,10 +48,17 @@ func Walk(paths []string) ([]SourceItem, error) {
 			return nil, fmt.Errorf("walk: %s: %w", raw, err)
 		}
 		base := filepath.Base(abs)
+		if prev, ok := seen[strings.ToLower(base)]; ok {
+			return nil, fmt.Errorf("%w: %s and %s would both arrive as %q — rename one before sending", fserrors.ErrUsage, prev, raw, base)
+		}
+		seen[strings.ToLower(base)] = raw
 
 		switch {
 		case info.Mode()&os.ModeSymlink != 0:
-			target, _ := os.Readlink(abs)
+			target, err := os.Readlink(abs)
+			if err != nil {
+				return nil, fmt.Errorf("walk: %s: %w", raw, err)
+			}
 			items = append(items, SourceItem{
 				Info: wire.FileInfo{
 					Index:         uint32(i),

--- a/internal/transfer/walk_test.go
+++ b/internal/transfer/walk_test.go
@@ -1,0 +1,35 @@
+package transfer
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/polius/fsend/internal/fserrors"
+)
+
+// TestWalk_RejectsDuplicateBaseNames guards the up-front collision check:
+// receivers place every item by its base name, so two arguments sharing
+// one (even by case, for macOS/Windows receivers) must fail before any
+// byte moves instead of clobbering mid-transfer.
+func TestWalk_RejectsDuplicateBaseNames(t *testing.T) {
+	dir := t.TempDir()
+	a := filepath.Join(dir, "a", "report.pdf")
+	b := filepath.Join(dir, "b", "Report.pdf")
+	for _, p := range []string{a, b} {
+		if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(p, []byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := Walk([]string{a, b}); !errors.Is(err, fserrors.ErrUsage) {
+		t.Fatalf("Walk with duplicate base names: got %v, want ErrUsage", err)
+	}
+	if _, err := Walk([]string{a}); err != nil {
+		t.Fatalf("Walk with a single path: %v", err)
+	}
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,197 @@
+// Package update implements a best-effort "a newer fsend exists" check.
+//
+// It is deliberately passive: it never downloads or replaces anything, it
+// only tells the user a new release is out and how to get it. The result
+// of the GitHub lookup is cached for a day so normal runs do no network
+// I/O, and every failure path is silent — an update check must never
+// disturb a transfer.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/polius/fsend/internal/config"
+)
+
+// apiURL is the GitHub "latest release" endpoint. /latest already
+// excludes drafts and pre-releases, so we never nag about those. A
+// package var so tests can point it at a local server.
+var apiURL = "https://api.github.com/repos/polius/fsend/releases/latest"
+
+const (
+	cacheFile     = "update-check.json"
+	checkInterval = 24 * time.Hour
+	httpTimeout   = 2 * time.Second
+	// installCmd is the one-liner we point users at — same as the README.
+	installCmd = "curl -fsSL https://getfsend.alzina.dev | sh"
+)
+
+// cache is the on-disk memo of the last lookup. Latest has no leading "v".
+type cache struct {
+	CheckedAt time.Time `json:"checked_at"`
+	Latest    string    `json:"latest"`
+}
+
+// Notice returns a one-line upgrade message if a release newer than
+// current is available, or "" when up to date, opted out, or anything
+// goes wrong. current is the running version (version.Version).
+//
+// Opt out with FSEND_NO_UPDATE_CHECK=1. Dev builds never check.
+func Notice(ctx context.Context, current string) string {
+	if current == "" || current == "dev" {
+		return ""
+	}
+	if v := os.Getenv("FSEND_NO_UPDATE_CHECK"); v != "" && v != "0" && v != "false" {
+		return ""
+	}
+	latest := latestVersion(ctx)
+	if latest == "" || !newer(latest, current) {
+		return ""
+	}
+	return fmt.Sprintf("A new fsend is available (%s → %s). Update: %s",
+		strings.TrimPrefix(current, "v"), latest, installCmd)
+}
+
+// latestVersion returns the latest release version (no leading "v"),
+// preferring a fresh cache and only hitting the network once per
+// checkInterval. Returns "" if it has no answer.
+func latestVersion(ctx context.Context) string {
+	path := cachePath()
+	if c, ok := readCache(path); ok && time.Since(c.CheckedAt) < checkInterval {
+		return c.Latest
+	}
+	latest, ok := fetchLatest(ctx)
+	if !ok {
+		// Network failed: stamp the attempt so we don't retry (and re-pay
+		// the timeout) on every run for the next interval, and fall back
+		// to whatever we last knew.
+		if c, had := readCache(path); had {
+			writeCache(path, cache{CheckedAt: time.Now(), Latest: c.Latest})
+			return c.Latest
+		}
+		writeCache(path, cache{CheckedAt: time.Now()})
+		return ""
+	}
+	writeCache(path, cache{CheckedAt: time.Now(), Latest: latest})
+	return latest
+}
+
+// fetchLatest queries the GitHub API for the latest release tag.
+func fetchLatest(ctx context.Context) (string, bool) {
+	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", false
+	}
+	// GitHub requires a User-Agent; the recommended Accept pins the API
+	// version's media type.
+	req.Header.Set("User-Agent", "fsend-update-check")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+
+	var body struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", false
+	}
+	tag := strings.TrimPrefix(strings.TrimSpace(body.TagName), "v")
+	if tag == "" {
+		return "", false
+	}
+	return tag, true
+}
+
+func cachePath() string {
+	dir, err := config.Dir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, cacheFile)
+}
+
+func readCache(path string) (cache, bool) {
+	if path == "" {
+		return cache{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cache{}, false
+	}
+	var c cache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return cache{}, false
+	}
+	return c, true
+}
+
+func writeCache(path string, c cache) {
+	if path == "" {
+		return
+	}
+	if data, err := json.Marshal(c); err == nil {
+		_ = os.MkdirAll(filepath.Dir(path), 0o700)
+		_ = os.WriteFile(path, data, 0o600)
+	}
+}
+
+// newer reports whether semver latest is strictly greater than current.
+// Pre-release and build metadata are ignored — /latest only returns
+// stable tags, and we never want to nag about a dev build's own suffix.
+func newer(latest, current string) bool {
+	lMaj, lMin, lPat, ok1 := parse(latest)
+	cMaj, cMin, cPat, ok2 := parse(current)
+	if !ok1 || !ok2 {
+		return false
+	}
+	switch {
+	case lMaj != cMaj:
+		return lMaj > cMaj
+	case lMin != cMin:
+		return lMin > cMin
+	default:
+		return lPat > cPat
+	}
+}
+
+// parse splits a "MAJOR.MINOR.PATCH" string (optional leading "v",
+// optional -pre/+build suffix) into its numeric components.
+func parse(v string) (maj, min, pat int, ok bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	var err error
+	if maj, err = strconv.Atoi(parts[0]); err != nil {
+		return 0, 0, 0, false
+	}
+	if min, err = strconv.Atoi(parts[1]); err != nil {
+		return 0, 0, 0, false
+	}
+	if pat, err = strconv.Atoi(parts[2]); err != nil {
+		return 0, 0, 0, false
+	}
+	return maj, min, pat, true
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,62 @@
+package update
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/polius/fsend/internal/config"
+)
+
+func TestNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"0.2.0", "0.1.0", true},
+		{"v0.2.0", "0.1.0", true},
+		{"0.1.1", "0.1.0", true},
+		{"1.0.0", "0.9.9", true},
+		{"0.1.0", "0.1.0", false},
+		{"0.1.0", "0.2.0", false},
+		{"0.1.0", "0.1.0-rc1", false}, // suffix ignored → equal
+		{"garbage", "0.1.0", false},
+		{"0.1.0", "dev", false},
+	}
+	for _, c := range cases {
+		if got := newer(c.latest, c.current); got != c.want {
+			t.Errorf("newer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
+		}
+	}
+}
+
+func TestNotice(t *testing.T) {
+	// Redirect cache to a tempdir and the API to a stub server.
+	config.SetPathForTesting(filepath.Join(t.TempDir(), "config.json"))
+	t.Cleanup(func() { config.SetPathForTesting("") })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	}))
+	t.Cleanup(srv.Close)
+	apiURL = srv.URL
+
+	if msg := Notice(context.Background(), "0.1.0"); msg == "" {
+		t.Fatal("expected an upgrade notice for 0.1.0 vs 9.9.9")
+	}
+	// Up-to-date: no notice (served version cached, no second fetch needed).
+	if msg := Notice(context.Background(), "9.9.9"); msg != "" {
+		t.Fatalf("expected no notice when current, got %q", msg)
+	}
+	// Dev builds never check.
+	if msg := Notice(context.Background(), "dev"); msg != "" {
+		t.Fatalf("expected no notice for dev build, got %q", msg)
+	}
+	// Opt-out.
+	t.Setenv("FSEND_NO_UPDATE_CHECK", "1")
+	if msg := Notice(context.Background(), "0.1.0"); msg != "" {
+		t.Fatalf("expected no notice when opted out, got %q", msg)
+	}
+}

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -95,6 +95,10 @@ const (
 	// ErrCodeTargetExists — receiver refused to clobber an existing file
 	// because the user did not pass --overwrite.
 	ErrCodeTargetExists ErrorCode = 12
+	// ErrCodeWriteFailed — receiver hit a local filesystem error (mkdir,
+	// extract, …). Terminal for the sender: retrying won't fix the
+	// receiver's disk.
+	ErrCodeWriteFailed ErrorCode = 13
 )
 
 // Chunk-frame flag bits.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -96,6 +96,16 @@ default_prefix() {
     esac
 }
 
+# GNU wget supports an explicit TLS floor; busybox wget (Alpine) does
+# not and aborts on the unknown flag — it still validates certificates,
+# so emit the flag only when supported. Callers expand the result
+# unquoted on purpose (empty → no extra argument).
+wget_tls_opts() {
+    if wget --help 2>&1 | grep -q -- --secure-protocol; then
+        printf %s "--secure-protocol=TLSv1_2"
+    fi
+}
+
 download() {
     url="$1"
     out="$2"
@@ -103,7 +113,8 @@ download() {
         curl -fsSL --proto '=https' --tlsv1.2 -o "$out" "$url" \
             || err "download failed: $url"
     elif command -v wget >/dev/null 2>&1; then
-        wget -q -O "$out" "$url" \
+        # shellcheck disable=SC2046
+        wget -q $(wget_tls_opts) -O "$out" "$url" \
             || err "download failed: $url"
     else
         err "need curl or wget to download fsend"
@@ -120,7 +131,8 @@ resolve_latest() {
             | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' \
             | head -n1
     else
-        wget -q --secure-protocol=TLSv1_2 -O- "$api" \
+        # shellcheck disable=SC2046
+        wget -q $(wget_tls_opts) -O- "$api" \
             | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' \
             | head -n1
     fi


### PR DESCRIPTION
Implements the fixes from the production-readiness review: two issues that broke advertised guarantees, one panic, and a set of correctness/pipeline hardening items. Architecture-level findings (metrics/observability, relay scaling) are intentionally out of scope — they're design decisions, not bug fixes.

## Data integrity / correctness

- **Streaming retry corruption (blocker).** `pg_dump | fsend` + a transient drop made the sender retry with the already-consumed stdin reader; the receiver truncated and accepted, every per-chunk hash passed (root hash is skipped for synthetic items), and both sides reported success on a file missing an arbitrary prefix. Reader-backed transfers (stdin, `--text`) are now capped at one attempt (`cmd/fsend/sendpair.go`).
- **Duplicate base names** (`fsend a/report.pdf b/report.pdf`) are rejected up front in `Walk` (case-insensitive, since the receiver may be on macOS/Windows) instead of clobbering or aborting after the first file moved.
- **Read-only sources broke resume permanently.** The partial sidecar inherited the source mode, so a 0444 file produced a sidecar that could never be reopened (EACCES on every later attempt). Sidecars are now created 0600 with the sender's mode applied at finalize; legacy read-only partials self-heal. Same family fixed in extraction: read-only directory entries no longer block writing their children (modes deferred, children before parents), and `--overwrite` now actually replaces read-only files.
- **Symlink entries deleted receiver files without consent** — and on Windows the follow-up `os.Symlink` could fail silently after the delete, losing the file. Replacing anything at the target now requires the same overwrite consent as regular files. `Walk` also surfaces `Readlink` errors instead of sending an empty target.
- **Receiver failures now reach the sender.** Extraction failures, mkdir errors, and root-hash mismatches previously closed the connection without an ERROR frame, so the sender retried pointlessly (~45s) and reported a generic protocol error. They now send a typed ERROR with the symmetric shutdown, and the sender translates it (new wire code `ErrCodeWriteFailed`; hash-mismatch and target-exists mapped at the TRANSFER_ACK stage too).
- **Panic race in the ICE candidate pump.** `Close()` closed `localCh` while pion's gathering goroutine could still send; a `select` with `default` does not protect against send-on-closed-channel. Now guarded by a mutex + closed flag.
- **Unbounded internet re-accept.** A terminally-exited receiver left the sender's retry loop hanging until Ctrl-C; the re-accept is now bounded at 15s like the LAN path.

## Security

- **LAN discovery leaked the code to offline brute-force.** The mDNS name was an unsalted SHA-256 of the ~45-bit code (the PAKE secret) — recoverable in about an hour on one GPU by any passive observer on the broadcast domain. The name and port are now derived with argon2id (64 MiB, memoized), making each guess memory-hard. A per-session salt is impossible (peers share no prior state); the memory-hardness carries the defense.
- **`--pass` was an offline cracking oracle.** Anyone who knew the code could connect as a fake sender, choose the nonce, and grind the returned `HMAC(password, nonce)` offline. The password is now stretched with argon2id (salted by the session nonce) before keying the HMAC.
- **Slow-body request parking.** The server had no `ReadTimeout`, so a client trickling a declared body parked a handler goroutine indefinitely (the rate limiter only runs after decode). Now 15s; `/wait` long-polls are unaffected (write side stays unbounded).

## Release pipeline / docs

- New `-race` CI job (ubuntu) — the LAN/direct/relay paths race concurrently in production and nothing exercised the race detector.
- Docker images reported `fsend dev`: version/commit/date are now injected via build args in `docker.yml` + Dockerfile; added `.dockerignore`.
- `install.sh`: busybox wget (Alpine) aborted on `--secure-protocol`; the flag is now probed, and the wget download branch gets the same TLS hardening as curl.
- Corrected the "two independent encryption layers" claim (README, `docs/security.md`, `docs/comparison.md`): payload confidentiality is TLS 1.3; SPAKE2 + RFC 5705 channel binding is the independent peer-authentication layer that defeats a TLS-terminating MITM.

## Compatibility notes

- The landisc derivation change means old↔new clients won't discover each other on the LAN — they silently fall back to the internet path, which still works.
- Mixed-version `--pass` transfers report wrong password; worth folding into the next minor release notes.

## Testing

- New tests: `TestWalk_RejectsDuplicateBaseNames`, `TestExtractArchive_ReadOnlyDirAndOverwrite` (the latter caught a real second-order bug during development: `MkdirAll` no-ops on existing read-only dirs).
- Full suite (`go test ./...` incl. e2e), `go vet`, `golangci-lint` (0 issues), `go test -race` over all unit packages, and a local `docker build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)