### PR TITLE
ux: role-aware errors, abandoned-session reclaim, CLI polish from audit

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -140,7 +140,8 @@ func classifyRelayDrop(ctx context.Context, client *signaling.Client, sessionID,
 	switch status.Reason {
 	case relay.ReasonCapHit:
 		if status.LimitBytes > 0 {
-			return fmt.Errorf("%w: Server limit: %s", fserrors.ErrRelayCapHit, uxlog.HumanBytes(int64(status.LimitBytes)))
+			return fmt.Errorf("%w: Server limit: %s on the wire (after compression)",
+				fserrors.ErrRelayCapHit, uxlog.HumanBytes(int64(status.LimitBytes)))
 		}
 		return fserrors.ErrRelayCapHit
 	case relay.ReasonIdle:

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -22,6 +22,10 @@ import (
 	"github.com/polius/fsend/internal/uxlog"
 )
 
+// errorRoleSender is set by runSend so renderError can pick sender-side
+// wording for errors mirrored from the receiver (E009, E013, E021).
+var errorRoleSender bool
+
 func main() {
 	// Normalise --connect arguments before cobra parses. We use
 	// NoOptDefVal so bare `fsend --connect` prints the current server,
@@ -140,6 +144,9 @@ func renderError(err error, debug bool) int {
 		err = fserrors.ErrUserCancelled
 	}
 	entry, known := fserrors.Lookup(err)
+	if known && errorRoleSender {
+		entry = entry.ForSender()
+	}
 
 	// Surface wrap context as a second line so users see WHY without
 	// having to enable --debug. Used for:

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -88,7 +88,10 @@ func runReceive(f *flags, c string) error {
 	// TestReceive_Overwrite under -race.
 	first, err := quicconn.Dial(ctx, addr, c)
 	if err != nil {
-		if !f.quiet {
+		// Debug-only: the transfer may still end up "Direct on local
+		// network" via the server-paired race, so surfacing this notice
+		// by default reads as the tool contradicting itself.
+		if f.debug && !f.quiet {
 			fmt.Fprintln(os.Stderr, uxlog.Info(), "Local sender unreachable — falling back to server.")
 		}
 		cfg := loadConfig(f.quiet)
@@ -166,10 +169,10 @@ func receiverPasswordPrompt(ctx context.Context, f *flags) func() (string, error
 // file that would collide) the warning chip that pre-discloses the
 // overwrite. The chip means the user only ever sees one question per
 // transfer instead of an accept-then-overwrite double prompt.
-func renderArtifact(w io.Writer, h wire.SenderHello, outDir string, alreadyOverwriting bool) {
+func renderArtifact(w io.Writer, h wire.SenderHello, outDir string, f *flags) {
 	pwChip := ""
 	if h.HasPassword {
-		pwChip = "  🔒 password required"
+		pwChip = "  " + uxlog.PasswordChip()
 	}
 	switch h.TransferKind {
 	case wire.TransferSingleFile:
@@ -181,12 +184,18 @@ func renderArtifact(w io.Writer, h wire.SenderHello, outDir string, alreadyOverw
 		}
 		_, _ = fmt.Fprintf(w, "      %s  ·  %s%s\n", name, uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)
 		// outDir is "" in sink mode — nothing on disk to collide with.
-		if !alreadyOverwriting && outDir != "" {
+		if !f.overwrite && outDir != "" {
 			target := filepath.Join(outDir, name)
 			if st, err := os.Stat(target); err == nil && !st.IsDir() {
-				chip := fmt.Sprintf("⚠ already in %s (%s) — will be overwritten if you accept",
+				// Under --yes there is no accept prompt to consent
+				// through, so the transfer will fail with E013.
+				chip := fmt.Sprintf("already in %s (%s) — will be overwritten if you accept",
 					displayPath(outDir), uxlog.HumanBytes(st.Size()))
-				_, _ = fmt.Fprintln(w, "      "+uxlog.Dim(chip))
+				if f.yes {
+					chip = fmt.Sprintf("already in %s (%s) — rerun with --overwrite to replace",
+						displayPath(outDir), uxlog.HumanBytes(st.Size()))
+				}
+				_, _ = fmt.Fprintln(w, "      "+uxlog.Warn()+" "+uxlog.Dim(chip))
 			}
 		}
 	case wire.TransferDirectory:
@@ -194,11 +203,11 @@ func renderArtifact(w io.Writer, h wire.SenderHello, outDir string, alreadyOverw
 		if name == "" {
 			name = "directory"
 		}
-		_, _ = fmt.Fprintf(w, "      %s  ·  %d files  ·  %s%s\n",
-			name, h.TotalFiles, uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)
+		_, _ = fmt.Fprintf(w, "      %s  ·  %s  ·  %s%s\n",
+			name, uxlog.CountNoun(int(h.TotalFiles), "file"), uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)
 	case wire.TransferMultiFile:
-		_, _ = fmt.Fprintf(w, "      %d files  ·  %s%s\n",
-			h.TotalFiles, uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)
+		_, _ = fmt.Fprintf(w, "      %s  ·  %s%s\n",
+			uxlog.CountNoun(int(h.TotalFiles), "file"), uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)
 	case wire.TransferText:
 		_, _ = fmt.Fprintf(w, "      text  ·  %s%s\n",
 			uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -153,7 +153,7 @@ func (ui *receiverUI) promptAccept(h wire.SenderHello) bool {
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintf(os.Stderr, "  Incoming from %s%s\n", peer, pathChip)
 	fmt.Fprintln(os.Stderr)
-	renderArtifact(os.Stderr, h, ui.outDir, f.overwrite)
+	renderArtifact(os.Stderr, h, ui.outDir, f)
 	fmt.Fprintln(os.Stderr)
 	if f.yes {
 		fmt.Fprintln(os.Stderr, uxlog.Check(), "Accepting (--yes)")

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -24,6 +24,7 @@ import (
 // started in parallel; whichever the receiver reaches first wins. See
 // sendpair.go for the coordinator.
 func runSend(f *flags, paths []string) error {
+	errorRoleSender = true // renderError picks sender-side catalog wording
 	if f.textArg != "" && len(paths) > 0 {
 		return fmt.Errorf("%w: --text cannot be combined with file arguments", fserrors.ErrUsage)
 	}
@@ -124,7 +125,7 @@ func collectItems(f *flags, paths []string) ([]transfer.SourceItem, wire.Transfe
 		if len(paths) == 1 {
 			label = filepath.Base(paths[0]) + "/"
 		} else {
-			label = fmt.Sprintf("%d items", len(paths))
+			label = uxlog.CountNoun(len(paths), "item")
 		}
 		return items, wire.TransferDirectory, numFiles, label, cleanup, nil
 	}
@@ -139,7 +140,7 @@ func collectItems(f *flags, paths []string) ([]transfer.SourceItem, wire.Transfe
 		// directory-resolved file).
 		return items, wire.TransferSingleFile, 0, filepath.Base(paths[0]), noop, nil
 	}
-	return items, wire.TransferMultiFile, 0, fmt.Sprintf("%d files", len(paths)), noop, nil
+	return items, wire.TransferMultiFile, 0, uxlog.CountNoun(len(paths), "file"), noop, nil
 }
 
 // containsDirectory reports whether any of paths refers to a directory.
@@ -287,11 +288,11 @@ func printSendArtifact(f *flags, c string, items []transfer.SourceItem, kind wir
 		for _, it := range items {
 			total += it.Info.Size
 		}
-		fmt.Fprintf(os.Stderr, "  Sending  %s  ·  %d files  ·  %s\n",
-			label, totalFiles, uxlog.HumanBytes(int64(total)))
+		fmt.Fprintf(os.Stderr, "  Sending  %s  ·  %s  ·  %s\n",
+			label, uxlog.CountNoun(int(totalFiles), "file"), uxlog.HumanBytes(int64(total)))
 	case wire.TransferMultiFile:
-		fmt.Fprintf(os.Stderr, "  Sending  %d files  ·  %s\n",
-			len(items), uxlog.HumanBytes(totalBytes(items)))
+		fmt.Fprintf(os.Stderr, "  Sending  %s  ·  %s\n",
+			uxlog.CountNoun(len(items), "file"), uxlog.HumanBytes(totalBytes(items)))
 	case wire.TransferText:
 		fmt.Fprintf(os.Stderr, "  Sending  text  ·  %s\n",
 			uxlog.HumanBytes(totalBytes(items)))

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -308,7 +308,8 @@ CONFIGURATION (environment variables — all optional)
   FSEND_LOG_LEVEL                       Default info
   FSEND_MAX_SESSIONS_PER_IP             Default 5
   FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN Default 30
-  FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MiB (accepts e.g. "100MiB", "500m", "104857600")
+  FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MiB, counted in wire bytes after compression
+                                        (accepts e.g. "100MiB", "500m", "104857600")
   FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every endpoint except
                                         /v1/health requires the X-Fsend-Auth header to match.
                                         Clients set theirs with: fsend --connect <host:port>,<password>.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -148,4 +148,4 @@ All optional; defaults shown. Set under the `environment:` block in
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
 | `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit. |
-| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MiB` | Accepts `500m`, `1GiB`, `104857600`. |
+| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MiB` | Wire bytes after compression. Accepts `500m`, `1GiB`, `104857600`. |

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -107,6 +107,23 @@ type Entry struct {
 	Exit    int    // process exit code
 	Message string // first line, what went wrong in user terms
 	Action  string // second (and subsequent) lines, what to do next
+
+	// Sender-side wording for errors that originate on the receiver and
+	// are mirrored across the wire (wrong password, overwrite refused).
+	// Empty means Message/Action read correctly on both sides.
+	SenderMessage string
+	SenderAction  string
+}
+
+// ForSender returns the entry with sender-side wording swapped in.
+func (e Entry) ForSender() Entry {
+	if e.SenderMessage != "" {
+		e.Message = e.SenderMessage
+	}
+	if e.SenderAction != "" {
+		e.Action = e.SenderAction
+	}
+	return e
 }
 
 // Format renders the entry as a multi-line message ready for stderr.
@@ -180,8 +197,10 @@ var catalog = map[error]Entry{
 	},
 	ErrWriteFailed: {
 		Code: "E009", Exit: 9,
-		Message: "Could not write to the target file.",
-		Action:  "Try --out <dir> to save somewhere writable.",
+		Message:       "Could not write to the target file.",
+		Action:        "Try --out <dir> to save somewhere writable.",
+		SenderMessage: "The receiver could not write the file to disk.",
+		SenderAction:  "They can retry with --out <dir> to save somewhere writable.",
 	},
 	ErrReadFailed: {
 		Code: "E010", Exit: 10,
@@ -203,8 +222,10 @@ var catalog = map[error]Entry{
 	},
 	ErrTargetExists: {
 		Code: "E013", Exit: 13,
-		Message: "Target file exists and --overwrite was not given.",
-		Action:  "Use --overwrite to replace existing files.",
+		Message:       "Target file exists and --overwrite was not given.",
+		Action:        "Use --overwrite to replace existing files.",
+		SenderMessage: "The receiver already has a file with this name.",
+		SenderAction:  "They can rerun with --overwrite to replace it.",
 	},
 	ErrConnectFailed: {
 		Code: "E014", Exit: 14,
@@ -258,6 +279,9 @@ var catalog = map[error]Entry{
 		Message: "Wrong password. Transfer aborted.",
 		Action: "Ask the sender for the correct password and run again. Codes are\n" +
 			"  one-shot — the sender may need to restart to issue a fresh code.",
+		SenderMessage: "The receiver entered the wrong password. Transfer aborted.",
+		SenderAction: "Run fsend again to issue a fresh code, and re-share the\n" +
+			"  password with the receiver.",
 	},
 	ErrPeerAuthFailed: {
 		Code: "E022", Exit: 22,

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -26,6 +26,7 @@ import (
 type Config struct {
 	ServerVersion        string
 	UnpairedTTL          time.Duration // default 1h
+	AbandonedTTL         time.Duration // default 5m
 	PairedTTL            time.Duration // default 600s
 	LongPollTimeout      time.Duration // default 25s
 	MaxSessionsPerIP     int           // default 5
@@ -47,6 +48,14 @@ func (c *Config) Default() {
 		// would surface as a confusing "code expired" failure even when
 		// the sender's process is still alive.
 		c.UnpairedTTL = time.Hour
+	}
+	if c.AbandonedTTL == 0 {
+		// Live senders touch their session every /wait long-poll
+		// (≤LongPollTimeout apart). A session not seen for 5 minutes
+		// has a dead client — reclaim it so a crashed or killed fsend
+		// doesn't hold one of the MaxSessionsPerIP slots for the full
+		// UnpairedTTL hour.
+		c.AbandonedTTL = 5 * time.Minute
 	}
 	if c.PairedTTL == 0 {
 		c.PairedTTL = 600 * time.Second
@@ -335,11 +344,18 @@ func (s *Server) evict(now time.Time) {
 	for id, sess := range s.byID {
 		switch sess.State {
 		case "waiting":
-			if now.Sub(sess.CreatedAt) > s.cfg.UnpairedTTL {
+			expired := now.Sub(sess.CreatedAt) > s.cfg.UnpairedTTL
+			abandoned := now.Sub(sess.LastSeen) > s.cfg.AbandonedTTL
+			if expired || abandoned {
 				delete(s.byID, id)
 				delete(s.byCode, sess.Code)
 				s.releaseIP(sess.SenderRateKey)
 				close(sess.waiters)
+				reason := "expired"
+				if abandoned && !expired {
+					reason = "abandoned"
+				}
+				s.cfg.Logger.Debug("session evicted", "code", sess.Code, "reason", reason)
 			}
 		case "paired":
 			if now.Sub(sess.PairedAt) > s.cfg.PairedTTL {
@@ -347,6 +363,7 @@ func (s *Server) evict(now time.Time) {
 				delete(s.byCode, sess.Code)
 				s.releaseIP(sess.SenderRateKey)
 				s.releaseIP(sess.ReceiverRateKey)
+				s.cfg.Logger.Debug("session evicted", "code", sess.Code, "reason", "paired_ttl")
 			}
 		}
 	}
@@ -434,12 +451,14 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		SenderToken:   senderTok,
 		State:         "waiting",
 		CreatedAt:     time.Now(),
+		LastSeen:      time.Now(),
 		waiters:       make(chan struct{}),
 	}
 	s.byCode[c] = sess
 	s.byID[sid] = sess
 	s.ipCounts[rateKey]++
 	s.mu.Unlock()
+	s.cfg.Logger.Debug("session created", "code", c, "ip", clientIP)
 
 	writeJSON(w, http.StatusOK, CreateSessionResponse{
 		SessionID:        sid,
@@ -500,6 +519,7 @@ func (s *Server) joinSession(w http.ResponseWriter, r *http.Request) {
 		RoleToken:          sess.ReceiverToken,
 	}
 	s.mu.Unlock()
+	s.cfg.Logger.Debug("session paired", "code", c, "ip", clientIP)
 	writeJSON(w, http.StatusOK, resp)
 }
 
@@ -512,6 +532,8 @@ func (s *Server) waitSession(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusNotFound, "code not found")
 		return
 	}
+	// Each /wait poll doubles as the sender's liveness heartbeat.
+	sess.LastSeen = time.Now()
 	// Snapshot what we need under the lock so concurrent joinSession
 	// writes don't race the reads below.
 	state := sess.State
@@ -654,6 +676,7 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 	delete(s.byCode, sess.Code)
 	s.releaseIP(sess.SenderRateKey)
 	s.releaseIP(sess.ReceiverRateKey)
+	s.cfg.Logger.Debug("session deleted", "code", sess.Code)
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -700,6 +700,50 @@ func TestEvict_PrunesIPBucket(t *testing.T) {
 	}
 }
 
+// TestEvict_AbandonedSession: a waiting session whose sender stopped
+// polling /wait is reclaimed after AbandonedTTL (freeing its per-IP
+// slot) long before UnpairedTTL; a still-polling one survives.
+func TestEvict_AbandonedSession(t *testing.T) {
+	s := New(Config{
+		ServerVersion:        "0.0.0-test",
+		UnpairedTTL:          time.Hour,
+		AbandonedTTL:         5 * time.Minute,
+		PairedTTL:            time.Hour,
+		MaxSessionsPerIP:     100,
+		MaxNewSessionsPerMin: 100,
+	})
+	now := time.Now()
+	mk := func(id, code string, lastSeen time.Time) {
+		s.byID[id] = &session{
+			ID: id, Code: code, State: "waiting",
+			SenderRateKey: "1.2.3.4",
+			CreatedAt:     now.Add(-10 * time.Minute),
+			LastSeen:      lastSeen,
+			waiters:       make(chan struct{}),
+		}
+		s.byCode[code] = s.byID[id]
+		s.ipCounts["1.2.3.4"]++
+	}
+	s.mu.Lock()
+	mk("alive", "aaa-aaaa-aaa", now.Add(-30*time.Second))
+	mk("dead", "bbb-bbbb-bbb", now.Add(-6*time.Minute))
+	s.mu.Unlock()
+
+	s.evict(now)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.byID["alive"]; !ok {
+		t.Error("recently-polled session should survive")
+	}
+	if _, ok := s.byID["dead"]; ok {
+		t.Error("abandoned session should have been reclaimed")
+	}
+	if got := s.ipCounts["1.2.3.4"]; got != 1 {
+		t.Errorf("ipCounts = %d, want 1 (dead session's slot freed)", got)
+	}
+}
+
 func itoaHex(n int) string {
 	const hex = "0123456789abcdef"
 	if n == 0 {

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -138,19 +138,24 @@ type IceCreds struct {
 // decrement on session teardown lands on the same map key the
 // increment used.
 type session struct {
-	ID                 string
-	Code               string
-	SenderAddr         string
-	SenderRateKey      string
-	SenderICE          IceCreds
-	SenderToken        string
-	ReceiverAddr       string
-	ReceiverRateKey    string
-	ReceiverICE        IceCreds
-	ReceiverToken      string
-	State              string // "waiting" | "paired" | "complete"
-	CreatedAt          time.Time
-	PairedAt           time.Time
+	ID              string
+	Code            string
+	SenderAddr      string
+	SenderRateKey   string
+	SenderICE       IceCreds
+	SenderToken     string
+	ReceiverAddr    string
+	ReceiverRateKey string
+	ReceiverICE     IceCreds
+	ReceiverToken   string
+	State           string // "waiting" | "paired" | "complete"
+	CreatedAt       time.Time
+	PairedAt        time.Time
+	// LastSeen is touched by the sender's /wait long-poll (recurs every
+	// LongPollTimeout while the client is alive). Sessions whose client
+	// stopped polling are reclaimed after AbandonedTTL instead of
+	// holding a per-IP slot for the full UnpairedTTL.
+	LastSeen           time.Time
 	SenderCandidates   []string
 	ReceiverCandidates []string
 	// relayToken is the shared relay session token, allocated lazily on

--- a/internal/uxlog/format.go
+++ b/internal/uxlog/format.go
@@ -73,6 +73,15 @@ func HumanRate(bytes int64, elapsed time.Duration) string {
 	return HumanBytes(int64(rate)) + "/s"
 }
 
+// CountNoun renders "<n> <noun>" with naive pluralisation ("1 file",
+// "3 files").
+func CountNoun(n int, noun string) string {
+	if n == 1 {
+		return "1 " + noun
+	}
+	return fmt.Sprintf("%d %ss", n, noun)
+}
+
 // Code renders a share code in bold + cyan so it stands out as the one
 // thing the user is about to type or dictate. Degrades to plain text
 // when color is disabled or stderr is not a TTY.

--- a/internal/uxlog/glyphs.go
+++ b/internal/uxlog/glyphs.go
@@ -53,6 +53,15 @@ func Info() string { return Marker(gInfo) }
 // Retry returns the retry glyph (↻ or [RETRY]).
 func Retry() string { return Marker(gRetry) }
 
+// PasswordChip renders the "password required" artifact chip, degrading
+// to plain text on pipes/files like every other glyph here.
+func PasswordChip() string {
+	if renderTTY(os.Stderr) {
+		return "🔒 password required"
+	}
+	return "[password required]"
+}
+
 func glyphForKind(k glyphKind) (utf8, ascii, color string) {
 	switch k {
 	case gCheck:

--- a/internal/uxlog/progress_test.go
+++ b/internal/uxlog/progress_test.go
@@ -73,7 +73,8 @@ func TestProgress_NilSafety(t *testing.T) {
 // TestProgress_PlainModeNoEscapes guards the non-TTY contract: piped
 // progress output must contain no ANSI escapes (mpb's non-interactive
 // mode emits cursor-up sequences, which is why plain mode bypasses it)
-// and must end with a single "done" line on completion.
+// and prints no completion line — the summary that follows carries the
+// final size.
 func TestProgress_PlainModeNoEscapes(t *testing.T) {
 	f, err := os.CreateTemp(t.TempDir(), "stderr")
 	if err != nil {
@@ -95,8 +96,8 @@ func TestProgress_PlainModeNoEscapes(t *testing.T) {
 	if bytes.ContainsRune(out, 0x1b) {
 		t.Fatalf("plain progress emitted ANSI escapes: %q", out)
 	}
-	if got, want := string(out), "  done  1000 B\n"; got != want {
-		t.Fatalf("final line: got %q, want %q", got, want)
+	if got := string(out); got != "" {
+		t.Fatalf("completed plain progress should print nothing: got %q", got)
 	}
 }
 

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/vbauerster/mpb/v8"
 	"github.com/vbauerster/mpb/v8/decor"
+	"golang.org/x/term"
 )
 
 // Progress wraps an mpb.Progress + a single bar that tracks total bytes
@@ -82,13 +83,9 @@ func (p *plainProgress) setTotal(total int64, complete bool) {
 func (p *plainProgress) done() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
-	if p.closed || p.current == 0 {
-		return
-	}
+	// No final "done <size>" line — the summary line that follows
+	// already carries the size.
 	p.closed = true
-	if p.complete || (p.total > 0 && p.current >= p.total) {
-		fmt.Fprintf(p.w, "  done  %s\n", HumanBytes(p.current))
-	}
 }
 
 // barWidth caps the progress bar at a fixed column count. 40 leaves room
@@ -111,9 +108,10 @@ const rateThreshold = 1 << 20
 // front; for stdin/text transfers we pass 0 and the bar renders without
 // a percentage, ETA, or rate chip.
 func New(totalBytes int64) *Progress {
-	if !renderTTY(os.Stderr) {
-		// Pipe/CI mode: line-oriented output only. The throttle starts
-		// now so fast transfers print just the final "done" line.
+	// Plain mode for pipes/CI, and for terminals that report a 0×0
+	// window (some pty wrappers) — mpb discards every row at height 0.
+	width, _, sizeErr := term.GetSize(int(os.Stderr.Fd()))
+	if !renderTTY(os.Stderr) || sizeErr != nil || width <= 0 {
 		return &Progress{plain: &plainProgress{
 			w: os.Stderr, total: totalBytes, lastLine: time.Now(),
 		}}
@@ -141,7 +139,9 @@ func New(totalBytes int64) *Progress {
 	// chip lingering at 0s.
 	prependDecs := []decor.Decorator{
 		decor.Name("  "),
-		decor.OnComplete(decor.Percentage(decor.WC{W: 4}), "done"),
+		// "%d" renders "66%", matching plain mode — the default
+		// "% d" pads a space before the sign ("66 %").
+		decor.OnComplete(decor.NewPercentage("%d", decor.WC{W: 4}), "done"),
 		decor.Name("  "),
 	}
 	if !hasTotal {


### PR DESCRIPTION
Fixes everything from the 2026-06-10 CLI UX audit.

## Error messaging
- **Role-aware catalog wording**: errors mirrored from the receiver (E009 write failed, E013 target exists, E021 wrong password) now render sender-appropriate text on the sender — previously the sender read "Ask the sender for the correct password and run again."

## Server
- **Abandoned-session reclaim (5 min)**: the sender's `/wait` long-poll (every ≤25 s) now doubles as a liveness heartbeat. Waiting sessions not seen for `AbandonedTTL` (default 5 min) are reclaimed and free their per-IP slot, so a crashed/killed/slept client no longer locks its IP out of the server for the full 1 h `UnpairedTTL`. Live senders keep their code the full hour as before.
- Debug-level `session created/paired/deleted/evicted` logs so self-hosters can see what the server is doing.

## Receive UX
- Overwrite chip under `--yes` now says "rerun with --overwrite to replace" instead of promising an overwrite that E013 then refuses (interactive wording unchanged).
- Collision and password chips degrade to ASCII on pipes (`[!]`, `[password required]`) like every other glyph.
- "Local sender unreachable — falling back to server" moved behind `--debug` (it contradicted the eventual "Direct on local network" summary).

## Progress
- Plain mode no longer prints a redundant `done <size>` line — the summary line carries it.
- Terminals reporting a 0×0 window (some pty wrappers/CI) fall back to plain line mode; mpb discards all output at height 0.
- Bar percentage now renders `66%`, matching plain mode (was `66 %`).

## Misc
- `1 file` / `1 item` pluralisation via `uxlog.CountNoun`.
- Relay cap docs/messages clarify the limit counts **wire bytes after compression** (E023 detail, `fsend server --help`, self-hosting docs). Investigation confirmed the cap is enforced correctly — a zero-filled test file simply compresses to ~54 KB on the wire.

All audit scenarios re-verified live against a local server; full test suite + vet pass. New unit test: `TestEvict_AbandonedSession`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
