### PR TITLE
fix: release readiness — Windows install, CLI polish, mDNS query watchdog

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -4,7 +4,9 @@ project_name: fsend
 
 before:
   hooks:
-    - go mod tidy
+    # verify, not tidy: tidy can rewrite go.mod/go.sum, and goreleaser
+    # aborts on a dirty git state mid-release.
+    - go mod verify
 
 builds:
   - id: fsend

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,8 @@ RUN go build -trimpath -ldflags "-s -w \
     -o /out/fsend ./cmd/fsend
 
 FROM scratch
+# CA bundle so the image also works as a client (sending/receiving needs
+# to verify the HTTPS pairing server) — server mode never dials out.
+COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=builder /out/fsend /fsend
 ENTRYPOINT ["/fsend"]

--- a/cmd/fsend/connect.go
+++ b/cmd/fsend/connect.go
@@ -171,10 +171,14 @@ func defaultPortForHost(host string) string {
 	return "443"
 }
 
+// printCurrentServer answers the `fsend --connect` query. The answer
+// lines go to stdout (the result of a query, greppable — same
+// convention as `git config` / `gh`); the surrounding guidance stays on
+// stderr so `fsend --connect | grep` sees only the data.
 func printCurrentServer(cfg *config.Config) {
 	fmt.Fprintln(os.Stderr)
 	if cfg.IsDefault() {
-		fmt.Fprintln(os.Stderr, "  Current server:", config.DefaultServer, "(default)")
+		fmt.Println("  Current server:", config.DefaultServer, "(default)")
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "  Set a custom server:  fsend --connect <host[:port]>[,<password>]")
 	} else {
@@ -182,8 +186,8 @@ func printCurrentServer(cfg *config.Config) {
 		if cfg.ServerPassword != "" {
 			tag = "custom, password set"
 		}
-		fmt.Fprintf(os.Stderr, "  Current server: %s  (%s)\n", cfg.Server, tag)
-		fmt.Fprintln(os.Stderr, "  Default server:", config.DefaultServer)
+		fmt.Printf("  Current server: %s  (%s)\n", cfg.Server, tag)
+		fmt.Println("  Default server:", config.DefaultServer)
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "  Revert to the default:  fsend --connect default")
 		fmt.Fprintln(os.Stderr, "  Set a new server:       fsend --connect <host[:port]>[,<password>]")

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -370,6 +370,27 @@ func captureStderr(t *testing.T, fn func()) string {
 	return <-done
 }
 
+// captureStdout is the stdout twin of captureStderr, for helpers whose
+// output is a query answer (printCurrentServer's data lines).
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	fn()
+	_ = w.Close()
+	os.Stdout = old
+	return <-done
+}
+
 // ---------------------------------------------------------------------------
 // main.go debugRequested
 // ---------------------------------------------------------------------------
@@ -480,18 +501,31 @@ func TestSignalingClient_SchemeSelection(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPrintCurrentServer_DefaultAndCustom(t *testing.T) {
-	got := captureStderr(t, func() {
-		printCurrentServer(&config.Config{})
+	// The query's answer rides stdout (scriptable, `fsend --connect |
+	// grep`); the guidance lines stay on stderr. Lock the split in.
+	var guidance string
+	answer := captureStdout(t, func() {
+		guidance = captureStderr(t, func() {
+			printCurrentServer(&config.Config{})
+		})
 	})
-	if !strings.Contains(got, "default") || !strings.Contains(got, config.DefaultServer) {
-		t.Errorf("default rendering missing markers:\n%s", got)
+	if !strings.Contains(answer, "default") || !strings.Contains(answer, config.DefaultServer) {
+		t.Errorf("default rendering missing markers on stdout:\n%s", answer)
+	}
+	if !strings.Contains(guidance, "Set a custom server") {
+		t.Errorf("guidance missing from stderr:\n%s", guidance)
 	}
 
-	got = captureStderr(t, func() {
-		printCurrentServer(&config.Config{Server: "relay.example.com:443", ServerPassword: "x"})
+	answer = captureStdout(t, func() {
+		guidance = captureStderr(t, func() {
+			printCurrentServer(&config.Config{Server: "relay.example.com:443", ServerPassword: "x"})
+		})
 	})
-	if !strings.Contains(got, "relay.example.com:443") || !strings.Contains(got, "password set") {
-		t.Errorf("custom rendering missing markers:\n%s", got)
+	if !strings.Contains(answer, "relay.example.com:443") || !strings.Contains(answer, "password set") {
+		t.Errorf("custom rendering missing markers on stdout:\n%s", answer)
+	}
+	if !strings.Contains(guidance, "Revert to the default") {
+		t.Errorf("guidance missing from stderr:\n%s", guidance)
 	}
 }
 

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -16,6 +16,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/polius/fsend/internal/code"
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/uxlog"
 )
@@ -170,6 +171,13 @@ func renderError(err error, debug bool) int {
 		// "[E025] No such file or directory: hola".
 		msg := strings.TrimSuffix(entry.Message, ".")
 		fmt.Fprintf(os.Stderr, "%s [%s] %s: %s\n", glyph, entry.Code, msg, detail)
+		// A mistyped receive code falls through dispatch to the send
+		// path and lands here — by far the most common failure when
+		// codes are relayed verbally. Without the hint, the bare "no
+		// such file" sends those users hunting for a file problem.
+		if code.LooksLikeCode(detail) {
+			fmt.Fprintf(os.Stderr, "  If this was a receive code, check it with the sender — codes look like abc-defg-jkm.\n")
+		}
 		if entry.Action != "" {
 			fmt.Fprintf(os.Stderr, "  %s\n", entry.Action)
 		}

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/polius/fsend/internal/code"
 	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/uxlog"
 	"github.com/polius/fsend/internal/version"
 )
 
@@ -93,6 +94,7 @@ Examples:
 	// running on every `--help` — saves a round-trip to `--version`
 	// when writing a bug report.
 	ht := strings.Replace(helpTemplate, "fsend —", "fsend "+version.Version+" —", 1)
+	ht = boldHelpHeaders(ht)
 	c.SetHelpTemplate(ht)
 	c.SetUsageTemplate(ht)
 
@@ -224,6 +226,40 @@ LEARN MORE
   Docs    https://github.com/polius/fsend
   Issues  https://github.com/polius/fsend/issues
 `
+
+// boldHelpHeaders wraps the ALL-CAPS section headers (USAGE, EXAMPLES,
+// …) of a help template in ANSI bold so the page scans by section.
+// Gated on stdout — where cobra writes help — so pipes, NO_COLOR, and
+// non-TTY contexts get the template byte-for-byte untouched.
+func boldHelpHeaders(tpl string) string {
+	if !uxlog.ColorFor(os.Stdout) {
+		return tpl
+	}
+	lines := strings.Split(tpl, "\n")
+	for i, line := range lines {
+		if isHelpHeader(line) {
+			lines[i] = uxlog.Bold(line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// isHelpHeader reports whether line is a column-0 ALL-CAPS section
+// header ("COMMON FLAGS", "SELF-HOSTING", …). Body lines are indented,
+// and the version header line starts lowercase, so neither matches.
+func isHelpHeader(line string) bool {
+	if line == "" || (line[0] < 'A' || line[0] > 'Z') {
+		return false
+	}
+	for _, r := range line {
+		switch {
+		case r >= 'A' && r <= 'Z', r == ' ', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
 
 // passPromptSentinel is the value cobra hands us when the user passes
 // bare --pass with no argument. The dispatch layer translates this into

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -94,3 +94,34 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 		})
 	}
 }
+
+func TestBoldHelpHeaders(t *testing.T) {
+	t.Run("colored", func(t *testing.T) {
+		// FORCE_COLOR makes ColorFor true even though test stdout is
+		// not a TTY, so the bolding path is exercised deterministically.
+		t.Setenv("NO_COLOR", "")
+		t.Setenv("FORCE_COLOR", "1")
+		got := boldHelpHeaders(helpTemplate)
+		for _, header := range []string{"USAGE", "EXAMPLES", "COMMON FLAGS",
+			"ADVANCED FLAGS", "ENVIRONMENT", "SELF-HOSTING", "LEARN MORE"} {
+			if !strings.Contains(got, "\x1b[1m"+header+"\x1b[0m") {
+				t.Errorf("header %q not bolded", header)
+			}
+		}
+		// Indented body lines and the lowercase version header line must
+		// pass through untouched.
+		if !strings.Contains(got, "\n  fsend <file|dir>...") {
+			t.Error("indented body line was altered")
+		}
+		if strings.Contains(got, "\x1b[1mfsend —") {
+			t.Error("version header line should not be bolded")
+		}
+	})
+
+	t.Run("no_color_untouched", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "1")
+		if got := boldHelpHeaders(helpTemplate); got != helpTemplate {
+			t.Error("template must be byte-for-byte unchanged when color is off")
+		}
+	})
+}

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -57,8 +57,9 @@ func serverCmd() *cobra.Command {
 	c.Flags().BoolVar(&healthCheckFlag, "health-check", false,
 		"probe /v1/health and exit 0 if healthy (for Docker)")
 
-	c.SetHelpTemplate(serverHelpTemplate)
-	c.SetUsageTemplate(serverHelpTemplate)
+	sht := boldHelpHeaders(serverHelpTemplate)
+	c.SetHelpTemplate(sht)
+	c.SetUsageTemplate(sht)
 
 	return c
 }

--- a/internal/code/code.go
+++ b/internal/code/code.go
@@ -70,6 +70,26 @@ func IsCode(s string) bool {
 	return Pattern.MatchString(s)
 }
 
+// looksLikeCodePattern is deliberately looser than Pattern: any-case
+// alphanumeric groups joined by hyphens. Digits are included because the
+// alphabet excludes i/l/o precisely for their 1/1/0 lookalikes — typing
+// the digit is the expected transcription mistake.
+var looksLikeCodePattern = regexp.MustCompile(`^[a-zA-Z0-9]+(-[a-zA-Z0-9]+)+$`)
+
+// LooksLikeCode reports whether s is shaped enough like a code that a
+// mistyped code is the plausible explanation: hyphen-joined groups with
+// roughly the right number of characters, even if the strict Pattern
+// rejects it (wrong group sizes, dropped/extra letter, digit for letter).
+// Used to attach a "was this a receive code?" hint to errors — false
+// positives only cost a harmless extra hint line, so close is good enough.
+func LooksLikeCode(s string) bool {
+	if !looksLikeCodePattern.MatchString(s) {
+		return false
+	}
+	n := len(s) - strings.Count(s, "-")
+	return n >= Length-2 && n <= Length+2
+}
+
 // format takes a 10-byte buffer of code letters and inserts hyphens.
 func format(letters []byte) string {
 	var b strings.Builder

--- a/internal/code/code_test.go
+++ b/internal/code/code_test.go
@@ -102,6 +102,37 @@ func TestIsCode(t *testing.T) {
 	}
 }
 
+func TestLooksLikeCode(t *testing.T) {
+	tests := []struct {
+		in   string
+		want bool
+	}{
+		// Plausible typos of a real code.
+		{"abc-defg-jk", true},   // dropped last letter
+		{"abc-defg-jkmm", true}, // doubled letter
+		{"abcd-efg-jkm", true},  // hyphen in the wrong place
+		{"abcdefg-jkm", true},   // dropped hyphen
+		{"abc-def0-jkm", true},  // digit for letter (0 ↔ o confusion)
+		{"Abc-Defg-Jkm", true},  // chat-app capitalization
+		{"abc-defg-jkm", true},  // exact code shape counts too
+
+		// Things that are clearly not codes.
+		{"report.pdf", false},                  // extension
+		{"my-file", false},                     // too short
+		{"my-favorite-very-long-notes", false}, // too long
+		{"abc defg jkm", false},                // spaces, not hyphens
+		{"abc-defg-", false},                   // trailing hyphen
+		{"-abc-defg", false},                   // leading hyphen
+		{"dir/abc-defg-jkm", false},            // path separator
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := LooksLikeCode(tt.in); got != tt.want {
+			t.Errorf("LooksLikeCode(%q) = %v, want %v", tt.in, got, tt.want)
+		}
+	}
+}
+
 func TestAlphabet_NoConfusables(t *testing.T) {
 	// Defensive: confirms the alphabet constant matches the regex.
 	for _, r := range Alphabet {

--- a/internal/landisc/landisc.go
+++ b/internal/landisc/landisc.go
@@ -22,6 +22,7 @@ import (
 	"encoding/hex"
 	"fmt"
 	"net"
+	"net/netip"
 	"sync"
 	"time"
 
@@ -100,6 +101,15 @@ type QueryResult struct {
 	Port int
 }
 
+// watchdogGrace is how long past the caller's timeout Query waits for
+// pion/mdns before force-closing the sockets and declaring a LAN miss.
+// QueryAddr is supposed to honor its context deadline, but a wedged
+// read/close path inside the library has been observed to block forever
+// while re-multicasting the query every QueryInterval — and that spam
+// in turn wedges the next receiver querying the same name, so one stuck
+// process poisons every later transfer with that code on the LAN.
+const watchdogGrace = 2 * time.Second
+
 // Query searches for a sender announcing the given code, up to timeout.
 //
 // Returns a QueryResult if found; otherwise an error (usually
@@ -109,23 +119,21 @@ type QueryResult struct {
 // pion/mdns's QueryAddr blocks until it gets a response or the context
 // expires, retrying on QueryInterval. Callers pass a short timeout
 // (300 ms is fsend's default) so a LAN miss doesn't block the
-// pairing-server fallback.
+// pairing-server fallback. The library runs on its own goroutine behind
+// a watchdog: if it blows past the deadline (see watchdogGrace), Query
+// closes the multicast sockets out from under it — which both unblocks
+// its read loop and stops the query spam — and reports a miss.
 func Query(ctx context.Context, code string, timeout time.Duration) (*QueryResult, error) {
 	v4Conn, v6Conn, err := openMulticast()
 	if err != nil {
 		return nil, fmt.Errorf("landisc: opening multicast: %w", err)
 	}
-
-	cfg := &mdns.Config{
-		Name:            "fsend-receiver",
-		IncludeLoopback: true,
-		QueryInterval:   100 * time.Millisecond,
+	closeSockets := func() {
+		_ = v4Conn.Close()
+		if v6Conn != nil {
+			_ = v6Conn.Close()
+		}
 	}
-	conn, err := mdns.Server(v4Conn, v6Conn, cfg)
-	if err != nil {
-		return nil, fmt.Errorf("landisc: mdns server: %w", err)
-	}
-	defer func() { _ = conn.Close() }()
 
 	qCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
@@ -137,11 +145,48 @@ func Query(ctx context.Context, code string, timeout time.Duration) (*QueryResul
 	port := PortForCode(code)
 	name := serviceName(code)
 
-	_, addr, err := conn.QueryAddr(qCtx, name)
-	if err != nil {
-		return nil, fmt.Errorf("landisc: query: %w", err)
+	type outcome struct {
+		addr netip.Addr
+		err  error
 	}
-	return &QueryResult{IP: net.IP(addr.AsSlice()), Port: port}, nil
+	ch := make(chan outcome, 1)
+	go func() {
+		cfg := &mdns.Config{
+			Name:            "fsend-receiver",
+			IncludeLoopback: true,
+			QueryInterval:   100 * time.Millisecond,
+		}
+		conn, err := mdns.Server(v4Conn, v6Conn, cfg)
+		if err != nil {
+			closeSockets()
+			ch <- outcome{err: fmt.Errorf("landisc: mdns server: %w", err)}
+			return
+		}
+		_, addr, err := conn.QueryAddr(qCtx, name)
+		// Deliver the result before Close: a wedged Close leaks this
+		// goroutine until process exit but can no longer hang the caller.
+		ch <- outcome{addr: addr, err: err}
+		_ = conn.Close()
+		closeSockets()
+	}()
+
+	watchdog := time.NewTimer(timeout + watchdogGrace)
+	defer watchdog.Stop()
+	select {
+	case o := <-ch:
+		if o.err != nil {
+			return nil, fmt.Errorf("landisc: query: %w", o.err)
+		}
+		return &QueryResult{IP: net.IP(o.addr.AsSlice()), Port: port}, nil
+	case <-ctx.Done():
+		// Caller is shutting down (e.g. SIGINT). Don't wait out the
+		// watchdog — kill the sockets so the query goroutine unblocks.
+		closeSockets()
+		return nil, fmt.Errorf("landisc: query: %w", ctx.Err())
+	case <-watchdog.C:
+		closeSockets()
+		return nil, fmt.Errorf("landisc: query stuck past its %v deadline (watchdog)", timeout)
+	}
 }
 
 // PortForCode deterministically derives a UDP port from the code so that

--- a/internal/landisc/landisc_test.go
+++ b/internal/landisc/landisc_test.go
@@ -1,9 +1,45 @@
 package landisc
 
 import (
+	"context"
 	"strings"
 	"testing"
+	"time"
 )
+
+// TestQuery_MissIsBounded pins the watchdog contract: with no sender
+// announcing the code, Query must report a miss within timeout +
+// watchdogGrace — never hang. A wedged pion/mdns query used to block
+// forever (and keep multicasting, poisoning later receivers); callers
+// rely on a prompt miss to fall through to the pairing-server path.
+func TestQuery_MissIsBounded(t *testing.T) {
+	const timeout = 300 * time.Millisecond
+	start := time.Now()
+	res, err := Query(context.Background(), "zzz-wdog-tst", timeout)
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatalf("Query found a sender for a code nobody announces: %+v", res)
+	}
+	// Generous bound: timeout + watchdogGrace plus slack for -race CI.
+	if limit := timeout + watchdogGrace + 2*time.Second; elapsed > limit {
+		t.Errorf("Query took %v, want < %v", elapsed, limit)
+	}
+}
+
+// TestQuery_CancelledContext documents shutdown behavior: a cancelled
+// context must surface as a prompt error, not wait out the watchdog —
+// SIGINT during the LAN probe should not stall the exit path.
+func TestQuery_CancelledContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	start := time.Now()
+	if _, err := Query(ctx, "zzz-wdog-tst", 300*time.Millisecond); err == nil {
+		t.Fatal("Query with cancelled context returned no error")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("cancelled Query took %v, want < 1s", elapsed)
+	}
+}
 
 // TestPortForCode_Deterministic locks in the property both peers depend
 // on: same code derives the same UDP port, so the receiver knows where

--- a/internal/uxlog/format.go
+++ b/internal/uxlog/format.go
@@ -91,3 +91,11 @@ func Dim(s string) string {
 	}
 	return colorDim + s + colorReset
 }
+
+// Bold wraps s in the ANSI bold escape, unconditionally. Unlike Dim and
+// Code it carries no colour gate of its own: it decorates --help, which
+// cobra writes to stdout, so the caller must gate on stdout's state via
+// ColorFor — the stderr-keyed colorEnabled would be the wrong check.
+func Bold(s string) string {
+	return colorBold + s + colorReset
+}

--- a/internal/uxlog/glyphs.go
+++ b/internal/uxlog/glyphs.go
@@ -91,6 +91,7 @@ func glyphForKind(k glyphKind) (utf8, ascii, color string) {
 
 const (
 	colorReset    = "\x1b[0m"
+	colorBold     = "\x1b[1m"
 	colorRed      = "\x1b[31m"
 	colorGreen    = "\x1b[32m"
 	colorYellow   = "\x1b[33m"
@@ -120,19 +121,39 @@ func colorEnabled() bool {
 		return colorAllow
 	}
 	colorChecked = true
-	// NO_COLOR convention (https://no-color.org): the variable is
-	// "honoured" when set to any non-empty value. An empty value
-	// behaves as if unset.
-	if v := os.Getenv("NO_COLOR"); v != "" {
-		colorAllow = false
-		return false
-	}
-	if v := os.Getenv("FORCE_COLOR"); v != "" && v != "0" && v != "false" {
-		colorAllow = true
-		return true
+	if on, ok := colorEnvOverride(); ok {
+		colorAllow = on
+		return colorAllow
 	}
 	colorAllow = IsTTY(os.Stderr)
 	return colorAllow
+}
+
+// colorEnvOverride applies the de-facto standard env conventions.
+// NO_COLOR (https://no-color.org) is "honoured" when set to any
+// non-empty value → forced off; FORCE_COLOR (non-empty, not "0" or
+// "false") → forced on, even on non-TTYs. ok=false means neither var
+// is set — fall back to the target writer's TTY state.
+func colorEnvOverride() (on, ok bool) {
+	if v := os.Getenv("NO_COLOR"); v != "" {
+		return false, true
+	}
+	if v := os.Getenv("FORCE_COLOR"); v != "" && v != "0" && v != "false" {
+		return true, true
+	}
+	return false, false
+}
+
+// ColorFor reports whether ANSI colour should be emitted on w. Same
+// NO_COLOR / FORCE_COLOR rules as colorEnabled, but keyed to w's TTY
+// state instead of stderr's — for the few surfaces that write to
+// stdout (--help) rather than the stderr UX stream. Not cached: callers
+// are one-shot renders, not per-line emitters.
+func ColorFor(w io.Writer) bool {
+	if on, ok := colorEnvOverride(); ok {
+		return on
+	}
+	return IsTTY(w)
 }
 
 // resetColorForTesting is exposed so unit tests can flip env vars

--- a/internal/uxlog/glyphs_test.go
+++ b/internal/uxlog/glyphs_test.go
@@ -1,6 +1,7 @@
 package uxlog
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -39,6 +40,26 @@ func TestColorEnabled_ForceColor(t *testing.T) {
 	resetColorForTesting()
 	if !colorEnabled() {
 		t.Error("colorEnabled() = false despite FORCE_COLOR=1")
+	}
+}
+
+func TestColorFor(t *testing.T) {
+	var buf bytes.Buffer
+
+	t.Setenv("NO_COLOR", "")
+	t.Setenv("FORCE_COLOR", "")
+	if ColorFor(&buf) {
+		t.Error("ColorFor(non-TTY) = true with no env override")
+	}
+
+	t.Setenv("FORCE_COLOR", "1")
+	if !ColorFor(&buf) {
+		t.Error("ColorFor(non-TTY) = false despite FORCE_COLOR=1")
+	}
+
+	t.Setenv("NO_COLOR", "1")
+	if ColorFor(&buf) {
+		t.Error("NO_COLOR should win over FORCE_COLOR in ColorFor")
 	}
 }
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -79,6 +79,19 @@ detect_arch() {
     esac
 }
 
+# Releases only cover a subset of the os × arch product (see the ignore
+# list in .goreleaser.yml). Catch unbuilt combinations up front so the
+# user sees "no prebuilt binary" instead of a mystifying download 404.
+check_release_target() {
+    case "$1-$2" in
+        linux-amd64|linux-arm64|linux-386|linux-armv7) ;;
+        darwin-amd64|darwin-arm64) ;;
+        windows-amd64|windows-arm64|windows-386) ;;
+        freebsd-amd64|freebsd-arm64) ;;
+        *) err "no prebuilt binary for $1/$2 — build from source: go install github.com/${REPO}/cmd/fsend@latest" ;;
+    esac
+}
+
 default_prefix() {
     pf_os="$1"
     case "$pf_os" in
@@ -118,23 +131,6 @@ download() {
             || err "download failed: $url"
     else
         err "need curl or wget to download fsend"
-    fi
-}
-
-resolve_latest() {
-    api="https://api.github.com/repos/${REPO}/releases/latest"
-    # Same hardened TLS as download(): explicit https+TLS 1.2+ so a
-    # downgrade can't feed us a tampered tag and the rest of the install
-    # follows.
-    if command -v curl >/dev/null 2>&1; then
-        curl -fsSL --proto '=https' --tlsv1.2 "$api" \
-            | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' \
-            | head -n1
-    else
-        # shellcheck disable=SC2046
-        wget -q $(wget_tls_opts) -O- "$api" \
-            | sed -n 's/.*"tag_name": *"\([^"]*\)".*/\1/p' \
-            | head -n1
     fi
 }
 
@@ -228,36 +224,43 @@ main() {
 
     os="$(detect_os)"
     arch="$(detect_arch)"
+    check_release_target "$os" "$arch"
 
     if [ "$PREFIX_EXPLICIT" = "0" ]; then
         PREFIX="$(default_prefix "$os")"
     fi
 
+    tmp="$(mktemp -d 2>/dev/null || mktemp -d -t fsend)"
+    trap 'rm -rf "$tmp"' EXIT INT TERM HUP
+
     version="$FSEND_VERSION"
     if [ "$version" = "latest" ]; then
+        # Resolve "latest" through the plain release-asset redirect, NOT
+        # the GitHub API: unauthenticated API calls are capped at 60/hr
+        # per IP, which fails installs from shared egress IPs (offices,
+        # CI, universities). checksums.txt is needed anyway; the version
+        # is recovered from the archive names inside it, and the tag is
+        # rebuilt as "v<version>" (Go module tags are always v-prefixed).
         info "looking up latest release..."
-        version="$(resolve_latest)"
-        [ -n "$version" ] || err "could not resolve latest version"
+        download "https://github.com/${REPO}/releases/latest/download/checksums.txt" "$tmp/checksums.txt"
+        vnum="$(sed -n 's/.*[[:space:]]fsend_\([^_]*\)_.*/\1/p' "$tmp/checksums.txt" | head -n1)"
+        [ -n "$vnum" ] || err "could not resolve latest version"
+        version="v${vnum}"
+    else
+        vnum="${version#v}"
+        info "downloading checksums"
+        download "https://github.com/${REPO}/releases/download/${version}/checksums.txt" "$tmp/checksums.txt"
     fi
     info "installing fsend ${version} for ${os}-${arch} into ${PREFIX}"
 
-    vnum="${version#v}"
     case "$os" in
         windows) ext="zip";    bin_file="${BINARY}.exe" ;;
         *)       ext="tar.gz"; bin_file="${BINARY}"     ;;
     esac
     archive="fsend_${vnum}_${os}_${arch}.${ext}"
-    archive_url="https://github.com/${REPO}/releases/download/${version}/${archive}"
-    sums_url="https://github.com/${REPO}/releases/download/${version}/checksums.txt"
-
-    tmp="$(mktemp -d 2>/dev/null || mktemp -d -t fsend)"
-    trap 'rm -rf "$tmp"' EXIT INT TERM HUP
 
     info "downloading $archive"
-    download "$archive_url" "$tmp/$archive"
-
-    info "downloading checksums"
-    download "$sums_url" "$tmp/checksums.txt"
+    download "https://github.com/${REPO}/releases/download/${version}/${archive}" "$tmp/$archive"
 
     info "verifying checksum"
     verify_checksum "$tmp/$archive" "$tmp/checksums.txt"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -134,6 +134,42 @@ download() {
     fi
 }
 
+# winpath converts an MSYS/Cygwin path to a Windows path for native
+# tools (System32 tar.exe, PowerShell), which can't resolve /tmp/...
+# Falls through to the raw path where cygpath doesn't exist.
+winpath() {
+    cygpath -w "$1" 2>/dev/null || printf '%s' "$1"
+}
+
+# extract_zip unpacks a release zip with whatever the host actually has.
+# Git Bash — the shell the README points Windows users at — ships
+# neither unzip nor bsdtar in its own /usr/bin (its tar is GNU tar,
+# which cannot read zip), so the System32 bsdtar (Windows 10+) and
+# PowerShell fallbacks are the paths that fire there.
+extract_zip() {
+    zip="$1"
+    dest="$2"
+    if command -v unzip >/dev/null 2>&1; then
+        unzip -q "$zip" -d "$dest"
+        return
+    fi
+    if command -v tar >/dev/null 2>&1 && tar --version 2>/dev/null | grep -q bsdtar; then
+        tar -xf "$zip" -C "$dest"
+        return
+    fi
+    systar="${SYSTEMROOT:-C:\\Windows}/System32/tar.exe"
+    if [ -x "$systar" ]; then
+        "$systar" -xf "$(winpath "$zip")" -C "$(winpath "$dest")"
+        return
+    fi
+    if command -v powershell.exe >/dev/null 2>&1; then
+        powershell.exe -NoProfile -NonInteractive -Command \
+            "Expand-Archive -LiteralPath '$(winpath "$zip")' -DestinationPath '$(winpath "$dest")' -Force"
+        return
+    fi
+    err "no zip extractor found (need unzip, bsdtar, or PowerShell)"
+}
+
 verify_checksum() {
     archive="$1"
     sums="$2"
@@ -269,7 +305,7 @@ main() {
     info "extracting"
     case "$ext" in
         tar.gz) need tar; tar -xzf "$tmp/$archive" -C "$tmp" ;;
-        zip)    need unzip; unzip -q "$tmp/$archive" -d "$tmp" ;;
+        zip)    extract_zip "$tmp/$archive" "$tmp" ;;
     esac
     [ -f "$tmp/$bin_file" ] || err "binary $bin_file not found in archive"
 


### PR DESCRIPTION
## Summary

Three release-readiness fixes ahead of v1:

- **Windows install without unzip** — Git Bash (the shell the README points Windows users at) ships no `unzip`, so the documented one-liner died at extraction. `extract_zip` now falls back through `bsdtar`, the Windows 10+ System32 `tar.exe`, and PowerShell's `Expand-Archive`, converting paths via `cygpath` for the native tools.
- **Release pipeline validated locally** — full goreleaser snapshot (`release --snapshot --clean --skip=sign`): all 11 targets build, archive names and `checksums.txt` match `install.sh`'s expectations, version/commit/date injection verified, Windows zip layout correct, Docker image passes TLS client mode.
- **mDNS query watchdog** — `fsend <code>` could hang forever in LAN discovery: pion/mdns's `QueryAddr` was observed blowing past its context deadline, surviving SIGTERM, and re-multicasting its query every 100 ms — which wedged every later receiver querying the same name, so one stuck process poisoned all subsequent transfers with that code on the LAN (reproducible via the e2e suite under `-race`, which reuses the fixed code `abc-defg-jkm`). `landisc.Query` now runs the library behind a watchdog (timeout + 2 s grace): if pion wedges, the multicast sockets are force-closed — unblocking its read loop and killing the query spam — and the receiver falls through to the pairing-server path. Cancelled contexts (SIGINT mid-probe) return promptly, and the `mdns.Server` error path no longer leaks sockets. Healthy-path behavior is unchanged.

## Known residual risk (intentionally out of scope)

The sender's `landisc.Announce` conn uses the same pion `Close`; a wedged close there would stall sender teardown. Not observed in practice and the sender path is guarded by the LAN/internet pairing race, so it's left untouched to avoid regressions in pairing logic.

## Validation

- `go build`, `go vet`, `golangci-lint` (0 issues), `deadcode` (clean)
- Full suite fresh (`-count=1`) and full suite under `-race` — pass
- Two new regression tests pin the Query contract: a miss is time-bounded; a cancelled context returns fast
- Real end-to-end transfers with the patched binary: LAN path ("Direct on local network") and internet path through fsend.alzina.dev both verified

Note: GitHub Actions is currently failing for billing reasons (jobs die at start with a spending-limit error), so CI will not validate this PR until billing is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)