### PR TITLE
feat: passive update check + Windows install note

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,9 @@ fsend lets any two computers transfer files **directly** to each other — no ac
 curl -fsSL https://getfsend.alzina.dev | sh
 ```
 
-Works on Linux, macOS, FreeBSD, and Windows — x86 and ARM.
+Works on Linux, macOS, FreeBSD, and Windows — x86 and ARM. On Windows, run
+this in a POSIX shell (MSYS / MinGW / Cygwin / Git Bash); the installed
+`fsend.exe` then runs in any terminal once its directory is on your PATH.
 
 <details>
 <summary>Other install methods</summary>

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -213,6 +213,8 @@ ADVANCED FLAGS
 ENVIRONMENT
   FSEND_PASS             Used as --pass when the flag is not given
                          (keeps the password out of argv)
+  FSEND_NO_UPDATE_CHECK  Set to 1 to disable the daily check for a newer
+                         fsend release
 
 SELF-HOSTING
   fsend server                 Run your own pairing + relay server

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -496,6 +496,7 @@ func printSendSummary(f *flags, bytes int64, elapsed time.Duration, path connpat
 	}
 	parts := summaryParts(bytes, elapsed, path)
 	fmt.Fprintf(os.Stderr, "%s Sent  ·  %s\n", uxlog.Check(), strings.Join(parts, "  ·  "))
+	printUpdateNotice(f)
 }
 
 // printRecvSummary is the receive-side counterpart. The bytes figure is
@@ -514,9 +515,11 @@ func printRecvSummary(f *flags, destLabel string, bytes int64, elapsed time.Dura
 	if destLabel != "" {
 		fmt.Fprintf(os.Stderr, "%s Saved to %s  ·  %s\n",
 			uxlog.Check(), destLabel, strings.Join(parts, "  ·  "))
+		printUpdateNotice(f)
 		return
 	}
 	fmt.Fprintf(os.Stderr, "%s Received  ·  %s\n", uxlog.Check(), strings.Join(parts, "  ·  "))
+	printUpdateNotice(f)
 }
 
 // summaryParts builds the bytes/duration/path/rate sequence that both

--- a/cmd/fsend/update_notice.go
+++ b/cmd/fsend/update_notice.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"golang.org/x/term"
+
+	"github.com/polius/fsend/internal/update"
+	"github.com/polius/fsend/internal/version"
+)
+
+// printUpdateNotice prints a one-line "newer fsend available" hint after a
+// successful transfer, when interactive. It's best-effort and silent on
+// failure (see internal/update); the lookup is cached for a day so most
+// runs do no network I/O.
+//
+// Skipped under --quiet (the stdout contract must stay clean) and when
+// stderr isn't a terminal, so piped/scripted use never triggers the
+// network call or the extra line.
+func printUpdateNotice(f *flags) {
+	if f.quiet || !term.IsTerminal(int(os.Stderr.Fd())) {
+		return
+	}
+	if msg := update.Notice(context.Background(), version.Version); msg != "" {
+		fmt.Fprintf(os.Stderr, "\n  %s\n", msg)
+	}
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -107,8 +107,14 @@ Config is at `~/.config/fsend/config.json` (Linux),
 |---|---|---|
 | `FSEND_PASS` | `--pass` | Supply the transfer password out-of-band. |
 | `FSEND_DEBUG` | `--debug` | `1` enables verbose stderr logging. |
+| `FSEND_NO_UPDATE_CHECK` | — | `1` disables the once-a-day check for a newer release. |
 
 Flags always win when both are set.
+
+After a successful transfer, fsend checks GitHub at most once a day for a
+newer release and, if one exists, prints a one-line upgrade hint. The
+check is skipped when output is piped or `--quiet` is set, and can be
+turned off entirely with `FSEND_NO_UPDATE_CHECK=1`.
 
 ## `fsend server`
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -97,6 +97,16 @@ func Path() (string, error) {
 	return p, nil
 }
 
+// Dir returns the directory that holds the config file, used for other
+// small bits of fsend state too (e.g. the update-check cache).
+func Dir() (string, error) {
+	p, err := Path()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Dir(p), nil
+}
+
 // Load reads the config from disk. A missing file returns a zero-value
 // Config and nil — that's the normal first-run state, not an error.
 //

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,197 @@
+// Package update implements a best-effort "a newer fsend exists" check.
+//
+// It is deliberately passive: it never downloads or replaces anything, it
+// only tells the user a new release is out and how to get it. The result
+// of the GitHub lookup is cached for a day so normal runs do no network
+// I/O, and every failure path is silent — an update check must never
+// disturb a transfer.
+package update
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/polius/fsend/internal/config"
+)
+
+// apiURL is the GitHub "latest release" endpoint. /latest already
+// excludes drafts and pre-releases, so we never nag about those. A
+// package var so tests can point it at a local server.
+var apiURL = "https://api.github.com/repos/polius/fsend/releases/latest"
+
+const (
+	cacheFile     = "update-check.json"
+	checkInterval = 24 * time.Hour
+	httpTimeout   = 2 * time.Second
+	// installCmd is the one-liner we point users at — same as the README.
+	installCmd = "curl -fsSL https://getfsend.alzina.dev | sh"
+)
+
+// cache is the on-disk memo of the last lookup. Latest has no leading "v".
+type cache struct {
+	CheckedAt time.Time `json:"checked_at"`
+	Latest    string    `json:"latest"`
+}
+
+// Notice returns a one-line upgrade message if a release newer than
+// current is available, or "" when up to date, opted out, or anything
+// goes wrong. current is the running version (version.Version).
+//
+// Opt out with FSEND_NO_UPDATE_CHECK=1. Dev builds never check.
+func Notice(ctx context.Context, current string) string {
+	if current == "" || current == "dev" {
+		return ""
+	}
+	if v := os.Getenv("FSEND_NO_UPDATE_CHECK"); v != "" && v != "0" && v != "false" {
+		return ""
+	}
+	latest := latestVersion(ctx)
+	if latest == "" || !newer(latest, current) {
+		return ""
+	}
+	return fmt.Sprintf("A new fsend is available (%s → %s). Update: %s",
+		strings.TrimPrefix(current, "v"), latest, installCmd)
+}
+
+// latestVersion returns the latest release version (no leading "v"),
+// preferring a fresh cache and only hitting the network once per
+// checkInterval. Returns "" if it has no answer.
+func latestVersion(ctx context.Context) string {
+	path := cachePath()
+	if c, ok := readCache(path); ok && time.Since(c.CheckedAt) < checkInterval {
+		return c.Latest
+	}
+	latest, ok := fetchLatest(ctx)
+	if !ok {
+		// Network failed: stamp the attempt so we don't retry (and re-pay
+		// the timeout) on every run for the next interval, and fall back
+		// to whatever we last knew.
+		if c, had := readCache(path); had {
+			writeCache(path, cache{CheckedAt: time.Now(), Latest: c.Latest})
+			return c.Latest
+		}
+		writeCache(path, cache{CheckedAt: time.Now()})
+		return ""
+	}
+	writeCache(path, cache{CheckedAt: time.Now(), Latest: latest})
+	return latest
+}
+
+// fetchLatest queries the GitHub API for the latest release tag.
+func fetchLatest(ctx context.Context) (string, bool) {
+	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
+	if err != nil {
+		return "", false
+	}
+	// GitHub requires a User-Agent; the recommended Accept pins the API
+	// version's media type.
+	req.Header.Set("User-Agent", "fsend-update-check")
+	req.Header.Set("Accept", "application/vnd.github+json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", false
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return "", false
+	}
+
+	var body struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", false
+	}
+	tag := strings.TrimPrefix(strings.TrimSpace(body.TagName), "v")
+	if tag == "" {
+		return "", false
+	}
+	return tag, true
+}
+
+func cachePath() string {
+	dir, err := config.Dir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(dir, cacheFile)
+}
+
+func readCache(path string) (cache, bool) {
+	if path == "" {
+		return cache{}, false
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return cache{}, false
+	}
+	var c cache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return cache{}, false
+	}
+	return c, true
+}
+
+func writeCache(path string, c cache) {
+	if path == "" {
+		return
+	}
+	if data, err := json.Marshal(c); err == nil {
+		_ = os.MkdirAll(filepath.Dir(path), 0o700)
+		_ = os.WriteFile(path, data, 0o600)
+	}
+}
+
+// newer reports whether semver latest is strictly greater than current.
+// Pre-release and build metadata are ignored — /latest only returns
+// stable tags, and we never want to nag about a dev build's own suffix.
+func newer(latest, current string) bool {
+	lMaj, lMin, lPat, ok1 := parse(latest)
+	cMaj, cMin, cPat, ok2 := parse(current)
+	if !ok1 || !ok2 {
+		return false
+	}
+	switch {
+	case lMaj != cMaj:
+		return lMaj > cMaj
+	case lMin != cMin:
+		return lMin > cMin
+	default:
+		return lPat > cPat
+	}
+}
+
+// parse splits a "MAJOR.MINOR.PATCH" string (optional leading "v",
+// optional -pre/+build suffix) into its numeric components.
+func parse(v string) (maj, min, pat int, ok bool) {
+	v = strings.TrimPrefix(strings.TrimSpace(v), "v")
+	if i := strings.IndexAny(v, "-+"); i >= 0 {
+		v = v[:i]
+	}
+	parts := strings.SplitN(v, ".", 3)
+	if len(parts) != 3 {
+		return 0, 0, 0, false
+	}
+	var err error
+	if maj, err = strconv.Atoi(parts[0]); err != nil {
+		return 0, 0, 0, false
+	}
+	if min, err = strconv.Atoi(parts[1]); err != nil {
+		return 0, 0, 0, false
+	}
+	if pat, err = strconv.Atoi(parts[2]); err != nil {
+		return 0, 0, 0, false
+	}
+	return maj, min, pat, true
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,62 @@
+package update
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"testing"
+
+	"github.com/polius/fsend/internal/config"
+)
+
+func TestNewer(t *testing.T) {
+	cases := []struct {
+		latest, current string
+		want            bool
+	}{
+		{"0.2.0", "0.1.0", true},
+		{"v0.2.0", "0.1.0", true},
+		{"0.1.1", "0.1.0", true},
+		{"1.0.0", "0.9.9", true},
+		{"0.1.0", "0.1.0", false},
+		{"0.1.0", "0.2.0", false},
+		{"0.1.0", "0.1.0-rc1", false}, // suffix ignored → equal
+		{"garbage", "0.1.0", false},
+		{"0.1.0", "dev", false},
+	}
+	for _, c := range cases {
+		if got := newer(c.latest, c.current); got != c.want {
+			t.Errorf("newer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
+		}
+	}
+}
+
+func TestNotice(t *testing.T) {
+	// Redirect cache to a tempdir and the API to a stub server.
+	config.SetPathForTesting(filepath.Join(t.TempDir(), "config.json"))
+	t.Cleanup(func() { config.SetPathForTesting("") })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v9.9.9"}`))
+	}))
+	t.Cleanup(srv.Close)
+	apiURL = srv.URL
+
+	if msg := Notice(context.Background(), "0.1.0"); msg == "" {
+		t.Fatal("expected an upgrade notice for 0.1.0 vs 9.9.9")
+	}
+	// Up-to-date: no notice (served version cached, no second fetch needed).
+	if msg := Notice(context.Background(), "9.9.9"); msg != "" {
+		t.Fatalf("expected no notice when current, got %q", msg)
+	}
+	// Dev builds never check.
+	if msg := Notice(context.Background(), "dev"); msg != "" {
+		t.Fatalf("expected no notice for dev build, got %q", msg)
+	}
+	// Opt-out.
+	t.Setenv("FSEND_NO_UPDATE_CHECK", "1")
+	if msg := Notice(context.Background(), "0.1.0"); msg != "" {
+		t.Fatalf("expected no notice when opted out, got %q", msg)
+	}
+}


### PR DESCRIPTION
Adds a lightweight "a newer fsend is available" notification so users don't have to poll GitHub for releases, plus a small README clarification for Windows installs. Split out of #39 (production-readiness audit) since it's a separate, additive feature.

## Update check

After a **successful** transfer, fsend checks GitHub's `/releases/latest` and, if a newer version exists, prints one stderr line:

```
  A new fsend is available (0.1.0 → 0.2.0). Update: curl -fsSL https://getfsend.alzina.dev | sh
```

Deliberately passive and low-maintenance — it only notifies, it never downloads or replaces the binary (no cross-platform self-replacement code to own).

Guardrails:
- **Cached for 24h** in the config dir (`update-check.json`), so normal runs do zero network I/O — only one run per day hits the network, and that's *after* the transfer already completed (2s timeout, never blocks the transfer).
- **Silent on every failure** — a stale/unreachable check can't disturb a transfer; the attempt is stamped so a failure doesn't re-pay the timeout every run.
- **Skipped** under `--quiet` and when stderr isn't a terminal, so piped/scripted use never triggers the network call or the extra line (keeps the `--quiet` stdout-only contract intact). Dev builds never check.
- **Opt-out** via `FSEND_NO_UPDATE_CHECK=1`, documented in `--help` and `docs/usage.md`.

`/releases/latest` already excludes drafts and pre-releases, so it never nags about those; semver comparison ignores pre-release/build suffixes.

## Windows install note

Clarifies in the README that the `curl … | sh` one-liner needs a POSIX shell (MSYS / MinGW / Cygwin / Git Bash) on Windows, and that the resulting `fsend.exe` then runs in any terminal once its directory is on PATH — no separate installer introduced.

## Files

- `internal/update/` — the check (notify-only, cached, fail-silent) + tests
- `cmd/fsend/update_notice.go` — interactive/quiet gating, wired into the send & receive success summaries
- `internal/config/config.go` — `Dir()` helper for the cache location
- `README.md`, `docs/usage.md`, `cmd/fsend/root.go --help` — docs + env var

## Testing

`go build`, `go vet`, `golangci-lint` (0 issues), `go test ./...`, and `go test -race` on the new packages all pass. New tests cover the semver comparison and the notice/up-to-date/dev/opt-out paths against a stub API server.

🤖 Generated with [Claude Code](https://claude.com/claude-code)