### PR TITLE
ux: second-pass CLI audit — prompt safety, honest degradation, polish

### DIFF
--- a/cmd/fsend/connect.go
+++ b/cmd/fsend/connect.go
@@ -92,7 +92,7 @@ func runConnect(f *flags) error {
 		return nil
 	default:
 		if len(args) > 2 {
-			return fmt.Errorf("%w: --connect takes at most: <host[:port]> [password]", fserrors.ErrUsage)
+			return fmt.Errorf("%w: --connect takes at most: <host[:port]>,<password>", fserrors.ErrUsage)
 		}
 		server, err := normalizeServer(args[0])
 		if err != nil {

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -420,14 +420,16 @@ func retryNoticeFor(f *flags) func(attempt int, wait time.Duration, lastErr erro
 	if f.quiet {
 		return nil
 	}
+	// uxlog.Println coordinates with a live progress bar so the notice
+	// prints above it instead of colliding with the in-place redraw.
 	return func(attempt int, wait time.Duration, lastErr error) {
 		if f.debug {
-			fmt.Fprintf(os.Stderr, "  %s Connection interrupted (%s) — retrying in %s (attempt %d/%d)\n",
-				uxlog.Retry(), shortErr(lastErr), wait, attempt, retry.DefaultAttempts)
+			uxlog.Println(fmt.Sprintf("  %s Connection interrupted (%s) — retrying in %s (attempt %d/%d)",
+				uxlog.Retry(), shortErr(lastErr), wait, attempt, retry.DefaultAttempts))
 			return
 		}
-		fmt.Fprintf(os.Stderr, "  %s Connection interrupted — retrying in %s (attempt %d/%d)\n",
-			uxlog.Retry(), wait, attempt, retry.DefaultAttempts)
+		uxlog.Println(fmt.Sprintf("  %s Connection interrupted — retrying in %s (attempt %d/%d)",
+			uxlog.Retry(), wait, attempt, retry.DefaultAttempts))
 	}
 }
 

--- a/cmd/fsend/internet_test.go
+++ b/cmd/fsend/internet_test.go
@@ -111,7 +111,7 @@ func TestClassifyRelayDrop_MapsReasons(t *testing.T) {
 			body:       `{"state":"evicted","reason":"cap_hit","limit_bytes":104857600}`,
 			runErr:     errors.New("idle timeout"),
 			wantErr:    fserrors.ErrRelayCapHit,
-			wantDetail: "Server limit: 100.0 MB",
+			wantDetail: "Server limit: 100 MB",
 		},
 		{
 			name:    "cap_hit_without_limit_is_bare_sentinel",

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -153,9 +153,9 @@ func renderError(err error, debug bool) int {
 	//   - usage / source-not-found: the missing path or bad flag.
 	//   - relay-limit hits: the server's configured limit ("100 MiB").
 	detail := ""
-	// E001 names the server it tried so a stale --connect entry is
-	// self-diagnosing instead of reading as a network outage.
-	if errors.Is(err, fserrors.ErrServerUnreachable) {
+	// E001 and E018 name the server it tried so a stale --connect entry
+	// is self-diagnosing instead of reading as a network outage.
+	if errors.Is(err, fserrors.ErrServerUnreachable) || errors.Is(err, fserrors.ErrServerRetired) {
 		if cfg, cfgErr := config.Load(); cfgErr == nil {
 			detail = "Server: " + cfg.EffectiveServer()
 		}
@@ -173,10 +173,16 @@ func renderError(err error, debug bool) int {
 	// Pick the leading glyph based on severity: warnings (Exit==0, e.g.
 	// ErrConfigCorrupted) get ⚠, real failures get ✗. Without this,
 	// every catalog entry — including "this is fine, falling back to
-	// defaults" — would be flagged with a red cross.
+	// defaults" — would be flagged with a red cross. Deliberate user
+	// actions (Ctrl-C, the receiver's own decline) aren't failures
+	// either, so they get the neutral info glyph.
 	glyph := uxlog.Cross()
-	if entry.Exit == 0 {
+	switch {
+	case entry.Exit == 0:
 		glyph = uxlog.Warn()
+	case errors.Is(err, fserrors.ErrUserCancelled),
+		!errorRoleSender && errors.Is(err, fserrors.ErrReceiverDeclined):
+		glyph = uxlog.Info()
 	}
 
 	switch {
@@ -190,8 +196,16 @@ func renderError(err error, debug bool) int {
 		// path and lands here — by far the most common failure when
 		// codes are relayed verbally. Without the hint, the bare "no
 		// such file" sends those users hunting for a file problem.
-		if code.LooksLikeCode(detail) {
+		// Suppressed under an explicit --send: the user already told us
+		// the argument is a path.
+		switch {
+		case code.LooksLikeCode(detail) && !argsHaveFlag("--send"):
 			fmt.Fprintf(os.Stderr, "  If this was a receive code, check it with the sender — codes look like abc-defg-jkm.\n")
+		// Muscle-memory from other tools: there are no subcommands.
+		case detail == "version":
+			fmt.Fprintf(os.Stderr, "  For the fsend version, run: fsend --version\n")
+		case detail == "send" || detail == "receive":
+			fmt.Fprintf(os.Stderr, "  fsend has no %q subcommand — `fsend <file>` sends, `fsend <code>` receives.\n", detail)
 		}
 		if entry.Action != "" {
 			fmt.Fprintf(os.Stderr, "  %s\n", entry.Action)
@@ -234,8 +248,14 @@ func debugRequested() bool {
 	if v := os.Getenv("FSEND_DEBUG"); v != "" && v != "0" && v != "false" {
 		return true
 	}
+	return argsHaveFlag("--debug")
+}
+
+// argsHaveFlag scans os.Args for a literal flag token. Used by the error
+// renderer, which runs after cobra state is gone.
+func argsHaveFlag(name string) bool {
 	for _, a := range os.Args[1:] {
-		if a == "--debug" {
+		if a == name {
 			return true
 		}
 		if a == "--" {

--- a/cmd/fsend/password.go
+++ b/cmd/fsend/password.go
@@ -91,7 +91,12 @@ func readPasswordHiddenCtx(ctx context.Context, prompt string) (string, error) {
 // Receiver side: hidden no-echo prompt. The receiver must type whatever
 // the sender configured, so a "random default" makes no sense; we just
 // reuse the standard hidden-password reader.
-func resolvePassword(f *flags, sender bool) error {
+//
+// ctx must come from signalContext(): once the handler is installed,
+// SIGINT only cancels the context, so a prompt that doesn't select on
+// ctx would leave Ctrl-C dead — and for the hidden prompt, the terminal
+// stuck with echo off.
+func resolvePassword(ctx context.Context, f *flags, sender bool) error {
 	if f.passArg != passPromptSentinel {
 		return nil
 	}
@@ -104,19 +109,42 @@ func resolvePassword(f *flags, sender bool) error {
 		return fmt.Errorf("%w: bare --pass needs a terminal; use --pass <value> or FSEND_PASS", fserrors.ErrUsage)
 	}
 	if sender {
-		pw, err := promptPasswordWithSuggestion()
+		pw, err := promptPasswordWithSuggestionCtx(ctx)
 		if err != nil {
 			return err
 		}
 		f.passArg = pw
 		return nil
 	}
-	pw, err := readPasswordHidden("Password for this transfer: ")
+	pw, err := readPasswordHiddenCtx(ctx, "Password for this transfer: ")
 	if err != nil {
 		return err
 	}
 	f.passArg = pw
 	return nil
+}
+
+// promptPasswordWithSuggestionCtx is promptPasswordWithSuggestion that
+// aborts on ctx cancellation (Ctrl-C at the prompt). The prompt echoes
+// normally, so unlike the hidden reader there is no terminal state to
+// restore — just move off the prompt line.
+func promptPasswordWithSuggestionCtx(ctx context.Context) (string, error) {
+	type result struct {
+		pw  string
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		pw, err := promptPasswordWithSuggestion()
+		ch <- result{pw, err}
+	}()
+	select {
+	case <-ctx.Done():
+		fmt.Fprintln(os.Stderr)
+		return "", context.Canceled
+	case r := <-ch:
+		return r.pw, r.err
+	}
 }
 
 // promptPasswordWithSuggestion offers a freshly-generated random password

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -39,16 +39,26 @@ func runReceive(f *flags, c string) error {
 	if f.outDir == "-" && f.overwrite {
 		return fmt.Errorf("%w: --overwrite has no effect with --out -", fserrors.ErrUsage)
 	}
+	// Validate --out before any network work: a missing directory would
+	// otherwise only fail at write time, after the sender's one-shot code
+	// has been consumed.
+	if _, _, err := resolveOutDir(f); err != nil {
+		return err
+	}
+
+	// The signal handler must be installed before any interactive prompt:
+	// resolvePassword reads with echo off, and a default-disposition
+	// SIGINT inside that read would kill the process without restoring
+	// the terminal.
+	ctx, cancel := signalContext()
+	defer cancel()
 
 	// Bare --pass: hidden no-echo prompt. We're not the password's
 	// author — we have to type what the sender configured — so there's
 	// no point offering a random default here.
-	if err := resolvePassword(f, false); err != nil {
+	if err := resolvePassword(ctx, f, false); err != nil {
 		return err
 	}
-
-	ctx, cancel := signalContext()
-	defer cancel()
 
 	// LAN discovery is a 300 ms probe — short enough that showing a
 	// spinner only flashes a line that immediately gets cleared on miss,

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -42,6 +42,7 @@ type receiverUI struct {
 	prev           map[uint32]uint64
 	total          int64
 	bar            *uxlog.Progress
+	firstByte      time.Time // latched on first progress byte; see finishReceive
 	totalBytesHint int64
 	streamingTotal bool // HELLO carried TotalBytes=0 (piped stdin)
 	preApproved    bool // accept prompt already disclosed the overwrite
@@ -59,6 +60,8 @@ func newReceiverUI(ctx context.Context, f *flags, outDir string, sink bool, path
 // resolveOutDir resolves --out: "-" selects sink (stdout) mode, ""
 // defaults to the CWD. Directories come back absolute so the prompt and
 // the summary show a stable path regardless of how the user spelled it.
+// An explicit --out must already exist — failing fast here beats
+// accepting a transfer that is doomed at write time.
 func resolveOutDir(f *flags) (dir string, sink bool, err error) {
 	if f.outDir == "-" {
 		return "", true, nil
@@ -71,6 +74,15 @@ func resolveOutDir(f *flags) (dir string, sink bool, err error) {
 	}
 	if abs, absErr := filepath.Abs(dir); absErr == nil {
 		dir = abs
+	}
+	if f.outDir != "" {
+		st, statErr := os.Stat(dir)
+		switch {
+		case statErr != nil:
+			return "", false, fmt.Errorf("%w: --out directory does not exist: %s", fserrors.ErrUsage, dir)
+		case !st.IsDir():
+			return "", false, fmt.Errorf("%w: --out is not a directory: %s", fserrors.ErrUsage, dir)
+		}
 	}
 	return dir, false, nil
 }
@@ -209,6 +221,9 @@ func (ui *receiverUI) confirmOverwrite(relPath string, existing int64, incoming 
 func (ui *receiverUI) progress(fileIndex uint32, bytesWritten uint64) {
 	ui.mu.Lock()
 	defer ui.mu.Unlock()
+	if ui.firstByte.IsZero() {
+		ui.firstByte = time.Now()
+	}
 	if ui.bar == nil && !ui.f.quiet {
 		ui.bar = uxlog.New(ui.totalBytesHint)
 	}
@@ -258,7 +273,14 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 	ui.mu.Lock()
 	h := ui.hello
 	files := append([]string(nil), ui.files...)
+	firstByte := ui.firstByte
 	ui.mu.Unlock()
+
+	// Time from the first byte: the caller's window includes the accept
+	// prompt, and a 20 s deliberation would read as a glacial transfer.
+	if !firstByte.IsZero() {
+		elapsed = time.Since(firstByte)
+	}
 
 	if h != nil && h.TransferKind == wire.TransferText && !ui.sink {
 		if err := printTextPayload(files); err != nil {

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -123,7 +123,7 @@ Examples:
 	// Server selection. Bare --connect (no value) means "show current
 	// server" — same NoOptDefVal trick as --pass. The dispatcher
 	// recognises the sentinel and treats it as "no args".
-	c.Flags().StringSliceVar(&f.connectArgsRaw, "connect", nil, "set the server: <host:port> [password] | 'default'")
+	c.Flags().StringSliceVar(&f.connectArgsRaw, "connect", nil, "set the server: <host[:port]>[,<password>] | 'default'")
 	connectFlag := c.Flags().Lookup("connect")
 	connectFlag.NoOptDefVal = connectShowSentinel
 	connectFlag.DefValue = ""
@@ -137,8 +137,61 @@ Examples:
 
 	c.AddCommand(serverCmd())
 
+	// Replace cobra's auto-generated completion command: it inherits the
+	// root help/usage template (so `fsend completion --help` printed the
+	// root page) and exits 0 on a missing or unknown shell — fatal when
+	// the output is eval'd in a dotfile.
+	c.CompletionOptions.DisableDefaultCmd = true
+	c.AddCommand(completionCmd())
+
 	return c
 }
+
+// completionCmd prints a completion script for one of the supported
+// shells, with a usage error (E024, nonzero exit) for anything else.
+func completionCmd() *cobra.Command {
+	const shells = "bash, zsh, fish, powershell"
+	c := &cobra.Command{
+		Use:           "completion <shell>",
+		Short:         "Print a shell completion script",
+		SilenceUsage:  true,
+		SilenceErrors: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) != 1 {
+				return fmt.Errorf("%w: completion expects one shell argument (%s)", fserrors.ErrUsage, shells)
+			}
+			root := cmd.Root()
+			switch args[0] {
+			case "bash":
+				return root.GenBashCompletionV2(os.Stdout, true)
+			case "zsh":
+				return root.GenZshCompletion(os.Stdout)
+			case "fish":
+				return root.GenFishCompletion(os.Stdout, true)
+			case "powershell":
+				return root.GenPowerShellCompletionWithDesc(os.Stdout)
+			}
+			return fmt.Errorf("%w: unknown shell %q (expected one of: %s)", fserrors.ErrUsage, args[0], shells)
+		},
+	}
+	ht := boldHelpHeaders(completionHelpTemplate)
+	c.SetHelpTemplate(ht)
+	c.SetUsageTemplate(ht)
+	return c
+}
+
+const completionHelpTemplate = `fsend completion — print a shell completion script
+
+USAGE
+  fsend completion <bash|zsh|fish|powershell>
+
+EXAMPLES
+  zsh:   eval "$(fsend completion zsh)"
+  bash:  eval "$(fsend completion bash)"
+  fish:  fsend completion fish | source
+
+  Add the line to your shell's rc file to load it on every session.
+`
 
 // validMode reports whether s is an accepted --mode value.
 // "" means "no override" (default auto-selection).
@@ -319,6 +372,26 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	}
 	if f.forceSend && f.forceReceive {
 		return fmt.Errorf("%w: --send and --receive are mutually exclusive", fserrors.ErrUsage)
+	}
+	// An empty positional ("" from a botched shell expansion) would fall
+	// through to the send path as a nameless E025.
+	for _, a := range f.posArgs {
+		if a == "" {
+			return fmt.Errorf("%w: empty argument (check your shell quoting)", fserrors.ErrUsage)
+		}
+	}
+
+	// `fsend --pass file.pdf`: the value rides with the flag, so the file
+	// is consumed as the password — and with piped stdin that silently
+	// opens a session sending the wrong content. If the flag's value
+	// names an existing file and nothing is left to send, it was almost
+	// certainly a misplaced path.
+	if cmd.Flags().Changed("pass") && f.passArg != "" && f.passArg != passPromptSentinel &&
+		len(f.posArgs) == 0 && !cmd.Flags().Changed("text") {
+		if st, err := os.Stat(f.passArg); err == nil && !st.IsDir() {
+			return fmt.Errorf("%w: --pass consumed %q as the password; to send that file: fsend %s --pass",
+				fserrors.ErrUsage, f.passArg, f.passArg)
+		}
 	}
 
 	// Env-var fallback for the password (FSEND_PASS). Passing a secret via

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -3,7 +3,9 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/signal"
 	"path/filepath"
@@ -31,11 +33,26 @@ func runSend(f *flags, paths []string) error {
 	if f.textArg == "" && len(paths) == 0 {
 		return fmt.Errorf("%w: nothing to send (provide a file, a directory, or --text)", fserrors.ErrUsage)
 	}
+	// Receive-side flags silently dropped on a send mask swapped-argument
+	// mistakes (`fsend file --out dir`); reject instead.
+	for _, rf := range []struct {
+		name string
+		set  bool
+	}{{"--out", f.outDir != ""}, {"--yes", f.yes}, {"--overwrite", f.overwrite}} {
+		if rf.set {
+			return fmt.Errorf("%w: %s is a receive-side flag and has no effect when sending", fserrors.ErrUsage, rf.name)
+		}
+	}
+
+	// The signal handler must be installed before the --pass prompt so
+	// Ctrl-C there cancels cleanly instead of hitting a blocking read.
+	ctx, cancel := signalContext()
+	defer cancel()
 
 	// Bare --pass: suggest a random default the user can accept by
 	// pressing Enter. Done before any network setup so the prompt
 	// can't collide with the pairing-server spinner.
-	if err := resolvePassword(f, true); err != nil {
+	if err := resolvePassword(ctx, f, true); err != nil {
 		return err
 	}
 
@@ -50,8 +67,9 @@ func runSend(f *flags, paths []string) error {
 		return fmt.Errorf("generating code: %w", err)
 	}
 
-	ctx, cancel := signalContext()
-	defer cancel()
+	// Load config before the artifact block: it can print the E016
+	// corruption warning, which must not land on the spinner's line.
+	cfg := loadConfig(f.quiet)
 
 	// Print the artifact (code + receive command) exactly once, here,
 	// before any path is attempted. Both LAN and internet paths use the
@@ -69,7 +87,6 @@ func runSend(f *flags, paths []string) error {
 	// 300 ms mDNS query misses, so same-LAN receivers always win the
 	// race against the server path, and cross-network receivers don't
 	// wait on any timer.
-	cfg := loadConfig(f.quiet)
 	return runSendParallel(ctx, f, items, kind, totalFiles, label, c, cfg, waitSpin)
 }
 
@@ -117,6 +134,16 @@ func collectItems(f *flags, paths []string) ([]transfer.SourceItem, wire.Transfe
 		if err != nil {
 			return nil, 0, 0, "", noop, err
 		}
+		// "0 files" in the artifact line is honest but easy to miss; a
+		// fat-fingered --exclude glob deserves a nudge before the sender
+		// shares a code for an empty archive.
+		if numFiles == 0 && !f.quiet {
+			msg := "The directory is empty — sending an empty archive."
+			if len(f.excludes) > 0 {
+				msg = "Every file matched --exclude — sending an empty archive."
+			}
+			fmt.Fprintln(os.Stderr, uxlog.Warn(), msg)
+		}
 		// Pick a label the user recognises. Single input path → its
 		// basename (the folder they typed). Multiple inputs → "N items"
 		// so the display reflects the user's command, not the
@@ -132,7 +159,7 @@ func collectItems(f *flags, paths []string) ([]transfer.SourceItem, wire.Transfe
 
 	items, err := transfer.Walk(paths)
 	if err != nil {
-		return nil, 0, 0, "", noop, err
+		return nil, 0, 0, "", noop, mapLocalReadErr(err)
 	}
 	if len(paths) == 1 {
 		// Surface the user-typed basename, not the walker's relative
@@ -141,6 +168,16 @@ func collectItems(f *flags, paths []string) ([]transfer.SourceItem, wire.Transfe
 		return items, wire.TransferSingleFile, 0, filepath.Base(paths[0]), noop, nil
 	}
 	return items, wire.TransferMultiFile, 0, uxlog.CountNoun(len(paths), "file"), noop, nil
+}
+
+// mapLocalReadErr promotes a permission failure on a local source file
+// to E010 ("check the file permissions"). Without this it falls into the
+// E099 catchall, which tells users to file a bug for their own chmod.
+func mapLocalReadErr(err error) error {
+	if errors.Is(err, fs.ErrPermission) {
+		return fmt.Errorf("%w: %v", fserrors.ErrReadFailed, err)
+	}
+	return err
 }
 
 // containsDirectory reports whether any of paths refers to a directory.
@@ -172,7 +209,7 @@ func containsDirectory(paths []string) (bool, error) {
 func buildArchiveItem(paths []string, excludes []string) ([]transfer.SourceItem, uint32, func(), error) {
 	res, err := transfer.BuildArchive(paths, excludes)
 	if err != nil {
-		return nil, 0, func() {}, err
+		return nil, 0, func() {}, mapLocalReadErr(err)
 	}
 	cleanup := func() { _ = os.Remove(res.Path) }
 

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -351,9 +351,10 @@ func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem,
 			if errors.Is(lanErr, context.Canceled) {
 				continue
 			}
-			// Don't print the "must use a different network" notice when the
-			// user explicitly forced the LAN path with --mode=local:
-			// there is no other path, so the bare error is the whole story.
+			// Only the notice when there's another path left (not under
+			// --mode=local). Same-LAN receivers can still pair through
+			// the server (host↔host ICE), so this describes the loss of
+			// the discovery shortcut, not a reachability verdict.
 			if !lanDownNoticed && !f.quiet && !serverDisabled {
 				lanDownNoticed = true
 				// Pause the spinner so the notice prints on a clean
@@ -362,7 +363,7 @@ func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem,
 				// winnerPicked (and Stop fires via deferred cleanup)
 				// or trigger another notice.
 				waitSpin.Stop()
-				fmt.Fprintln(os.Stderr, uxlog.Info(), "Local network unavailable — receiver must use a different network.")
+				fmt.Fprintln(os.Stderr, uxlog.Info(), "Local-network discovery unavailable — connecting via the server instead.")
 				waitSpin = startWaitSpinner(f, "Waiting for receiver via server")
 			}
 
@@ -377,14 +378,19 @@ func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem,
 			if errors.Is(serverErr, context.Canceled) {
 				continue
 			}
-			// Don't print the "only same-LAN receivers can connect" notice
-			// when the user explicitly forced the internet path with
-			// --mode=direct/relay: LAN is disabled, so the notice would
-			// be misleading.
-			if !serverDownNoticed && !f.quiet && !lanDisabled && isServerDown(serverErr) {
+			// Any server-path failure (unreachable, rate-limited, bad
+			// password, 5xx) leaves the code working on the local network
+			// only — say so, or the sender waits forever on a code that
+			// cross-network receivers can't redeem. Skipped when the user
+			// explicitly forced the internet path with --mode=direct/relay:
+			// LAN is disabled, so the notice would be misleading.
+			if !serverDownNoticed && !f.quiet && !lanDisabled {
 				serverDownNoticed = true
 				waitSpin.Stop()
-				fmt.Fprintln(os.Stderr, uxlog.Warn(), "Server unreachable — only receivers on your local network can connect.")
+				fmt.Fprintln(os.Stderr, uxlog.Warn(), "Server unavailable — only receivers on your local network can connect.")
+				if entry, known := fserrors.Lookup(serverErr); known {
+					fmt.Fprintf(os.Stderr, "  [%s] %s\n", entry.Code, entry.Message)
+				}
 				waitSpin = startWaitSpinner(f, "Waiting for receiver on local network")
 			}
 		}
@@ -401,11 +407,21 @@ func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem,
 	// land on a clean line. The deferred Stop above is idempotent.
 	waitSpin.Stop()
 
+	pathInfo := connpath.FromLAN()
+	if winner.lan == nil {
+		pathInfo = winner.server.pathInfo
+	}
+	printPath(f, pathInfo)
+	// The receiver may now sit at its accept prompt for a while; without
+	// this line the sender stares at a dead terminal wondering whether
+	// the code even arrived.
+	if !f.quiet {
+		fmt.Fprintln(os.Stderr, uxlog.Check(), "Receiver connected — waiting for them to accept.")
+	}
+
 	if winner.lan != nil {
-		printPath(f, connpath.FromLAN())
 		return runSenderTransferOverLAN(ctx, f, items, kind, totalFiles, label, winner.lan)
 	}
-	printPath(f, winner.server.pathInfo)
 	return runSenderTransferOverInternet(ctx, f, items, kind, totalFiles, label, winner.server)
 }
 
@@ -469,7 +485,17 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 	closeProg, progressFn, sentBytes, onStreamingEOF := newSenderProgress(f, items)
 	defer closeProg()
 
+	// Time from the first byte, not from here — the receiver may sit at
+	// its accept prompt for a while, and counting that wait makes the
+	// summary read like a glacial transfer.
 	start := time.Now()
+	var firstByte time.Time
+	progress := func(fi uint32, b uint64) {
+		if firstByte.IsZero() {
+			firstByte = time.Now()
+		}
+		progressFn(fi, b)
+	}
 	current := firstRes
 	opts := retry.Options{OnRetry: retryNoticeFor(f)}
 	if hasConsumableReader(items) {
@@ -498,7 +524,7 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 				TotalFiles:     totalFiles,
 				DisplayName:    displayName,
 				Password:       f.passArg,
-				ProgressFn:     progressFn,
+				ProgressFn:     progress,
 				OnStreamingEOF: onStreamingEOF,
 			})
 		})
@@ -515,7 +541,11 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 	// Flush the bar first so its terminal frame lands above the summary
 	// (the deferred call is then a no-op).
 	closeProg()
-	printSendSummary(f, bytes, time.Since(start), pathInfo)
+	elapsed := time.Since(start)
+	if !firstByte.IsZero() {
+		elapsed = time.Since(firstByte)
+	}
+	printSendSummary(f, bytes, elapsed, pathInfo)
 	return nil
 }
 

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -308,11 +308,13 @@ CONFIGURATION (environment variables — all optional)
   FSEND_LOG_LEVEL                       Default info
   FSEND_MAX_SESSIONS_PER_IP             Default 5
   FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN Default 30
-  FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MiB, counted in wire bytes after compression
-                                        (accepts e.g. "100MiB", "500m", "104857600")
-  FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every endpoint except
-                                        /v1/health requires the X-Fsend-Auth header to match.
-                                        Clients set theirs with: fsend --connect <host:port>,<password>.
+  FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MiB, counted in wire bytes
+                                        after compression (accepts e.g.
+                                        "100MiB", "500m", "104857600")
+  FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every
+                                        endpoint except /v1/health requires the
+                                        X-Fsend-Auth header to match. Clients:
+                                        fsend --connect <host:port>,<password>
 
 LEARN MORE
   https://github.com/polius/fsend

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -85,14 +85,16 @@ func confirmUninstall(f *flags) bool {
 	if cfgPath != "" {
 		cfgDir = filepath.Dir(cfgPath)
 	}
-	fmt.Fprintln(os.Stderr, "This will remove:")
+	// Same shape as the receive prompts: two-space indent, no trailing
+	// colon, ASCII list markers (the • glyph has no pipe fallback).
+	fmt.Fprintln(os.Stderr, "  This will remove:")
 	if binPath != "" {
-		fmt.Fprintf(os.Stderr, "  • binary:     %s\n", binPath)
+		fmt.Fprintf(os.Stderr, "    - binary:     %s\n", binPath)
 	}
 	if cfgDir != "" {
-		fmt.Fprintf(os.Stderr, "  • config dir: %s\n", cfgDir)
+		fmt.Fprintf(os.Stderr, "    - config dir: %s\n", cfgDir)
 	}
-	fmt.Fprint(os.Stderr, "Continue? [y/N]: ")
+	fmt.Fprint(os.Stderr, "  Continue? [y/N] ")
 	switch readLine(os.Stdin) {
 	case "y", "yes":
 		return true

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -183,7 +183,10 @@ var catalog = map[error]Entry{
 	},
 	ErrReceiverDeclined: {
 		Code: "E006", Exit: 6,
-		Message: "Receiver declined the transfer.",
+		// Receiver-side wording: this is the decliner's own deliberate
+		// choice, so don't narrate it back in the third person.
+		Message:       "Declined.",
+		SenderMessage: "Receiver declined the transfer.",
 	},
 	ErrSessionExpired: {
 		Code: "E007", Exit: 7,
@@ -218,7 +221,7 @@ var catalog = map[error]Entry{
 		Code: "E012", Exit: 12,
 		Message: "Sender tried to write outside the target directory. Transfer rejected.",
 		Action: "This is a security check — please report at:\n" +
-			"    https://github.com/polius/fsend/issues/new?label=security",
+			"    https://github.com/polius/fsend/issues/new?labels=security",
 	},
 	ErrTargetExists: {
 		Code: "E013", Exit: 13,
@@ -258,7 +261,9 @@ var catalog = map[error]Entry{
 	},
 	ErrServerRetired: {
 		Code: "E018", Exit: 18,
-		Message: "The default server (fsend.alzina.dev) has been retired.",
+		// No hardcoded host: any server (including self-hosted ones) can
+		// return 410. renderError appends "Server: <addr>" as the detail.
+		Message: "This server has been retired.",
 		Action: "Switch to a different server with:\n" +
 			"    fsend --connect <host:port>\n" +
 			"  Or self-host: https://github.com/polius/fsend/blob/main/docs/self-hosting.md",
@@ -297,7 +302,8 @@ var catalog = map[error]Entry{
 			"  limit; same-network and direct internet transfers are uncapped.\n" +
 			"  Workarounds:\n" +
 			"    - Run again from a different network so fsend can connect you directly.\n" +
-			"    - Self-host your own server (`fsend server`) and raise FSEND_MAX_RELAY_BYTES_PER_SESSION.",
+			"    - Self-host your own server (`fsend server`) and raise\n" +
+			"      FSEND_MAX_RELAY_BYTES_PER_SESSION.",
 	},
 	ErrUsage: {
 		Code: "E024", Exit: 24,

--- a/internal/transfer/walk.go
+++ b/internal/transfer/walk.go
@@ -106,7 +106,8 @@ func blake3FileHash(path string) ([32]byte, error) {
 	var zero [32]byte
 	f, err := os.Open(path)
 	if err != nil {
-		return zero, fmt.Errorf("walk: open %s: %w", path, err)
+		// The os error already names the path; don't repeat it.
+		return zero, fmt.Errorf("walk: %w", err)
 	}
 	defer func() { _ = f.Close() }()
 	h := blake3.New()

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -40,7 +40,7 @@ type cache struct {
 	Latest    string    `json:"latest"`
 }
 
-// Notice returns a one-line upgrade message if a release newer than
+// Notice returns a short upgrade message if a release newer than
 // current is available, or "" when up to date, opted out, or anything
 // goes wrong. current is the running version (version.Version).
 //
@@ -56,7 +56,9 @@ func Notice(ctx context.Context, current string) string {
 	if latest == "" || !newer(latest, current) {
 		return ""
 	}
-	return fmt.Sprintf("A new fsend is available (%s → %s). Update: %s",
+	// Two lines: with the install command inline the notice runs past 80
+	// columns. The caller indents the first line; match it on the second.
+	return fmt.Sprintf("A new fsend is available (%s → %s).\n  Update: %s",
 		strings.TrimPrefix(current, "v"), latest, installCmd)
 }
 

--- a/internal/uxlog/format.go
+++ b/internal/uxlog/format.go
@@ -23,7 +23,12 @@ func HumanBytes(n int64) string {
 		div *= unit
 		exp++
 	}
-	return fmt.Sprintf("%.1f %cB", float64(n)/float64(div), "KMGTPE"[exp])
+	v := float64(n) / float64(div)
+	// Round values drop the decimal: "100 MB", not "100.0 MB".
+	if v == float64(int64(v)) {
+		return fmt.Sprintf("%d %cB", int64(v), "KMGTPE"[exp])
+	}
+	return fmt.Sprintf("%.1f %cB", v, "KMGTPE"[exp])
 }
 
 // HumanDuration renders elapsed in compact form. Sub-second durations

--- a/internal/uxlog/format_test.go
+++ b/internal/uxlog/format_test.go
@@ -13,10 +13,11 @@ func TestHumanBytes(t *testing.T) {
 	}{
 		{0, "0 B"},
 		{512, "512 B"},
-		{1024, "1.0 KB"},
+		{1024, "1 KB"},
 		{1536, "1.5 KB"},
-		{1024 * 1024, "1.0 MB"},
+		{1024 * 1024, "1 MB"},
 		{int64(2.5 * 1024 * 1024), "2.5 MB"},
+		{100 * 1024 * 1024, "100 MB"},
 	} {
 		if got := HumanBytes(tc.in); got != tc.want {
 			t.Errorf("HumanBytes(%d) = %q, want %q", tc.in, got, tc.want)

--- a/internal/uxlog/glyphs.go
+++ b/internal/uxlog/glyphs.go
@@ -44,13 +44,13 @@ func Check() string { return Marker(gCheck) }
 // Cross returns the failure glyph (✗ or [FAIL]).
 func Cross() string { return Marker(gCross) }
 
-// Warn returns the warning glyph (⚠ or [WARN]).
+// Warn returns the warning glyph (⚠ or [!]).
 func Warn() string { return Marker(gWarn) }
 
-// Info returns the informational glyph (ℹ or [INFO]).
+// Info returns the informational glyph (ℹ or [i]).
 func Info() string { return Marker(gInfo) }
 
-// Retry returns the retry glyph (↻ or [RETRY]).
+// Retry returns the retry glyph (⟳ or [~]).
 func Retry() string { return Marker(gRetry) }
 
 // PasswordChip renders the "password required" artifact chip, degrading
@@ -87,13 +87,6 @@ func glyphForKind(k glyphKind) (utf8, ascii, color string) {
 	return "", "", ""
 }
 
-// IsTTY reports whether w refers to a terminal. Mirrors the helper that
-// already lives in this package; kept here so glyphs can be used without
-// importing the progress-bar code.
-//
-// Note: the canonical implementation is in uxlog.go; this file uses the
-// same name so call sites have one obvious helper.
-
 // ---------------------------------------------------------------------
 // Colour handling
 // ---------------------------------------------------------------------
@@ -122,7 +115,12 @@ var (
 // escapes (color, cursor movement). On Windows the first call flips the
 // console into VT mode; when that fails (legacy conhost) every renderer
 // degrades to its non-TTY output instead of printing escape garbage.
+// TERM=dumb gets the same degradation — those terminals are TTYs but
+// can't interpret escapes.
 func renderTTY(w io.Writer) bool {
+	if os.Getenv("TERM") == "dumb" {
+		return false
+	}
 	ansiOnce.Do(func() { ansiOK = enableANSI() })
 	return ansiOK && IsTTY(w)
 }
@@ -134,6 +132,8 @@ func renderTTY(w io.Writer) bool {
 //   - FORCE_COLOR set (any non-empty, non-"0") → enabled, even on non-TTYs
 //   - otherwise: enabled iff stderr is a TTY
 //
+// FORCE_COLOR affects colours only: glyph/spinner selection still keys
+// off the writer's TTY state, so pipes always get the ASCII fallbacks.
 // Cached after first check to avoid re-stat'ing stderr on every line.
 func colorEnabled() bool {
 	colorMu.Lock()

--- a/internal/uxlog/spinner.go
+++ b/internal/uxlog/spinner.go
@@ -47,10 +47,9 @@ const spinnerInterval = 100 * time.Millisecond
 // anything else to stderr, otherwise the spinner's redraw will fight the
 // caller's output.
 //
-// A nil-safe no-op spinner is returned when stderr is not a TTY *and* the
-// caller is in quiet mode (we still print a static line when stderr is a
-// pipe but the program isn't quiet — log files should record the wait
-// happened).
+// On non-TTY stderr a single static "[*] msg" line is printed instead —
+// log files should record the wait happened. Quiet mode is the caller's
+// concern (don't start a spinner); the package consults no flags.
 func StartSpinner(msg string) *Spinner {
 	s := &Spinner{
 		msg:  msg,

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -101,6 +101,37 @@ const barWidth = 40
 // figure becomes meaningful.
 const rateThreshold = 1 << 20
 
+// activeProgress is the bar currently drawing on the terminal, if any.
+// Println routes through it so foreign lines (retry notices) land between
+// refresh frames instead of inside one. There is only ever one bar at a
+// time per process.
+var (
+	activeMu       sync.Mutex
+	activeProgress *Progress
+)
+
+// Println writes a full line to stderr. While a TTY progress bar is
+// live, the line is handed to mpb so it prints above the bar instead of
+// colliding with the in-place redraw.
+func Println(line string) {
+	activeMu.Lock()
+	p := activeProgress
+	activeMu.Unlock()
+	if p != nil && p.mp != nil {
+		if _, err := fmt.Fprintln(p.mp, line); err == nil {
+			return
+		}
+		// mpb already shut down (ErrDone) — fall through to plain stderr.
+	}
+	fmt.Fprintln(os.Stderr, line)
+}
+
+func setActive(p *Progress) {
+	activeMu.Lock()
+	activeProgress = p
+	activeMu.Unlock()
+}
+
 // New constructs a Progress that writes to stderr (the only sink the spec
 // allows for visual output).
 //
@@ -117,6 +148,7 @@ func New(totalBytes int64) *Progress {
 		}}
 	}
 	p := &Progress{}
+	defer setActive(p)
 
 	p.mp = mpb.New(
 		mpb.WithOutput(os.Stderr),
@@ -277,6 +309,7 @@ func (p *Progress) Done() {
 		p.bar.Abort(false)
 	}
 	p.mp.Wait()
+	setActive(nil)
 }
 
 // IsTTY reports whether w refers to a terminal.


### PR DESCRIPTION
## Summary

Second full CLI UX audit (help surfaces, error paths, live transfers, interactive prompts/signals, and a static review of every user-facing string). No P0s found; this PR fixes the three P1s and the worthwhile P2/P3 polish.

### P1 fixes
- **Ctrl-C at a `--pass` prompt no longer leaves the terminal with echo off.** The signal handler is installed before the prompts and both prompts are context-aware, so SIGINT restores termios and prints a clean `[i] [E026] Cancelled.` (exit 130).
- **No more silent LAN-only degrade.** Any server-pairing failure (429 per-IP cap, 401, 5xx — previously only "unreachable") now warns `Server unavailable — only receivers on your local network can connect.` with the catalog reason, instead of letting the sender wait forever on a code cross-network receivers can't redeem.
- **`fsend completion` with a missing/unknown shell is a real error.** Previously it printed the full root help and exited 0 — fatal under `eval "$(fsend completion zhs)"`. Now E024/exit 24, and `fsend completion --help` documents the shells.

### UX fixes
- Permission-denied on send maps to E010 ("check the file permissions") instead of the E099 "file an issue" catchall with a doubled Go error chain.
- Config loads before the send spinner, so the E016 corruption warning can't garble the animated line.
- Retry notices print through the live mpb bar (new `uxlog.Println`) instead of colliding with the in-place redraw or a pending prompt.
- Sender now sees `✓ Receiver connected — waiting for them to accept.` instead of staring at a dead spinner while the receiver deliberates.
- Transfer summaries time from the first byte — a 20s accept-prompt deliberation no longer reads as a glacial transfer.
- `--out` validated up front (a missing dir used to fail only at write time, after burning the sender's one-shot code); receive-side flags rejected when sending; `fsend --pass file.txt` consuming the path as a password is caught with a corrective hint; empty positionals rejected; empty archives warn (`check --exclude`).
- `TERM=dumb` renders fully plain (was: 98 ANSI escapes + braille spinner).
- User-initiated cancel/decline use the neutral `[i]` glyph; the receiver's own decline reads `Declined.` instead of third-person `[FAIL] Receiver declined the transfer.` (sender wording unchanged).
- E018 no longer hardcodes the default server for self-hosted 410s (renders `Server: <addr>` like E001); E012 issue URL uses `?labels=`; hints for `fsend version` and `fsend send <file>` muscle memory; the receive-code hint is suppressed under explicit `--send`.
- `HumanBytes` drops trailing `.0` (`100 MB`, matching the server's `100MiB` config); uninstall prompt matches house prompt style; stale space-separated `--connect` password syntax corrected in two strings; >80-col help/notice lines wrapped; stale uxlog doc comments fixed.

### Deliberately not done (kept minimal)
Password retry attempts (single-attempt stays; protocol change), flag did-you-mean, directory preview before accept, wire-level cancel signaling (receiver still races retry-vs-E026 on sender Ctrl-C), SIGTERM exit 143 (130 kept for both signals), narrow-terminal help rewrap.

## Test plan
- `go test ./...` green, including e2e.
- Verified live against the built binary: completion errors/help, all new usage guards, empty-archive warnings, uninstall prompt, `TERM=dumb` (0 escapes under a pty), Ctrl-C glyph + exit 130, and a full local send→receive round trip (server-unavailable notice with E001 detail, "Receiver connected" line, byte-exact payload, first-byte summary timing) plus the decline path on both sides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)