### PR TITLE
ux: pipe-clean progress, text/stdout receive, named summaries, prompt polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ fsend report.pdf                 # home Wi-Fi
 Share this code:  abc-defg-jkm
 
 $ fsend abc-defg-jkm               # café Wi-Fi, two continents away
-✓ Saved to ~/Downloads  ·  2.4 MB  ·  1.3s  ·  Direct over the internet
+✓ Saved report.pdf to ~/Downloads  ·  2.4 MB  ·  1.3s  ·  Direct over the internet
 ```
 
 ## About

--- a/cmd/fsend/connect.go
+++ b/cmd/fsend/connect.go
@@ -1,11 +1,13 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/polius/fsend/internal/config"
 	"github.com/polius/fsend/internal/fserrors"
@@ -110,7 +112,25 @@ func runConnect(f *flags) error {
 			msg += " (password set)"
 		}
 		fmt.Fprintln(os.Stderr, uxlog.Check(), msg)
+		warnIfUnresolvable(server)
 		return nil
+	}
+}
+
+// warnIfUnresolvable flags a server whose host doesn't resolve — almost
+// always a typo that would otherwise only surface later as E001 on
+// every transfer. The config is saved either way (the user may simply
+// be offline, or the name may exist only on another network).
+func warnIfUnresolvable(server string) {
+	host, _, err := net.SplitHostPort(server)
+	if err != nil || net.ParseIP(host) != nil || host == "localhost" {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if _, err := net.DefaultResolver.LookupHost(ctx, host); err != nil {
+		fmt.Fprintf(os.Stderr, "%s %q does not resolve from here — saved anyway.\n", uxlog.Warn(), host)
+		fmt.Fprintln(os.Stderr, "  Check the address, or revert with: fsend --connect default")
 	}
 }
 

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -669,10 +669,12 @@ func TestReadLine_BasicCases(t *testing.T) {
 
 func TestPromptAccept_QuietRequiresYes(t *testing.T) {
 	h := wire.SenderHello{TransferKind: wire.TransferSingleFile, DisplayName: "x", TotalBytes: 1}
-	if promptAccept(context.Background(), &flags{quiet: true}, h, "/tmp", mustLANInfo()) {
+	ui := newReceiverUI(context.Background(), &flags{quiet: true}, "/tmp", false, mustLANInfo())
+	if ui.promptAccept(h) {
 		t.Error("quiet without --yes must decline")
 	}
-	if !promptAccept(context.Background(), &flags{quiet: true, yes: true}, h, "/tmp", mustLANInfo()) {
+	ui = newReceiverUI(context.Background(), &flags{quiet: true, yes: true}, "/tmp", false, mustLANInfo())
+	if !ui.promptAccept(h) {
 		t.Error("quiet + --yes must accept")
 	}
 }
@@ -687,7 +689,8 @@ func TestPromptAccept_YesAcceptsAcrossKinds(t *testing.T) {
 	} {
 		got := captureStderr(t, func() {
 			h := wire.SenderHello{TransferKind: k, DisplayName: "x", TotalBytes: 1, TotalFiles: 1}
-			if !promptAccept(context.Background(), &flags{yes: true}, h, "/tmp", mustLANInfo()) {
+			ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
+			if !ui.promptAccept(h) {
 				t.Errorf("--yes must accept kind %v", k)
 			}
 		})
@@ -705,7 +708,8 @@ func TestPromptAccept_PasswordChipRendered(t *testing.T) {
 			TotalBytes:   1,
 			HasPassword:  true,
 		}
-		_ = promptAccept(context.Background(), &flags{yes: true}, h, "/tmp", mustLANInfo())
+		ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
+		_ = ui.promptAccept(h)
 	})
 	if !strings.Contains(got, "password required") {
 		t.Errorf("expected password chip, got:\n%s", got)

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"runtime"
 	"strings"
 	"sync"
 	"time"
@@ -25,7 +24,6 @@ import (
 	"github.com/polius/fsend/internal/transfer"
 	"github.com/polius/fsend/internal/uxlog"
 	"github.com/polius/fsend/internal/version"
-	"github.com/polius/fsend/internal/wire"
 )
 
 // iceBudget caps the total time we'll spend trying to establish a direct
@@ -357,22 +355,23 @@ func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code 
 	tr := &quic.Transport{Conn: pc}
 	defer func() { _ = tr.Close() }()
 
-	outDir := f.outDir
-	if outDir == "" {
-		var err error
-		outDir, err = os.Getwd()
-		if err != nil {
-			return err
-		}
+	outDir, sink, err := resolveOutDir(f)
+	if err != nil {
+		return err
 	}
-
-	closeProg, accept, confirmOverwrite, progressFn, recvBytes := newReceiverProgress(ctx, f, outDir, pathInfo)
-	defer closeProg()
+	ui := newReceiverUI(ctx, f, outDir, sink, pathInfo)
+	defer ui.close()
 
 	start := time.Now()
-	if err := retry.WithBackoff(ctx, retry.Options{OnRetry: retryNoticeFor(f)}, nil,
+	// Sink mode gets one attempt: emitted bytes can't be reconciled, so
+	// a retry would duplicate output.
+	opts := retry.Options{OnRetry: retryNoticeFor(f)}
+	if sink {
+		opts.Attempts = 1
+	}
+	if err := retry.WithBackoff(ctx, opts, nil,
 		func(attempt int) error {
-			return runReceiverOneAttempt(ctx, tr, outDir, f, accept, confirmOverwrite, progressFn, code)
+			return runReceiverOneAttempt(ctx, tr, f, ui, code)
 		}); err != nil {
 		// A Ctrl-C at an interactive prompt cancels ctx but surfaces as a
 		// decline/target-exists error; report it as a cancellation (E026).
@@ -381,16 +380,13 @@ func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code 
 		}
 		return err
 	}
-	// Flush bar before summary; see receive.go for the streaming-stdin reason.
-	closeProg()
-	printRecvSummary(f, displayPath(outDir), recvBytes(), time.Since(start), pathInfo)
-	return nil
+	return finishReceive(f, ui, time.Since(start))
 }
 
 // runReceiverOneAttempt is one Dial → handshake → transfer iteration.
 // Mirror of runSenderOneAttempt; returns nil on success or an error for
 // the retry layer to classify.
-func runReceiverOneAttempt(ctx context.Context, tr *quic.Transport, outDir string, f *flags, accept func(wire.SenderHello) bool, confirmOverwrite func(string, int64, uint64) bool, progressFn func(uint32, uint64), code string) error {
+func runReceiverOneAttempt(ctx context.Context, tr *quic.Transport, f *flags, ui *receiverUI, code string) error {
 	dialCtx, dialCancel := context.WithTimeout(ctx, 15*time.Second)
 	defer dialCancel()
 	// The PacketConn ignores the dial address (both relay.Conn and our
@@ -408,18 +404,7 @@ func runReceiverOneAttempt(ctx context.Context, tr *quic.Transport, outDir strin
 	}
 	defer res.Close()
 
-	return transfer.Recv(ctx, &res.Streams, transfer.RecvOptions{
-		Hostname:         hostnameOrDefault(f.hostname),
-		OS:               runtime.GOOS,
-		ClientVersion:    version.Version,
-		TargetDir:        outDir,
-		Overwrite:        f.overwrite,
-		Accept:           accept,
-		Password:         f.passArg,
-		PromptPass:       receiverPasswordPrompt(ctx, f),
-		ConfirmOverwrite: confirmOverwrite,
-		ProgressFn:       progressFn,
-	})
+	return transfer.Recv(ctx, &res.Streams, ui.recvOptions(hostnameOrDefault(f.hostname)))
 }
 
 // retryNoticeFor returns an OnRetry callback that prints the standard
@@ -467,26 +452,23 @@ func hostnameOrDefault(s string) string {
 	return h
 }
 
-// printPath renders the connection-path status line. Tri-state:
-//
-//	✓ Direct on local network   — same network, no NAT crossed
-//	✓ Direct over the internet  — direct peer-to-peer; NAT hole-punched
-//	⚠ Relayed via <relay-host>  — direct failed, bytes flow through the relay
-//
-// In --debug mode, a second line shows the selected ICE candidate types
-// ("host → srflx" etc.) — useful for diagnosing why a peer ended up on a
-// particular path. --quiet suppresses both lines.
+// printPath renders the connection-path status line. Only the relay
+// path warrants a standalone headline (⚠ Relayed via <host> — the one
+// route users should know about before bytes flow); direct paths stay
+// silent here because the summary line already carries the path tag,
+// and repeating it read as padding. --debug restores the headline for
+// every path plus the selected ICE candidate types. --quiet suppresses
+// everything.
 func printPath(f *flags, info connpath.Info) {
 	if f.quiet {
 		return
 	}
-	var prefix string
-	if info.Kind == connpath.KindRelay {
-		prefix = uxlog.Warn()
-	} else {
-		prefix = uxlog.Check()
+	switch {
+	case info.Kind == connpath.KindRelay:
+		fmt.Fprintln(os.Stderr, uxlog.Warn(), info.Headline())
+	case f.debug:
+		fmt.Fprintln(os.Stderr, uxlog.Check(), info.Headline())
 	}
-	fmt.Fprintln(os.Stderr, prefix, info.Headline())
 	if f.debug {
 		if d := info.Detail(); d != "" {
 			fmt.Fprintln(os.Stderr, "    ICE candidate pair:", d)

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -17,6 +17,7 @@ import (
 	"strings"
 
 	"github.com/polius/fsend/internal/code"
+	"github.com/polius/fsend/internal/config"
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/uxlog"
 )
@@ -145,6 +146,13 @@ func renderError(err error, debug bool) int {
 	//   - usage / source-not-found: the missing path or bad flag.
 	//   - relay-limit hits: the server's configured limit ("100 MiB").
 	detail := ""
+	// E001 names the server it tried so a stale --connect entry is
+	// self-diagnosing instead of reading as a network outage.
+	if errors.Is(err, fserrors.ErrServerUnreachable) {
+		if cfg, cfgErr := config.Load(); cfgErr == nil {
+			detail = "Server: " + cfg.EffectiveServer()
+		}
+	}
 	if known && (errors.Is(err, fserrors.ErrUsage) ||
 		errors.Is(err, fserrors.ErrSourceNotFound) ||
 		errors.Is(err, fserrors.ErrRelayCapHit) ||

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -20,7 +19,6 @@ import (
 	"github.com/polius/fsend/internal/retry"
 	"github.com/polius/fsend/internal/transfer"
 	"github.com/polius/fsend/internal/uxlog"
-	"github.com/polius/fsend/internal/version"
 	"github.com/polius/fsend/internal/wire"
 )
 
@@ -36,6 +34,10 @@ func runReceive(f *flags, c string) error {
 	// decline. Fail fast with a clear hint instead.
 	if f.quiet && !f.yes {
 		return fmt.Errorf("%w: --quiet on receive requires --yes (no prompt to answer otherwise)", fserrors.ErrUsage)
+	}
+	// Sink mode writes no files, so --overwrite can only be a mistake.
+	if f.outDir == "-" && f.overwrite {
+		return fmt.Errorf("%w: --overwrite has no effect with --out -", fserrors.ErrUsage)
 	}
 
 	// Bare --pass: hidden no-echo prompt. We're not the password's
@@ -71,17 +73,9 @@ func runReceive(f *flags, c string) error {
 		fmt.Fprintln(os.Stderr, "    sender address:", addr)
 	}
 
-	hostname := f.hostname
-	if hostname == "" {
-		hostname, _ = os.Hostname()
-	}
-
-	outDir := f.outDir
-	if outDir == "" {
-		outDir, err = os.Getwd()
-		if err != nil {
-			return err
-		}
+	outDir, sink, err := resolveOutDir(f)
+	if err != nil {
+		return err
 	}
 
 	// First LAN dial sits outside the retry loop. If it fails before
@@ -105,17 +99,21 @@ func runReceive(f *flags, c string) error {
 		return runReceiveOverInternet(ctx, f, c, cfg, connSpin)
 	}
 
-	pathInfo := connpath.FromLAN()
-	closeProg, accept, confirmOverwrite, progressFn, recvBytes := newReceiverProgress(ctx, f, outDir, pathInfo)
-	defer closeProg()
+	ui := newReceiverUI(ctx, f, outDir, sink, connpath.FromLAN())
+	defer ui.close()
 
 	start := time.Now()
 
 	// LAN succeeded once — keep a normal retry loop around the transfer
 	// itself so a mid-stream drop can re-dial and resume from the
-	// receiver's partial.
+	// receiver's partial. Sink mode gets one attempt: emitted bytes
+	// can't be reconciled, so a retry would duplicate output.
+	opts := retry.Options{OnRetry: retryNoticeFor(f)}
+	if sink {
+		opts.Attempts = 1
+	}
 	current := first
-	if err := retry.WithBackoff(ctx, retry.Options{OnRetry: retryNoticeFor(f)}, nil,
+	if err := retry.WithBackoff(ctx, opts, nil,
 		func(attempt int) error {
 			if current == nil {
 				res, err := quicconn.Dial(ctx, addr, c)
@@ -127,18 +125,7 @@ func runReceive(f *flags, c string) error {
 			res := current
 			current = nil
 			defer res.Close()
-			return transfer.Recv(ctx, &res.Streams, transfer.RecvOptions{
-				Hostname:         hostname,
-				OS:               runtime.GOOS,
-				ClientVersion:    version.Version,
-				TargetDir:        outDir,
-				Overwrite:        f.overwrite,
-				Accept:           accept,
-				Password:         f.passArg,
-				PromptPass:       receiverPasswordPrompt(ctx, f),
-				ConfirmOverwrite: confirmOverwrite,
-				ProgressFn:       progressFn,
-			})
+			return transfer.Recv(ctx, &res.Streams, ui.recvOptions(hostnameOrDefault(f.hostname)))
 		}); err != nil {
 		// A Ctrl-C at an interactive prompt cancels ctx but surfaces as a
 		// decline/target-exists error from the engine; report it as a
@@ -149,12 +136,7 @@ func runReceive(f *flags, c string) error {
 		return err
 	}
 
-	// Flush the bar before the summary so the "Saved to ..." line lands
-	// below the terminal " done" frame on streaming items (stdin), where
-	// SetTotal+Done would otherwise fire later via the deferred call.
-	closeProg()
-	printRecvSummary(f, displayPath(outDir), recvBytes(), time.Since(start), pathInfo)
-	return nil
+	return finishReceive(f, ui, time.Since(start))
 }
 
 // receiverPasswordPrompt returns a callback that reads a password from
@@ -180,54 +162,6 @@ func receiverPasswordPrompt(ctx context.Context, f *flags) func() (string, error
 	}
 }
 
-// promptAccept renders the incoming-transfer block on stderr and asks
-// whether to receive. The block layout is the same regardless of kind:
-//
-//	Incoming from <peer>  [· via relay]
-//
-//	    <artifact>  ·  <size>  [🔒 password]
-//	    [⚠ already in <dir> · will overwrite if you accept]
-//
-//	Save to <path>/? [Y/n]
-//
-// pathInfo only affects the chip on the peer line (direct paths are
-// quiet, relay gets called out — it's the one users should be aware of).
-// outDir
-// is needed to (a) render the save target and (b) detect a single-file
-// collision so we can surface it inline instead of asking a second
-// question after the user has already said yes.
-func promptAccept(ctx context.Context, f *flags, h wire.SenderHello, outDir string, pathInfo connpath.Info) bool {
-	if f.quiet {
-		return f.yes
-	}
-	peer := sanitizeRemote(h.Hostname)
-	pathChip := ""
-	if pathInfo.Kind == connpath.KindRelay {
-		pathChip = uxlog.Dim("  ·  via relay")
-	}
-	fmt.Fprintln(os.Stderr)
-	fmt.Fprintf(os.Stderr, "  Incoming from %s%s\n", peer, pathChip)
-	fmt.Fprintln(os.Stderr)
-	renderArtifact(os.Stderr, h, outDir, f.overwrite)
-	fmt.Fprintln(os.Stderr)
-	if f.yes {
-		fmt.Fprintln(os.Stderr, uxlog.Check(), "Accepting (--yes)")
-		return true
-	}
-	fmt.Fprintf(os.Stderr, "  Save to %s? [Y/n] ", saveTargetLabel(outDir))
-	// Decline on Ctrl-C; the caller maps a cancelled ctx to E026.
-	line, ok := readLineCtx(ctx)
-	if !ok {
-		return false
-	}
-	switch line {
-	case "n", "no":
-		return false
-	default:
-		return true
-	}
-}
-
 // renderArtifact prints the indented artifact line and (for a single
 // file that would collide) the warning chip that pre-discloses the
 // overwrite. The chip means the user only ever sees one question per
@@ -246,7 +180,8 @@ func renderArtifact(w io.Writer, h wire.SenderHello, outDir string, alreadyOverw
 			name = "file"
 		}
 		_, _ = fmt.Fprintf(w, "      %s  ·  %s%s\n", name, uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)
-		if !alreadyOverwriting {
+		// outDir is "" in sink mode — nothing on disk to collide with.
+		if !alreadyOverwriting && outDir != "" {
 			target := filepath.Join(outDir, name)
 			if st, err := os.Stat(target); err == nil && !st.IsDir() {
 				chip := fmt.Sprintf("⚠ already in %s (%s) — will be overwritten if you accept",
@@ -262,7 +197,7 @@ func renderArtifact(w io.Writer, h wire.SenderHello, outDir string, alreadyOverw
 		_, _ = fmt.Fprintf(w, "      %s  ·  %d files  ·  %s%s\n",
 			name, h.TotalFiles, uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)
 	case wire.TransferMultiFile:
-		_, _ = fmt.Fprintf(w, "      %d items  ·  %s%s\n",
+		_, _ = fmt.Fprintf(w, "      %d files  ·  %s%s\n",
 			h.TotalFiles, uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)
 	case wire.TransferText:
 		_, _ = fmt.Fprintf(w, "      text  ·  %s%s\n",

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -1,0 +1,336 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync"
+	"time"
+
+	"golang.org/x/term"
+
+	"github.com/polius/fsend/internal/connpath"
+	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/transfer"
+	"github.com/polius/fsend/internal/uxlog"
+	"github.com/polius/fsend/internal/version"
+	"github.com/polius/fsend/internal/wire"
+)
+
+// receiverUI bundles the receive-side engine callbacks (accept prompt,
+// progress bar, overwrite confirm) with the state they share: the
+// sender's HELLO, the finalized file paths, and the byte counter the
+// summary reports. One instance serves a whole receive, including
+// retries.
+//
+// The progress bar is created lazily on the first byte rather than at
+// accept time — the password handshake may still need to prompt on
+// stderr, and a rejected transfer must leave no half-rendered bar.
+type receiverUI struct {
+	ctx      context.Context
+	f        *flags
+	outDir   string // absolute; "" in sink mode
+	sink     bool
+	pathInfo connpath.Info
+
+	mu             sync.Mutex
+	hello          *wire.SenderHello
+	files          []string
+	prev           map[uint32]uint64
+	total          int64
+	bar            *uxlog.Progress
+	totalBytesHint int64
+	streamingTotal bool // HELLO carried TotalBytes=0 (piped stdin)
+	preApproved    bool // accept prompt already disclosed the overwrite
+
+	closeOnce sync.Once
+}
+
+func newReceiverUI(ctx context.Context, f *flags, outDir string, sink bool, pathInfo connpath.Info) *receiverUI {
+	return &receiverUI{
+		ctx: ctx, f: f, outDir: outDir, sink: sink, pathInfo: pathInfo,
+		prev: make(map[uint32]uint64),
+	}
+}
+
+// resolveOutDir resolves --out: "-" selects sink (stdout) mode, ""
+// defaults to the CWD. Directories come back absolute so the prompt and
+// the summary show a stable path regardless of how the user spelled it.
+func resolveOutDir(f *flags) (dir string, sink bool, err error) {
+	if f.outDir == "-" {
+		return "", true, nil
+	}
+	dir = f.outDir
+	if dir == "" {
+		if dir, err = os.Getwd(); err != nil {
+			return "", false, err
+		}
+	}
+	if abs, absErr := filepath.Abs(dir); absErr == nil {
+		dir = abs
+	}
+	return dir, false, nil
+}
+
+// recvOptions assembles the engine options around this UI's callbacks.
+func (ui *receiverUI) recvOptions(hostname string) transfer.RecvOptions {
+	o := transfer.RecvOptions{
+		Hostname:      hostname,
+		OS:            runtime.GOOS,
+		ClientVersion: version.Version,
+		TargetDir:     ui.outDir,
+		Overwrite:     ui.f.overwrite,
+		Accept:        ui.accept,
+		Password:      ui.f.passArg,
+		PromptPass:    receiverPasswordPrompt(ui.ctx, ui.f),
+		ProgressFn:    ui.progress,
+		OnFileDone:    ui.onFileDone,
+	}
+	if ui.sink {
+		o.Sink = os.Stdout
+	}
+	// Under --quiet or --yes the confirm stays nil: the engine then
+	// rejects collisions with E013 instead of silently overwriting or
+	// blocking on a prompt nobody will answer.
+	if !ui.f.quiet && !ui.f.yes {
+		o.ConfirmOverwrite = ui.confirmOverwrite
+	}
+	return o
+}
+
+// accept records the HELLO, runs the prompt, and pre-approves the
+// per-file overwrite confirm when the prompt already disclosed the
+// collision — the user answers one question, not two.
+func (ui *receiverUI) accept(h wire.SenderHello) bool {
+	ui.mu.Lock()
+	cp := h
+	ui.hello = &cp
+	ui.totalBytesHint = int64(h.TotalBytes)
+	ui.streamingTotal = h.TotalBytes == 0
+	ui.mu.Unlock()
+
+	if !ui.promptAccept(h) {
+		return false
+	}
+	if !ui.sink && h.TransferKind == wire.TransferSingleFile && !ui.f.overwrite {
+		target := filepath.Join(ui.outDir, h.DisplayName)
+		if st, err := os.Stat(target); err == nil && !st.IsDir() {
+			ui.mu.Lock()
+			ui.preApproved = true
+			ui.mu.Unlock()
+		}
+	}
+	return true
+}
+
+// promptAccept renders the incoming-transfer block on stderr and asks
+// whether to receive:
+//
+//	Incoming from <peer>  [· via relay]
+//
+//	    <artifact>  ·  <size>  [🔒 password]
+//	    [⚠ already in <dir> · will overwrite if you accept]
+//
+//	Save to <path>/? [Y/n]
+//
+// The question adapts to the destination: "Write to stdout?" in sink
+// mode, "Accept?" for text (which prints rather than saves).
+// Unrecognized input re-prompts instead of defaulting — a stray typo
+// next to 'n' must not accept a transfer.
+func (ui *receiverUI) promptAccept(h wire.SenderHello) bool {
+	f := ui.f
+	if f.quiet {
+		return f.yes
+	}
+	peer := sanitizeRemote(h.Hostname)
+	pathChip := ""
+	if ui.pathInfo.Kind == connpath.KindRelay {
+		pathChip = uxlog.Dim("  ·  via relay")
+	}
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "  Incoming from %s%s\n", peer, pathChip)
+	fmt.Fprintln(os.Stderr)
+	renderArtifact(os.Stderr, h, ui.outDir, f.overwrite)
+	fmt.Fprintln(os.Stderr)
+	if f.yes {
+		fmt.Fprintln(os.Stderr, uxlog.Check(), "Accepting (--yes)")
+		return true
+	}
+	question := "Save to " + saveTargetLabel(ui.outDir) + "?"
+	switch {
+	case ui.sink:
+		question = "Write to stdout?"
+	case h.TransferKind == wire.TransferText:
+		question = "Accept?"
+	}
+	for {
+		fmt.Fprintf(os.Stderr, "  %s [Y/n] ", question)
+		// Decline on Ctrl-C; the caller maps a cancelled ctx to E026.
+		line, ok := readLineCtx(ui.ctx)
+		if !ok {
+			return false
+		}
+		switch line {
+		case "", "y", "yes":
+			return true
+		case "n", "no":
+			return false
+		}
+		fmt.Fprintln(os.Stderr, "  Please answer y or n.")
+	}
+}
+
+func (ui *receiverUI) confirmOverwrite(relPath string, existing int64, incoming uint64) bool {
+	ui.mu.Lock()
+	pre := ui.preApproved
+	ui.mu.Unlock()
+	if pre {
+		return true
+	}
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "  %s already exists  ·  local %s  ·  incoming %s\n",
+		relPath, uxlog.HumanBytes(existing), uxlog.HumanBytes(int64(incoming)))
+	fmt.Fprint(os.Stderr, "  Overwrite? [y/N] ")
+	line, ok := readLineCtx(ui.ctx)
+	if !ok {
+		return false
+	}
+	switch line {
+	case "y", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func (ui *receiverUI) progress(fileIndex uint32, bytesWritten uint64) {
+	ui.mu.Lock()
+	defer ui.mu.Unlock()
+	if ui.bar == nil && !ui.f.quiet {
+		ui.bar = uxlog.New(ui.totalBytesHint)
+	}
+	d := bytesWritten - ui.prev[fileIndex]
+	ui.prev[fileIndex] = bytesWritten
+	ui.total += int64(d)
+	ui.bar.Add(int64(d)) // nil-safe under --quiet
+}
+
+func (ui *receiverUI) onFileDone(path string) {
+	ui.mu.Lock()
+	ui.files = append(ui.files, path)
+	ui.mu.Unlock()
+}
+
+func (ui *receiverUI) bytes() int64 {
+	ui.mu.Lock()
+	defer ui.mu.Unlock()
+	return ui.total
+}
+
+// close flushes the progress bar. Idempotent: callers flush explicitly
+// before the summary and keep a deferred call as the safety net.
+func (ui *receiverUI) close() {
+	ui.closeOnce.Do(func() {
+		ui.mu.Lock()
+		bar, total, streaming := ui.bar, ui.total, ui.streamingTotal
+		ui.mu.Unlock()
+		if bar == nil {
+			return
+		}
+		// Streaming transfers latch the bar to the real total so the
+		// terminal frame reads "done" instead of "aborted".
+		if streaming && total > 0 {
+			bar.SetTotal(total, true)
+		}
+		bar.Done()
+	})
+}
+
+// finishReceive runs the post-transfer epilogue: flush the bar, print a
+// received --text payload to stdout (text is a message, not a download),
+// and render the summary.
+func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
+	ui.close()
+
+	ui.mu.Lock()
+	h := ui.hello
+	files := append([]string(nil), ui.files...)
+	ui.mu.Unlock()
+
+	if h != nil && h.TransferKind == wire.TransferText && !ui.sink {
+		if err := printTextPayload(files); err != nil {
+			return err
+		}
+		printRecvSummary(f, "Received text", ui.bytes(), elapsed, ui.pathInfo)
+		return nil
+	}
+	printRecvSummary(f, ui.headline(h, files), ui.bytes(), elapsed, ui.pathInfo)
+	return nil
+}
+
+// printTextPayload writes the received text to stdout and removes the
+// carrier file. Terminal output gains a trailing newline so the shell
+// prompt doesn't glue to the payload; piped output stays byte-exact.
+func printTextPayload(files []string) error {
+	if len(files) == 0 {
+		return nil
+	}
+	b, err := os.ReadFile(files[0])
+	if err != nil {
+		return fmt.Errorf("%w: text payload: %v", fserrors.ErrReadFailed, err)
+	}
+	_ = os.Remove(files[0])
+	if _, err := os.Stdout.Write(b); err != nil {
+		return err
+	}
+	if len(b) > 0 && b[len(b)-1] != '\n' && term.IsTerminal(int(os.Stdout.Fd())) {
+		fmt.Println()
+	}
+	return nil
+}
+
+// headline names what landed where for the summary line: "Saved
+// hello.bin to ~/dir", "Saved 3 files to ~/dir", or bare "Received" in
+// sink mode. The piped-stdin name is only knowable from the finalized
+// path (the sender generates it), hence the files fallback.
+func (ui *receiverUI) headline(h *wire.SenderHello, files []string) string {
+	if ui.sink {
+		return "Received"
+	}
+	name := ""
+	if h != nil {
+		switch h.TransferKind {
+		case wire.TransferSingleFile, wire.TransferDirectory:
+			name = sanitizeForDisplay(h.DisplayName, 128)
+		case wire.TransferMultiFile:
+			name = fmt.Sprintf("%d files", h.TotalFiles)
+		case wire.TransferStdin:
+			if len(files) > 0 {
+				name = filepath.Base(files[0])
+			}
+		}
+	}
+	dest := displayPath(ui.outDir)
+	if name == "" {
+		return "Saved to " + dest
+	}
+	return "Saved " + name + " to " + dest
+}
+
+// printRecvSummary renders the post-transfer success line. headline is
+// the fully-formed "Saved X to Y" / "Received" clause; the parts that
+// follow scan size → time → route. Suppressed under --quiet.
+func printRecvSummary(f *flags, headline string, bytes int64, elapsed time.Duration, path connpath.Info) {
+	if f.quiet {
+		return
+	}
+	if headline == "" {
+		headline = "Received"
+	}
+	parts := summaryParts(bytes, elapsed, path)
+	fmt.Fprintf(os.Stderr, "%s %s  ·  %s\n", uxlog.Check(), headline, strings.Join(parts, "  ·  "))
+	printUpdateNotice(f)
+}

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -189,7 +189,8 @@ EXAMPLES
 
 COMMON FLAGS
   --text "<string>"      Send a literal string instead of a file
-                         (the receiver prints it — nothing is saved)
+                         (the receiver prints it — nothing is saved;
+                         keep it with: fsend <code> > note.txt)
   --pass <password>      Require the receiver to enter a password.
                          Bare --pass prompts interactively — sender side
                          suggests a fresh random default (press Enter to

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -189,11 +189,14 @@ EXAMPLES
 
 COMMON FLAGS
   --text "<string>"      Send a literal string instead of a file
+                         (the receiver prints it — nothing is saved)
   --pass <password>      Require the receiver to enter a password.
                          Bare --pass prompts interactively — sender side
                          suggests a fresh random default (press Enter to
                          accept). Env: FSEND_PASS.
   --out <dir>            Receive into this directory (default: current)
+  --out -                Receive to stdout (single file, text, or piped
+                         stream — pipe-friendly: fsend <code> --out - | …)
   --yes                  Auto-accept incoming transfers (no prompt)
   --overwrite            Overwrite existing files on receive
   --quiet                Suppress all non-error output
@@ -221,6 +224,10 @@ ENVIRONMENT
 SELF-HOSTING
   fsend server                 Run your own pairing + relay server
                                (env-var config — see "fsend server --help")
+
+SHELL COMPLETIONS
+  fsend completion <shell>     Print a completion script
+                               (bash, zsh, fish, powershell)
 
 LEARN MORE
   Docs    https://github.com/polius/fsend

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"strings"
-	"sync"
 	"syscall"
 	"time"
 
@@ -140,7 +139,7 @@ func collectItems(f *flags, paths []string) ([]transfer.SourceItem, wire.Transfe
 		// directory-resolved file).
 		return items, wire.TransferSingleFile, 0, filepath.Base(paths[0]), noop, nil
 	}
-	return items, wire.TransferMultiFile, 0, fmt.Sprintf("%d items", len(paths)), noop, nil
+	return items, wire.TransferMultiFile, 0, fmt.Sprintf("%d files", len(paths)), noop, nil
 }
 
 // containsDirectory reports whether any of paths refers to a directory.
@@ -291,7 +290,7 @@ func printSendArtifact(f *flags, c string, items []transfer.SourceItem, kind wir
 		fmt.Fprintf(os.Stderr, "  Sending  %s  ·  %d files  ·  %s\n",
 			label, totalFiles, uxlog.HumanBytes(int64(total)))
 	case wire.TransferMultiFile:
-		fmt.Fprintf(os.Stderr, "  Sending  %d items  ·  %s\n",
+		fmt.Fprintf(os.Stderr, "  Sending  %d files  ·  %s\n",
 			len(items), uxlog.HumanBytes(totalBytes(items)))
 	case wire.TransferText:
 		fmt.Fprintf(os.Stderr, "  Sending  text  ·  %s\n",
@@ -376,125 +375,6 @@ func newSenderProgress(f *flags, items []transfer.SourceItem) (closeFn func(), p
 		}
 }
 
-// newReceiverProgress is the receive-side counterpart. The bar is
-// materialized lazily on the first ProgressFn call rather than at
-// Accept time. This matters because:
-//
-//   - Between Accept returning true and the first chunk arriving, the
-//     transfer engine runs the password handshake (when the sender used
-//     --pass). The handshake calls PromptPass, which writes a prompt to
-//     stderr and reads a line back. If mpb were already drawing the bar
-//     at Accept time, its 10 Hz repaint goroutine would step on the
-//     password prompt line.
-//   - Deferring also means a rejected transfer (Accept false, wrong
-//     password, sender abort before any chunk) leaves no half-rendered
-//     bar on screen — closeFn is a no-op if the bar was never created.
-func newReceiverProgress(ctx context.Context, f *flags, outDir string, pathInfo connpath.Info) (
-	closeFn func(),
-	accept func(wire.SenderHello) bool,
-	confirmOverwrite func(relPath string, existing int64, incoming uint64) bool,
-	progressFn func(uint32, uint64),
-	recvBytes func() int64,
-) {
-	prev := make(map[uint32]uint64)
-	var total int64
-	recvBytes = func() int64 { return total }
-
-	// preApproved fires when promptAccept already surfaced a single-file
-	// collision chip and the user said yes — the second "Overwrite? y/N"
-	// question would just be friction. Captured here so both callbacks
-	// share the flag without a parameter on RecvOptions.
-	var preApproved bool
-
-	if f.quiet {
-		closeFn = func() {}
-		accept = func(h wire.SenderHello) bool { return promptAccept(ctx, f, h, outDir, pathInfo) }
-		progressFn = func(fi uint32, b uint64) {
-			d := b - prev[fi]
-			prev[fi] = b
-			total += int64(d)
-		}
-		// confirmOverwrite stays nil under --quiet: the engine then
-		// rejects with E013 rather than blocking on a prompt nobody
-		// will see.
-		return
-	}
-
-	var bar *uxlog.Progress
-	var totalBytesHint int64
-	// streamingTotal is true when the sender's HELLO carried TotalBytes=0,
-	// which today only happens for piped stdin. The bar then renders
-	// without ETA/percentage; at close we latch it to the accumulated
-	// count so the trailing " done" suffix prints instead of "aborted".
-	var streamingTotal bool
-	accept = func(h wire.SenderHello) bool {
-		ok := promptAccept(ctx, f, h, outDir, pathInfo)
-		if !ok {
-			return false
-		}
-		totalBytesHint = int64(h.TotalBytes)
-		streamingTotal = h.TotalBytes == 0
-		// Mirror the renderArtifact collision check: if the prompt
-		// already disclosed an overwrite, treat the user's yes as
-		// consent for the per-file confirm too.
-		if h.TransferKind == wire.TransferSingleFile && !f.overwrite {
-			target := filepath.Join(outDir, h.DisplayName)
-			if st, err := os.Stat(target); err == nil && !st.IsDir() {
-				preApproved = true
-			}
-		}
-		return true
-	}
-	progressFn = func(fileIndex uint32, bytesWritten uint64) {
-		if bar == nil {
-			bar = uxlog.New(totalBytesHint)
-		}
-		d := bytesWritten - prev[fileIndex]
-		prev[fileIndex] = bytesWritten
-		bar.Add(int64(d))
-		total += int64(d)
-	}
-	// Idempotent: callers can flush the bar explicitly before printing
-	// the summary, then leave the deferred call as a no-op safety net.
-	// Without that, stdin transfers (streamingTotal=true) print the
-	// summary above the bar's terminal frame.
-	var closeOnce sync.Once
-	closeFn = func() {
-		closeOnce.Do(func() {
-			if bar == nil {
-				return
-			}
-			if streamingTotal && total > 0 {
-				bar.SetTotal(total, true)
-			}
-			bar.Done()
-		})
-	}
-	if !f.yes {
-		confirmOverwrite = func(relPath string, existing int64, incoming uint64) bool {
-			if preApproved {
-				return true
-			}
-			fmt.Fprintln(os.Stderr)
-			fmt.Fprintf(os.Stderr, "  %s already exists  ·  local %s  ·  incoming %s\n",
-				relPath, uxlog.HumanBytes(existing), uxlog.HumanBytes(int64(incoming)))
-			fmt.Fprint(os.Stderr, "  Overwrite? [y/N] ")
-			// Decline on Ctrl-C; the caller maps a cancelled ctx to E026.
-			line, ok := readLineCtx(ctx)
-			if !ok {
-				return false
-			}
-			switch line {
-			case "y", "yes":
-				return true
-			default:
-				return false
-			}
-		}
-	}
-	return
-}
-
 // printSendSummary renders the post-transfer success line on the sender.
 // The artifact name is already shown in printSendArtifact at session
 // start, so the summary deliberately omits it — repeating reads as
@@ -508,29 +388,6 @@ func printSendSummary(f *flags, bytes int64, elapsed time.Duration, path connpat
 	}
 	parts := summaryParts(bytes, elapsed, path)
 	fmt.Fprintf(os.Stderr, "%s Sent  ·  %s\n", uxlog.Check(), strings.Join(parts, "  ·  "))
-	printUpdateNotice(f)
-}
-
-// printRecvSummary is the receive-side counterpart. The bytes figure is
-// the actual received payload, captured by the progress callback so the
-// number reflects what's on disk (post-resume, this can be less than the
-// sender's TotalBytes if a prefix was already present).
-//
-// destLabel is the human-readable save location ("~/Downloads" or an
-// absolute path). When empty (text/stdin sinks, --quiet) the line
-// collapses to "Received".
-func printRecvSummary(f *flags, destLabel string, bytes int64, elapsed time.Duration, path connpath.Info) {
-	if f.quiet {
-		return
-	}
-	parts := summaryParts(bytes, elapsed, path)
-	if destLabel != "" {
-		fmt.Fprintf(os.Stderr, "%s Saved to %s  ·  %s\n",
-			uxlog.Check(), destLabel, strings.Join(parts, "  ·  "))
-		printUpdateNotice(f)
-		return
-	}
-	fmt.Fprintf(os.Stderr, "%s Received  ·  %s\n", uxlog.Check(), strings.Join(parts, "  ·  "))
 	printUpdateNotice(f)
 }
 

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -512,6 +512,9 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 	if bytes == 0 {
 		bytes = totalBytes(items)
 	}
+	// Flush the bar first so its terminal frame lands above the summary
+	// (the deferred call is then a no-op).
+	closeProg()
 	printSendSummary(f, bytes, time.Since(start), pathInfo)
 	return nil
 }

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -26,9 +26,9 @@ func runUninstall(f *flags) error {
 	if cfgPath != "" {
 		dir := filepath.Dir(cfgPath)
 		if err := os.RemoveAll(dir); err == nil {
-			fmt.Fprintf(os.Stderr, "  %s Removed config dir: %s\n", uxlog.Check(), dir)
+			fmt.Fprintf(os.Stderr, "%s Removed config dir: %s\n", uxlog.Check(), dir)
 		} else if !errors.Is(err, os.ErrNotExist) {
-			fmt.Fprintf(os.Stderr, "  %s Could not remove %s: %v\n", uxlog.Warn(), dir, err)
+			fmt.Fprintf(os.Stderr, "%s Could not remove %s: %v\n", uxlog.Warn(), dir, err)
 		}
 	}
 
@@ -54,16 +54,16 @@ func runUninstall(f *flags) error {
 	}
 
 	if err := os.Remove(binPath); err != nil {
-		fmt.Fprintf(os.Stderr, "  %s Could not remove binary at %s: %v\n", uxlog.Warn(), binPath, err)
+		fmt.Fprintf(os.Stderr, "%s Could not remove binary at %s: %v\n", uxlog.Warn(), binPath, err)
 		fmt.Fprintln(os.Stderr, "    Remove it manually, possibly with sudo.")
 		return nil
 	}
-	fmt.Fprintf(os.Stderr, "  %s Removed binary: %s\n", uxlog.Check(), binPath)
+	fmt.Fprintf(os.Stderr, "%s Removed binary: %s\n", uxlog.Check(), binPath)
 
 	// If the on-PATH name was a symlink, drop the dangling link too.
 	if rawPath != binPath {
 		if err := os.Remove(rawPath); err == nil {
-			fmt.Fprintf(os.Stderr, "  %s Removed symlink: %s\n", uxlog.Check(), rawPath)
+			fmt.Fprintf(os.Stderr, "%s Removed symlink: %s\n", uxlog.Check(), rawPath)
 		}
 	}
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,7 +34,7 @@ without a positional argument.
 
 | Flag | Purpose |
 |---|---|
-| `--text <string>` | Send a literal string instead of a file. The receiver prints it to stdout; nothing is saved to disk. |
+| `--text <string>` | Send a literal string instead of a file. The receiver prints it to stdout; nothing is saved to disk. To keep it: `fsend <code> > note.txt`. |
 | `--pass <password>` | Require the receiver to supply this password. Bare `--pass` prompts interactively with a random default. Also `FSEND_PASS`. |
 | `--exclude <glob,…>` | Skip entries when bundling a directory. |
 | `--name <hostname>` | Override the hostname shown to the peer. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -34,7 +34,7 @@ without a positional argument.
 
 | Flag | Purpose |
 |---|---|
-| `--text <string>` | Send a literal string instead of a file. |
+| `--text <string>` | Send a literal string instead of a file. The receiver prints it to stdout; nothing is saved to disk. |
 | `--pass <password>` | Require the receiver to supply this password. Bare `--pass` prompts interactively with a random default. Also `FSEND_PASS`. |
 | `--exclude <glob,…>` | Skip entries when bundling a directory. |
 | `--name <hostname>` | Override the hostname shown to the peer. |
@@ -60,12 +60,14 @@ sending, then confirms. Pass `--yes` to skip.
 |---|---|
 | `--yes` | Auto-accept. |
 | `--out <dir>` | Receive into this directory (created if missing). Default: cwd. |
+| `--out -` | Stream the payload to stdout instead of saving a file (single file, text, or piped stream — not directories). Retries are disabled: emitted bytes can't be rewound. |
 | `--overwrite` | Replace existing files instead of failing with `E013`. |
 | `--pass <password>` | Supply the sender's password non-interactively. Also `FSEND_PASS`. |
 
 ```sh
 fsend abc-defg-jkm
 fsend --yes --out ~/Downloads/incoming abc-defg-jkm
+fsend --yes --out - abc-defg-jkm > dump.sql   # pipe-to-pipe with the sender's `… | fsend`
 FSEND_PASS=swordfish fsend --yes abc-defg-jkm
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/zeebo/blake3 v0.2.4
 	golang.org/x/crypto v0.52.0
 	golang.org/x/net v0.55.0
+	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 	salsa.debian.org/vasudev/gospake2 v0.0.0-20210510093858-d91629950ad1
 )
@@ -36,6 +37,5 @@ require (
 	github.com/spf13/pflag v1.0.10 // indirect
 	github.com/twmb/murmur3 v1.1.8 // indirect
 	github.com/wlynxg/anet v0.0.5 // indirect
-	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 )

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -45,6 +45,16 @@ type RecvOptions struct {
 	// existing one and Overwrite is false. true → accept this file as if
 	// Overwrite were set; false or nil → E013 reject.
 	ConfirmOverwrite func(relativePath string, existingSize int64, incomingSize uint64) bool
+	// Sink, when non-nil, streams the payload to this writer instead of
+	// writing files under TargetDir. Single-payload transfers only
+	// (single file, text, piped stream); directory and multi-file
+	// transfers are declined before the Accept prompt. Resume never
+	// applies — emitted bytes can't be reconciled — so callers must not
+	// retry a sink receive.
+	Sink io.Writer
+	// OnFileDone is called with each file's final path after it has been
+	// verified and renamed into place. Not called in archive or Sink mode.
+	OnFileDone func(path string)
 }
 
 // Recv executes the full receiver-side protocol over the supplied streams.
@@ -59,6 +69,24 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 	}
 	if hello.ProtocolVersion != wire.ProtocolVersion {
 		return fmt.Errorf("%w: peer speaks v%d, we speak v%d", fserrors.ErrProtocolError, hello.ProtocolVersion, wire.ProtocolVersion)
+	}
+
+	// Sink mode carries one byte stream; concatenating a directory tar or
+	// several files into it would hand the user garbage. Decline before
+	// the Accept prompt so the user isn't asked about a doomed transfer.
+	if opts.Sink != nil &&
+		(hello.TransferKind == wire.TransferDirectory || hello.TransferKind == wire.TransferMultiFile) {
+		ack := &wire.ReceiverHello{
+			Hostname: opts.Hostname, OS: opts.OS, ClientVersion: opts.ClientVersion,
+		}
+		_ = wire.WriteControl(s.Control, wire.TypeHelloAck, ack)
+		_ = s.Control.Close()
+		_, _ = io.Copy(io.Discard, s.Control)
+		what := "directory"
+		if hello.TransferKind == wire.TransferMultiFile {
+			what = "multi-file"
+		}
+		return fmt.Errorf("%w: cannot stream a %s transfer to stdout; receive it with --out <dir>", fserrors.ErrUsage, what)
 	}
 
 	accept := true
@@ -137,6 +165,9 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 }
 
 func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts RecvOptions, archiveMode bool) error {
+	if opts.Sink != nil {
+		return recvPayloadToSink(ctx, s, info, opts)
+	}
 	// In archive mode the sender's RelativePath is a fixed placeholder
 	// (ArchiveName); we don't actually surface that name to the user.
 	// We just need a stable, hidden temp location inside TargetDir for
@@ -411,34 +442,9 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 			return fmt.Errorf("%w: chunk file index %d, expected %d", fserrors.ErrProtocolError, c.FileIndex, info.Index)
 		}
 
-		plain := c.Payload
-		if c.Flags&wire.FlagCompressed != 0 {
-			if dec == nil {
-				// Cap per-decode memory so an authenticated-but-misbehaving
-				// peer can't RAM-bomb us with a high-ratio chunk. A single
-				// frame can hold at most MaxChunkSize of plaintext (the
-				// sender's invariant); 2× gives headroom for zstd's own
-				// scratch buffers without admitting GB-scale balloons that
-				// the klauspost default (1 GiB) allows.
-				dec, err = zstd.NewReader(nil, zstd.WithDecoderMaxMemory(2*wire.MaxChunkSize))
-				if err != nil {
-					return fmt.Errorf("recv: zstd reader: %w", err)
-				}
-			}
-			plain, err = dec.DecodeAll(c.Payload, nil)
-			if err != nil {
-				return fmt.Errorf("recv: zstd decode: %w", err)
-			}
-			// Belt-and-braces against a sender that crafts a frame the
-			// decoder accepts but whose plaintext exceeds the wire bound.
-			if len(plain) > wire.MaxChunkSize {
-				return fmt.Errorf("%w: decompressed chunk %d > limit %d", fserrors.ErrProtocolError, len(plain), wire.MaxChunkSize)
-			}
-		}
-
-		// BLAKE3 of uncompressed payload must match the per-chunk hash.
-		if hashEq := blakeHash32(plain); hashEq != c.Blake3Hash {
-			return fserrors.ErrHashMismatch
+		plain, err := chunkPlain(c, &dec)
+		if err != nil {
+			return err
 		}
 
 		// Enforce the declared size: a misbehaving peer that never sets
@@ -531,6 +537,119 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 	if info.ModTime > 0 {
 		t := time.Unix(0, info.ModTime)
 		_ = os.Chtimes(target, t, t)
+	}
+	if opts.OnFileDone != nil {
+		opts.OnFileDone(target)
+	}
+	return nil
+}
+
+// chunkPlain decompresses (when flagged) and hash-verifies one chunk's
+// payload. dec is created lazily on the first compressed chunk and
+// reused; the caller owns its Close.
+func chunkPlain(c *wire.Chunk, dec **zstd.Decoder) ([]byte, error) {
+	plain := c.Payload
+	if c.Flags&wire.FlagCompressed != 0 {
+		if *dec == nil {
+			// Cap per-decode memory so an authenticated-but-misbehaving
+			// peer can't RAM-bomb us with a high-ratio chunk. A single
+			// frame can hold at most MaxChunkSize of plaintext (the
+			// sender's invariant); 2× gives headroom for zstd's own
+			// scratch buffers without admitting GB-scale balloons that
+			// the klauspost default (1 GiB) allows.
+			d, err := zstd.NewReader(nil, zstd.WithDecoderMaxMemory(2*wire.MaxChunkSize))
+			if err != nil {
+				return nil, fmt.Errorf("recv: zstd reader: %w", err)
+			}
+			*dec = d
+		}
+		var err error
+		plain, err = (*dec).DecodeAll(c.Payload, nil)
+		if err != nil {
+			return nil, fmt.Errorf("recv: zstd decode: %w", err)
+		}
+		// Belt-and-braces against a sender that crafts a frame the
+		// decoder accepts but whose plaintext exceeds the wire bound.
+		if len(plain) > wire.MaxChunkSize {
+			return nil, fmt.Errorf("%w: decompressed chunk %d > limit %d", fserrors.ErrProtocolError, len(plain), wire.MaxChunkSize)
+		}
+	}
+	// BLAKE3 of uncompressed payload must match the per-chunk hash.
+	if blakeHash32(plain) != c.Blake3Hash {
+		return nil, fserrors.ErrHashMismatch
+	}
+	return plain, nil
+}
+
+// recvPayloadToSink streams one file's bytes to opts.Sink. No partial,
+// no resume, no rename: per-chunk hashes verify each piece before it is
+// emitted, and the root hash is still checked at the end — but by then
+// the bytes are already out, so a mismatch can only surface as an error
+// exit, never as withheld output.
+func recvPayloadToSink(ctx context.Context, s *Streams, info *wire.FileInfo, opts RecvOptions) error {
+	if info.IsDir || info.IsSymlink {
+		return fmt.Errorf("%w: non-file entry in a sink transfer", fserrors.ErrProtocolError)
+	}
+	decision := wire.FileAcceptDecision{Index: info.Index, Action: wire.ActionAcceptFull}
+	if err := wire.WriteControl(s.Control, wire.TypeFileAccept, &decision); err != nil {
+		return fmt.Errorf("recv: file-accept: %w", err)
+	}
+
+	verifier := blake3.New()
+	var written uint64
+	var dec *zstd.Decoder
+	defer func() {
+		if dec != nil {
+			dec.Close()
+		}
+	}()
+	for {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		c, err := wire.ReadChunk(s.Data)
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				if reason := tryReadPeerError(s.Control); reason != nil {
+					return reason
+				}
+				return fmt.Errorf("recv: stream closed mid-file: %w", fserrors.ErrConnectFailed)
+			}
+			return fmt.Errorf("recv: chunk: %w", err)
+		}
+		if c.FileIndex != info.Index {
+			return fmt.Errorf("%w: chunk file index %d, expected %d", fserrors.ErrProtocolError, c.FileIndex, info.Index)
+		}
+		plain, err := chunkPlain(c, &dec)
+		if err != nil {
+			return err
+		}
+		if !info.Streaming && written+uint64(len(plain)) > info.Size {
+			return fmt.Errorf("%w: received bytes exceed declared size %d", fserrors.ErrProtocolError, info.Size)
+		}
+		if len(plain) > 0 {
+			if _, err := opts.Sink.Write(plain); err != nil {
+				return classifyWriteErr("sink write", err)
+			}
+			_, _ = verifier.Write(plain)
+			written += uint64(len(plain))
+			if opts.ProgressFn != nil {
+				opts.ProgressFn(info.Index, written)
+			}
+		}
+		if c.Flags&wire.FlagLastChunk != 0 {
+			break
+		}
+	}
+
+	// Same root-hash policy as the file path, including the synthetic
+	// (stdin / --text) skip.
+	var got, zero [32]byte
+	copy(got[:], verifier.Sum(nil))
+	syntheticSkip := !info.Resumable && info.Blake3Root == zero
+	if !syntheticSkip && got != info.Blake3Root {
+		declineTransfer(s, wire.ErrCodeFileHashMismatch, "root hash mismatch")
+		return fserrors.ErrHashMismatch
 	}
 	return nil
 }

--- a/internal/uxlog/ansi_other.go
+++ b/internal/uxlog/ansi_other.go
@@ -1,0 +1,7 @@
+//go:build !windows
+
+package uxlog
+
+// enableANSI reports whether the terminal can interpret ANSI escapes.
+// Unix terminals always can.
+func enableANSI() bool { return true }

--- a/internal/uxlog/ansi_windows.go
+++ b/internal/uxlog/ansi_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package uxlog
+
+import (
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+// enableANSI switches the Windows console into VT mode so ANSI escapes
+// (color, cursor movement) render instead of printing as garbage.
+// Returns false when any console handle refuses (legacy conhost), in
+// which case every renderer falls back to its non-TTY output.
+func enableANSI() bool {
+	ok := true
+	for _, f := range []*os.File{os.Stderr, os.Stdout} {
+		h := windows.Handle(f.Fd())
+		var mode uint32
+		if windows.GetConsoleMode(h, &mode) != nil {
+			continue // not a console (pipe/file) — nothing to enable
+		}
+		if mode&windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING != 0 {
+			continue
+		}
+		if windows.SetConsoleMode(h, mode|windows.ENABLE_VIRTUAL_TERMINAL_PROCESSING) != nil {
+			ok = false
+		}
+	}
+	return ok
+}

--- a/internal/uxlog/glyphs.go
+++ b/internal/uxlog/glyphs.go
@@ -29,7 +29,7 @@ const (
 // fallback with no colour so log files stay readable.
 func Marker(kind glyphKind) string {
 	utf8, ascii, color := glyphForKind(kind)
-	if !IsTTY(os.Stderr) {
+	if !renderTTY(os.Stderr) {
 		return ascii
 	}
 	if colorEnabled() {
@@ -104,7 +104,19 @@ var (
 	colorMu      sync.Mutex
 	colorChecked bool
 	colorAllow   bool
+
+	ansiOnce sync.Once
+	ansiOK   bool
 )
+
+// renderTTY reports whether w is a terminal that can interpret ANSI
+// escapes (color, cursor movement). On Windows the first call flips the
+// console into VT mode; when that fails (legacy conhost) every renderer
+// degrades to its non-TTY output instead of printing escape garbage.
+func renderTTY(w io.Writer) bool {
+	ansiOnce.Do(func() { ansiOK = enableANSI() })
+	return ansiOK && IsTTY(w)
+}
 
 // colorEnabled reports whether we should emit ANSI colour escapes.
 // Rules (de-facto standard):
@@ -125,7 +137,7 @@ func colorEnabled() bool {
 		colorAllow = on
 		return colorAllow
 	}
-	colorAllow = IsTTY(os.Stderr)
+	colorAllow = renderTTY(os.Stderr)
 	return colorAllow
 }
 
@@ -153,7 +165,7 @@ func ColorFor(w io.Writer) bool {
 	if on, ok := colorEnvOverride(); ok {
 		return on
 	}
-	return IsTTY(w)
+	return renderTTY(w)
 }
 
 // resetColorForTesting is exposed so unit tests can flip env vars

--- a/internal/uxlog/progress_test.go
+++ b/internal/uxlog/progress_test.go
@@ -1,6 +1,7 @@
 package uxlog
 
 import (
+	"bytes"
 	"os"
 	"testing"
 )
@@ -67,4 +68,58 @@ func TestProgress_NilSafety(t *testing.T) {
 	p.Add(100)
 	p.SetTotal(200, true)
 	p.Done()
+}
+
+// TestProgress_PlainModeNoEscapes guards the non-TTY contract: piped
+// progress output must contain no ANSI escapes (mpb's non-interactive
+// mode emits cursor-up sequences, which is why plain mode bypasses it)
+// and must end with a single "done" line on completion.
+func TestProgress_PlainModeNoEscapes(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = f
+	t.Cleanup(func() { os.Stderr = orig; _ = f.Close() })
+
+	p := New(1000)
+	p.Add(400)
+	p.Add(600)
+	p.Done()
+
+	out, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.ContainsRune(out, 0x1b) {
+		t.Fatalf("plain progress emitted ANSI escapes: %q", out)
+	}
+	if got, want := string(out), "  done  1000 B\n"; got != want {
+		t.Fatalf("final line: got %q, want %q", got, want)
+	}
+}
+
+// TestProgress_PlainModePartialSilent: an aborted plain-mode transfer
+// prints no terminal line — the error that follows is the record.
+func TestProgress_PlainModePartialSilent(t *testing.T) {
+	f, err := os.CreateTemp(t.TempDir(), "stderr")
+	if err != nil {
+		t.Fatal(err)
+	}
+	orig := os.Stderr
+	os.Stderr = f
+	t.Cleanup(func() { os.Stderr = orig; _ = f.Close() })
+
+	p := New(1000)
+	p.Add(250)
+	p.Done()
+
+	out, err := os.ReadFile(f.Name())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 0 {
+		t.Fatalf("partial plain progress should be silent, got %q", out)
+	}
 }

--- a/internal/uxlog/spinner.go
+++ b/internal/uxlog/spinner.go
@@ -55,7 +55,7 @@ func StartSpinner(msg string) *Spinner {
 	s := &Spinner{
 		msg:  msg,
 		w:    os.Stderr,
-		tty:  IsTTY(os.Stderr),
+		tty:  renderTTY(os.Stderr),
 		stop: make(chan struct{}),
 		done: make(chan struct{}),
 	}

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sync"
 	"time"
 
 	"github.com/vbauerster/mpb/v8"
@@ -25,10 +26,69 @@ import (
 
 // Progress wraps an mpb.Progress + a single bar that tracks total bytes
 // across the whole transfer regardless of mode (single file, multi-file,
-// or tar-bundled directory).
+// or tar-bundled directory). On non-TTY stderr the mpb pair is nil and
+// plain carries a line-oriented renderer instead.
 type Progress struct {
-	mp  *mpb.Progress
-	bar *mpb.Bar
+	mp    *mpb.Progress
+	bar   *mpb.Bar
+	plain *plainProgress
+}
+
+// plainProgress renders progress as occasional complete lines — no
+// cursor movement, no in-place redraws — so pipes and CI logs stay
+// readable. mpb is unsuitable here: even its non-interactive mode
+// emits cursor-up/erase escapes between frames.
+type plainProgress struct {
+	mu       sync.Mutex
+	w        io.Writer
+	total    int64
+	current  int64
+	complete bool
+	closed   bool
+	lastLine time.Time
+}
+
+// plainInterval throttles plain-mode lines. One line per second keeps
+// long transfers observable without flooding logs.
+const plainInterval = time.Second
+
+func (p *plainProgress) add(n int64) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.current += n
+	if time.Since(p.lastLine) < plainInterval {
+		return
+	}
+	p.lastLine = time.Now()
+	if p.total > 0 {
+		fmt.Fprintf(p.w, "  %d%%  %s / %s\n",
+			p.current*100/p.total, HumanBytes(p.current), HumanBytes(p.total))
+		return
+	}
+	fmt.Fprintf(p.w, "  %s\n", HumanBytes(p.current))
+}
+
+func (p *plainProgress) setTotal(total int64, complete bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.total = total
+	p.complete = p.complete || complete
+}
+
+// done prints one terminal line for transfers that actually completed.
+// Partial transfers print nothing — the error line that follows is the
+// authoritative record. Idempotent: callers flush before the summary
+// and keep a deferred call as the safety net.
+func (p *plainProgress) done() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.closed || p.current == 0 {
+		return
+	}
+	p.closed = true
+	if p.complete || (p.total > 0 && p.current >= p.total) {
+		fmt.Fprintf(p.w, "  done  %s\n", HumanBytes(p.current))
+	}
 }
 
 // barWidth caps the progress bar at a fixed column count. 40 leaves room
@@ -51,31 +111,23 @@ const rateThreshold = 1 << 20
 // front; for stdin/text transfers we pass 0 and the bar renders without
 // a percentage, ETA, or rate chip.
 func New(totalBytes int64) *Progress {
-	tty := IsTTY(os.Stderr)
+	if !renderTTY(os.Stderr) {
+		// Pipe/CI mode: line-oriented output only. The throttle starts
+		// now so fast transfers print just the final "done" line.
+		return &Progress{plain: &plainProgress{
+			w: os.Stderr, total: totalBytes, lastLine: time.Now(),
+		}}
+	}
 	p := &Progress{}
 
-	opts := []mpb.ContainerOption{
+	p.mp = mpb.New(
 		mpb.WithOutput(os.Stderr),
-		mpb.WithRefreshRate(100 * time.Millisecond), // spec: ≥10 Hz
-	}
-	if !tty {
-		// Pipe mode: emit periodic plain-text updates with no cursor
-		// manipulation. mpb still draws bars but we let it; downstream
-		// consumers see "\r"-overwritten lines that they can grep with
-		// the % column.
-		opts = append(opts, mpb.WithAutoRefresh())
-	}
-	p.mp = mpb.New(opts...)
+		mpb.WithRefreshRate(100*time.Millisecond), // spec: ≥10 Hz
+	)
 
-	// Unicode bar on TTYs; ASCII fallback on pipes so log files stay
-	// readable. The ━/╸/─ trio gives a calm, modern look without the
-	// "=====>" telegraph aesthetic the default style carries.
-	var style mpb.BarStyleComposer
-	if tty {
-		style = mpb.BarStyle().Lbound(" ").Rbound(" ").Filler("━").Tip("╸").Padding("─")
-	} else {
-		style = mpb.BarStyle().Lbound("[").Rbound("]").Filler("#").Tip(">").Padding(" ")
-	}
+	// The ━/╸/─ trio gives a calm, modern look without the "=====>"
+	// telegraph aesthetic the default style carries.
+	style := mpb.BarStyle().Lbound(" ").Rbound(" ").Filler("━").Tip("╸").Padding("─")
 
 	// Track elapsed locally — decor.Statistics doesn't carry it, and we
 	// want the rate decor to use the same "since New()" baseline the
@@ -170,19 +222,31 @@ func New(totalBytes int64) *Progress {
 // Safe to call from multiple goroutines (mpb's bar is internally
 // synchronized).
 func (p *Progress) Add(n int64) {
-	if p == nil || p.bar == nil {
+	if p == nil {
 		return
 	}
-	p.bar.IncrInt64(n)
+	if p.plain != nil {
+		p.plain.add(n)
+		return
+	}
+	if p.bar != nil {
+		p.bar.IncrInt64(n)
+	}
 }
 
 // SetTotal updates the bar's total. Useful for stdin transfers where the
 // final size is only known when EOF arrives.
 func (p *Progress) SetTotal(total int64, complete bool) {
-	if p == nil || p.bar == nil {
+	if p == nil {
 		return
 	}
-	p.bar.SetTotal(total, complete)
+	if p.plain != nil {
+		p.plain.setTotal(total, complete)
+		return
+	}
+	if p.bar != nil {
+		p.bar.SetTotal(total, complete)
+	}
 }
 
 // Done marks the bar complete and waits for mpb to flush. Always call
@@ -199,7 +263,14 @@ func (p *Progress) SetTotal(total int64, complete bool) {
 //     don't SetTotal here — that would render a misleading "done" on
 //     a partial bar.
 func (p *Progress) Done() {
-	if p == nil || p.mp == nil {
+	if p == nil {
+		return
+	}
+	if p.plain != nil {
+		p.plain.done()
+		return
+	}
+	if p.mp == nil {
 		return
 	}
 	if p.bar != nil && !p.bar.Completed() {

--- a/test/e2e/transfer_test.go
+++ b/test/e2e/transfer_test.go
@@ -212,16 +212,56 @@ func TestSend_TextLiteral(t *testing.T) {
 		dst, []string{"--yes"}, "")
 	r.requireSuccess(t)
 
-	matches, err := filepath.Glob(filepath.Join(dst, "fsend-text-*.txt"))
-	if err != nil || len(matches) == 0 {
-		t.Fatalf("no fsend-text-*.txt file in %s", dst)
+	// Text is a message, not a download: it lands on the receiver's
+	// stdout and leaves no file behind.
+	if !strings.Contains(r.receiverOut, "literal-9876") {
+		t.Fatalf("text payload not on receiver stdout: %q", r.receiverOut)
 	}
-	body, err := os.ReadFile(matches[0])
-	if err != nil {
+	if matches, _ := filepath.Glob(filepath.Join(dst, "fsend-text-*.txt")); len(matches) != 0 {
+		t.Fatalf("text receive must not leave a file, found %v", matches)
+	}
+}
+
+// TestReceive_OutStdout: `--out -` streams the payload to stdout and
+// writes nothing to disk.
+func TestReceive_OutStdout(t *testing.T) {
+	requireE2E(t)
+	src, dst := t.TempDir(), t.TempDir()
+	fp := filepath.Join(src, "payload.txt")
+	if err := os.WriteFile(fp, []byte("sink-payload-5432\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if !strings.Contains(string(body), "literal-9876") {
-		t.Fatalf("payload mismatch: %q", body)
+
+	r := h.runPair(t, []string{fp}, dst, []string{"--yes", "--out", "-"}, "")
+	r.requireSuccess(t)
+	if r.receiverOut != "sink-payload-5432\n" {
+		t.Fatalf("stdout payload mismatch: %q", r.receiverOut)
+	}
+	if entries, _ := os.ReadDir(dst); len(entries) != 0 {
+		t.Fatalf("--out - must not write files, found %v", entries)
+	}
+}
+
+// TestReceive_OutStdoutRejectsDirectory: a directory transfer can't be
+// streamed to one byte sink — the receiver must fail with a usage error
+// (E024) instead of dumping the internal tar.
+func TestReceive_OutStdoutRejectsDirectory(t *testing.T) {
+	requireE2E(t)
+	src, dst := t.TempDir(), t.TempDir()
+	sub := filepath.Join(src, "proj")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "f.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := h.runPair(t, []string{sub}, dst, []string{"--yes", "--out", "-"}, "")
+	if r.receiverExitCode != 24 {
+		t.Fatalf("receiver exit = %d, want 24 (usage)\n%s", r.receiverExitCode, r.receiverErr)
+	}
+	if r.receiverOut != "" {
+		t.Fatalf("nothing may reach stdout on rejection, got %q", r.receiverOut)
 	}
 }
 


### PR DESCRIPTION
## Summary

Addresses every finding from a full CLI UI/UX review, verified with live transfers under both pipes and pseudo-TTYs.

**Fixes**
- **Piped output contained ANSI cursor escapes** — mpb emits cursor-up/erase sequences even in non-interactive mode, polluting CI logs and `2>file` captures. Non-TTY progress now uses a plain line emitter: at most one line per second plus a single `done` line (regression-tested).
- **Windows legacy console**: VT processing is enabled on first render; when that fails (old conhost), output degrades to ASCII glyphs with no escapes instead of garbage.

**Receive-side UX**
- `--text` payloads print to the receiver's stdout and leave no file behind (previously buried in a random `fsend-text-*.txt`).
- New `--out -` streams a single file, text, or piped stdin to stdout — completing pipe-to-pipe workflows (`pg_dump | fsend` → `fsend <code> --out - > dump.sql`). Directory/multi-file transfers are declined with a usage error before the prompt; retries are disabled in sink mode so output can't duplicate.
- The summary names what landed: `✓ Saved report.pdf to ~/Downloads`, `Saved 3 files to …`, `Saved proj/ to …`, `Received text`. `--out` paths are absolutized so prompt and summary are stable.
- Accept prompt re-prompts on unrecognized input instead of treating a typo as yes.

**Polish**
- Direct-path headline dropped (the summary already carries the path tag); relay keeps its pre-transfer ⚠ warning. Sender flushes the bar before the summary so `done` lands above it.
- "N items" unified to "N files" across sender line, prompt, and summary.
- `--connect` warns when the host doesn't resolve (still saved — offline setting is legitimate); E001 names the server it tried so stale configs self-diagnose.
- Help documents `--out -`, the text-print behavior, and shell completions; uninstall glyph margins aligned.
- Receive callbacks consolidated into one `receiverUI` shared by the LAN and internet paths (was five closures returned from send.go).

## Test plan

- [x] `go test ./...` green, including the e2e suite
- [x] New tests: plain-progress escape-free contract (unit), `--out -` happy path + directory rejection (e2e), text-to-stdout (e2e, updated)
- [x] `gofmt` / `go vet` clean; `GOOS=windows` and `GOOS=linux` cross-builds pass
- [x] Empirical runs: file/multi-file/folder/text/stdin transfers over LAN under pipes and ptys; byte-exact pipe-to-pipe; E001/E024/E025 error paths; connect warning; uninstall prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)