### PR TITLE
fix: release blockers from holistic audit — pairing resilience, consent, integrity

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -651,14 +651,17 @@ func TestCollectItems_Directory_BuildsArchive(t *testing.T) {
 func TestReadLine_BasicCases(t *testing.T) {
 	for _, tc := range []struct {
 		in, want string
+		eof      bool
 	}{
-		{"yes\n", "yes"},
-		{"  Y \n", "y"},
-		{"NO\r\n", "no"},
-		{"", ""},
+		{"yes\n", "yes", false},
+		{"  Y \n", "y", false},
+		{"NO\r\n", "no", false},
+		{"n", "n", false}, // unterminated final line is still an answer
+		{"", "", true},    // closed stdin must be distinguishable from bare Enter
 	} {
-		if got := readLine(strings.NewReader(tc.in)); got != tc.want {
-			t.Errorf("readLine(%q) = %q, want %q", tc.in, got, tc.want)
+		got, eof := readLine(strings.NewReader(tc.in))
+		if got != tc.want || eof != tc.eof {
+			t.Errorf("readLine(%q) = (%q, %v), want (%q, %v)", tc.in, got, eof, tc.want, tc.eof)
 		}
 	}
 }

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -161,9 +161,17 @@ func classifyRelayDrop(ctx context.Context, client *signaling.Client, sessionID,
 // Other errors propagate immediately: code-already-claimed,
 // server-unreachable, ctx-cancelled, etc., are not transient and the
 // caller should hear about them on the first try.
+//
+// Every join — including a 404 — counts against the server's per-IP
+// new-session budget (that's what stops code-space probing), so the
+// schedule is deliberately sparse: ~7 joins across the budget, not a
+// tight poll. And if the server starts throttling us mid-loop after
+// every attempt said "not found", the honest answer is E002, not E017 —
+// a mistyped code must not surface as "too many attempts".
 func joinWithRetry(ctx context.Context, client *signaling.Client, code string, f *flags, existing *uxlog.Spinner) (*server.JoinSessionResponse, error) {
 	deadline := time.Now().Add(joinRetryBudget)
-	delay := 200 * time.Millisecond
+	delay := 500 * time.Millisecond
+	sawNotFound := false
 	var spin *uxlog.Spinner
 	// Close over the variable so a spinner started inside the loop is
 	// still Stopped on return — a plain `defer spin.Stop()` would only
@@ -174,9 +182,13 @@ func joinWithRetry(ctx context.Context, client *signaling.Client, code string, f
 		if err == nil {
 			return joined, nil
 		}
+		if sawNotFound && errors.Is(err, fserrors.ErrRateLimited) {
+			return nil, fserrors.ErrCodeNotFound
+		}
 		if !errors.Is(err, fserrors.ErrCodeNotFound) || time.Now().After(deadline) {
 			return nil, err
 		}
+		sawNotFound = true
 		// Animate a single line for the duration of the wait so the
 		// user knows we're holding for the sender rather than stuck.
 		// If the caller already gave us a running spinner, leave it
@@ -189,7 +201,7 @@ func joinWithRetry(ctx context.Context, client *signaling.Client, code string, f
 			return nil, ctx.Err()
 		case <-time.After(delay):
 		}
-		if delay < time.Second {
+		if delay < 4*time.Second {
 			delay *= 2
 		}
 	}

--- a/cmd/fsend/internet_test.go
+++ b/cmd/fsend/internet_test.go
@@ -7,6 +7,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -89,6 +90,55 @@ func TestJoinWithRetry_NonRetriableErrorPropagatesImmediately(t *testing.T) {
 	}
 	if elapsed > 2*time.Second {
 		t.Errorf("retried a non-retriable error: %v elapsed", elapsed)
+	}
+}
+
+// A mistyped code must report E002, not E017: every 404 join burns the
+// server's per-IP budget, so a strict server can start throttling our
+// own retry loop mid-budget. Once we've seen "not found", a rate-limit
+// response means "still not found, stop asking" — surfacing it as "too
+// many attempts from your network" blames the user for our retries.
+func TestJoinWithRetry_RateLimitAfterNotFoundReportsNotFound(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) <= 2 {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+	client := signaling.New(ts.URL, "test")
+
+	orig := joinRetryBudget
+	defer func() { joinRetryBudget = orig }()
+	joinRetryBudget = 30 * time.Second // must exit on the 429, not the budget
+
+	start := time.Now()
+	_, err := joinWithRetry(context.Background(), client, "abc-defg-jkm", &flags{quiet: true}, nil)
+
+	if !errors.Is(err, fserrors.ErrCodeNotFound) {
+		t.Errorf("expected ErrCodeNotFound when rate-limited after 404s, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 3 {
+		t.Errorf("expected to stop on the first 429 (3 calls), got %d", got)
+	}
+	if elapsed := time.Since(start); elapsed > 5*time.Second {
+		t.Errorf("kept retrying after the 429: %v elapsed", elapsed)
+	}
+}
+
+// A rate limit on the very first join is the genuine article (someone
+// behind this NAT really is hammering the server) and must surface as-is.
+func TestJoinWithRetry_ImmediateRateLimitPropagates(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	_, err := joinWithRetry(context.Background(), signaling.New(ts.URL, "test"), "abc-defg-jkm", &flags{quiet: true}, nil)
+	if !errors.Is(err, fserrors.ErrRateLimited) {
+		t.Errorf("expected ErrRateLimited on first-attempt 429, got %v", err)
 	}
 }
 

--- a/cmd/fsend/main_test.go
+++ b/cmd/fsend/main_test.go
@@ -96,11 +96,11 @@ func TestReadLine(t *testing.T) {
 		"Y\n":       "y",
 		"  Yes  \n": "yes",
 		"\n":        "",
-		"":          "", // EOF → empty
+		"":          "", // EOF → empty (and eof=true, covered in helpers_test)
 		"\r\n":      "",
 	}
 	for in, want := range cases {
-		if got := readLine(strings.NewReader(in)); got != want {
+		if got, _ := readLine(strings.NewReader(in)); got != want {
 			t.Errorf("readLine(%q) = %q, want %q", in, got, want)
 		}
 	}

--- a/cmd/fsend/prompts.go
+++ b/cmd/fsend/prompts.go
@@ -10,34 +10,42 @@ import (
 )
 
 // readLine reads one line from r, trims trailing CR/LF, lowercases it,
-// and returns the result. EOF and read errors both collapse to the empty
-// string so the caller sees "default" rather than a propagated read
-// error — empty input is a valid prompt response, not a failure mode.
+// and returns the result. eof is true when the read produced no input at
+// all (closed stdin, /dev/null, exhausted pipe) — callers that treat an
+// empty line as "take the default" must NOT do so on eof: nobody is
+// answering, and a default that consents to something is a footgun.
+// A read error that still yielded bytes is a valid answer line.
 //
 // When r is os.Stdin, the package-level shared bufio.Reader is used so
 // bytes are not lost between successive prompts (see stdinReader).
-func readLine(r io.Reader) string {
-	if r == os.Stdin {
-		line, _ := stdinReader().ReadString('\n')
-		return strings.ToLower(strings.TrimSpace(line))
+func readLine(r io.Reader) (line string, eof bool) {
+	br := stdinReader()
+	if r != os.Stdin {
+		br = bufio.NewReader(r)
 	}
-	br := bufio.NewReader(r)
-	line, _ := br.ReadString('\n')
-	return strings.ToLower(strings.TrimSpace(line))
+	raw, err := br.ReadString('\n')
+	return strings.ToLower(strings.TrimSpace(raw)), err != nil && raw == ""
 }
 
 // readLineCtx reads one line from os.Stdin but returns ok=false if ctx is
 // cancelled first — e.g. Ctrl-C while the prompt is waiting for input.
 // The blocked read goroutine is abandoned; that is harmless because a
 // cancelled ctx means the process is on its way down.
-func readLineCtx(ctx context.Context) (line string, ok bool) {
-	ch := make(chan string, 1)
-	go func() { ch <- readLine(os.Stdin) }()
+func readLineCtx(ctx context.Context) (line string, eof, ok bool) {
+	type res struct {
+		line string
+		eof  bool
+	}
+	ch := make(chan res, 1)
+	go func() {
+		l, e := readLine(os.Stdin)
+		ch <- res{l, e}
+	}()
 	select {
 	case <-ctx.Done():
-		return "", false
-	case s := <-ch:
-		return s, true
+		return "", false, false
+	case r := <-ch:
+		return r.line, r.eof, true
 	}
 }
 

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -181,8 +181,15 @@ func (ui *receiverUI) promptAccept(h wire.SenderHello) bool {
 	for {
 		fmt.Fprintf(os.Stderr, "  %s [Y/n] ", question)
 		// Decline on Ctrl-C; the caller maps a cancelled ctx to E026.
-		line, ok := readLineCtx(ui.ctx)
+		line, eof, ok := readLineCtx(ui.ctx)
 		if !ok {
+			return false
+		}
+		// Closed stdin must not take the interactive yes-default: a cron
+		// job or `fsend <code> </dev/null` would silently consent to
+		// writing files (and pre-approve an overwrite).
+		if eof {
+			fmt.Fprintf(os.Stderr, "\n%s No input to answer the prompt — declining. Pass --yes to accept automatically.\n", uxlog.Info())
 			return false
 		}
 		switch line {
@@ -206,7 +213,7 @@ func (ui *receiverUI) confirmOverwrite(relPath string, existing int64, incoming 
 	fmt.Fprintf(os.Stderr, "  %s already exists  ·  local %s  ·  incoming %s\n",
 		relPath, uxlog.HumanBytes(existing), uxlog.HumanBytes(int64(incoming)))
 	fmt.Fprint(os.Stderr, "  Overwrite? [y/N] ")
-	line, ok := readLineCtx(ui.ctx)
+	line, _, ok := readLineCtx(ui.ctx)
 	if !ok {
 		return false
 	}

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -505,7 +505,7 @@ func promptCodeOrPath(f *flags, arg string) error {
 	fmt.Fprintf(os.Stderr, "\n  %q matches a code AND is a local file.\n", arg)
 	fmt.Fprintf(os.Stderr, "  [s]end this file, or [r]eceive with this code? (r): ")
 
-	resp := readLine(os.Stdin)
+	resp, _ := readLine(os.Stdin)
 	switch resp {
 	case "s", "send":
 		return runSend(f, []string{arg})

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -118,6 +118,24 @@ func pairOverLAN(ctx context.Context, code string) (*lanSenderPairing, error) {
 	}, nil
 }
 
+// waitMaxConsecFails is how many consecutive Wait failures the sender
+// tolerates (sleeping 2s·n between attempts) before giving up on the
+// internet path and deleting the session.
+const waitMaxConsecFails = 6
+
+// firstAcceptTimeout bounds the first QUIC accept after the receiver
+// joins. The receiver's connect ladder (LAN dial → ICE → relay, with
+// dial retries) gives up well inside this window, so expiry means the
+// receiver is gone — without the bound the sender spins "Waiting for
+// receiver" forever.
+const firstAcceptTimeout = 60 * time.Second
+
+// errPairedGone marks failures after a receiver claimed the code. The
+// LAN race can't recover from these — a receiver that joined via the
+// server already failed LAN discovery — so the coordinator aborts
+// instead of waiting on a doomed LAN listener.
+var errPairedGone = fmt.Errorf("%w: the receiver paired but the connection could not be established", fserrors.ErrConnectFailed)
+
 // pairOverInternet runs the full pairing-server + ICE/relay handshake and
 // returns once the receiver has paired and the QUIC SenderHandshake
 // over the established data path is up.
@@ -139,42 +157,32 @@ func pairOverInternet(ctx context.Context, f *flags, code string, cfg *config.Co
 	// ctx may already be cancelled (e.g., the LAN path won the race).
 	deleteSession := func() { _ = client.Delete(context.Background(), created.SessionID, created.RoleToken) }
 
-	// Long-poll indefinitely until the receiver pairs, the user
-	// cancels, or the server reaps the session. The server's per-call
-	// long-poll timeout returns nil periodically; we just re-issue.
-	// There is no client-side deadline — the user controls the wait
-	// duration by keeping the terminal open.
-	//
-	// If the server reaps the session out from under us (unpaired TTL
-	// hit on the server side; ErrCodeNotFound from Wait), we surface a
-	// dedicated "session expired" error instead of the receiver-side
-	// E002 wording.
-	var waitResp *server.WaitResponse
-	for waitResp == nil {
-		resp, err := client.Wait(ctx, created.Code)
-		if err != nil {
-			if errors.Is(err, fserrors.ErrCodeNotFound) {
-				deleteSession()
-				return nil, fserrors.ErrSessionExpired
-			}
-			deleteSession()
-			return nil, err
-		}
-		waitResp = resp
+	waitResp, err := waitForReceiver(ctx, client, created.Code)
+	if err != nil {
+		deleteSession()
+		return nil, err
 	}
 
 	// Establish the underlying data path: ICE-direct first, relay fallback.
 	pc, pathInfo, err := establishInternetDataPath(ctx, f, client, created, waitResp)
 	if err != nil {
 		deleteSession()
+		if ctx.Err() == nil {
+			err = fmt.Errorf("%w: %v", errPairedGone, err)
+		}
 		return nil, err
 	}
 
 	// Bring up QUIC on the established PacketConn and run the sender
 	// handshake on the first peer. Retries re-Accept on the same listener.
-	ln, res, teardown, err := senderQUICAccept(ctx, pc, created.Code)
+	acceptCtx, cancelAccept := context.WithTimeout(ctx, firstAcceptTimeout)
+	ln, res, teardown, err := senderQUICAccept(acceptCtx, pc, created.Code)
+	cancelAccept()
 	if err != nil {
 		deleteSession()
+		if ctx.Err() == nil {
+			err = fmt.Errorf("%w: %v", errPairedGone, err)
+		}
 		return nil, err
 	}
 
@@ -191,6 +199,53 @@ func pairOverInternet(ctx context.Context, f *flags, code string, cfg *config.Co
 			deleteSession()
 		},
 	}, nil
+}
+
+// waitRetryStep scales the backoff between Wait retries (n·step for the
+// n-th consecutive failure). Var so tests can shrink it.
+var waitRetryStep = 2 * time.Second
+
+// waitForReceiver long-polls Wait until the receiver pairs, the user
+// cancels, or the server reaps the session. The server's per-call
+// long-poll timeout returns nil periodically; we just re-issue. There
+// is no client-side deadline — the user controls the wait duration by
+// keeping the terminal open.
+//
+// If the server reaps the session (unpaired TTL; ErrCodeNotFound from
+// Wait), we surface a dedicated "session expired" error instead of the
+// receiver-side E002 wording.
+//
+// Anything else is retried with backoff: senders wait minutes, and a
+// single dropped poll (wifi roam, laptop sleep/wake) must not abandon a
+// session the server still holds. The give-up threshold counts
+// consecutive failures, not elapsed time — a wall-clock deadline would
+// expire during a long sleep and kill the code on wake.
+func waitForReceiver(ctx context.Context, client *signaling.Client, code string) (*server.WaitResponse, error) {
+	consecFails := 0
+	for {
+		resp, err := client.Wait(ctx, code)
+		switch {
+		case err == nil:
+			consecFails = 0
+			if resp != nil {
+				return resp, nil
+			}
+		case ctx.Err() != nil:
+			return nil, ctx.Err()
+		case errors.Is(err, fserrors.ErrCodeNotFound):
+			return nil, fserrors.ErrSessionExpired
+		default:
+			consecFails++
+			if consecFails >= waitMaxConsecFails {
+				return nil, err
+			}
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(time.Duration(consecFails) * waitRetryStep):
+			}
+		}
+	}
 }
 
 // establishInternetDataPath wraps the ICE-then-relay ladder. On ICE
@@ -377,6 +432,15 @@ func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem,
 			serverErr = res.err
 			if errors.Is(serverErr, context.Canceled) {
 				continue
+			}
+			// A receiver claimed the code and then the connection died.
+			// That receiver already failed LAN discovery, so waiting on
+			// the LAN listener can never pair — abort the race.
+			if errors.Is(serverErr, errPairedGone) {
+				waitSpin.Stop()
+				cancelPair()
+				drainBoth(lanCh, serverCh, lanDone, serverDone)
+				return serverErr
 			}
 			// Any server-path failure (unreachable, rate-limited, bad
 			// password, 5xx) leaves the code working on the local network

--- a/cmd/fsend/sendpair_test.go
+++ b/cmd/fsend/sendpair_test.go
@@ -1,13 +1,89 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/signaling"
 )
+
+// shrinkWaitRetryStep makes waitForReceiver's backoff test-fast.
+func shrinkWaitRetryStep(t *testing.T) {
+	t.Helper()
+	orig := waitRetryStep
+	waitRetryStep = 2 * time.Millisecond
+	t.Cleanup(func() { waitRetryStep = orig })
+}
+
+// A transient Wait failure (dropped poll, wifi roam, sleep/wake) must be
+// retried, not treated as fatal — the old behavior deleted the session
+// on the first blip, so the shared code died while the sender kept
+// "waiting" on a path nobody could reach.
+func TestWaitForReceiver_RetriesTransientFailures(t *testing.T) {
+	shrinkWaitRetryStep(t)
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		switch atomic.AddInt32(&calls, 1) {
+		case 1, 2:
+			w.WriteHeader(http.StatusBadGateway) // transient server hiccup
+		case 3:
+			w.WriteHeader(http.StatusNoContent) // normal long-poll tick
+		default:
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{}`)) // receiver paired
+		}
+	}))
+	defer ts.Close()
+
+	resp, err := waitForReceiver(context.Background(), signaling.New(ts.URL, "test"), "abc-defg-jkm")
+	if err != nil || resp == nil {
+		t.Fatalf("expected pairing to survive transient failures, got resp=%v err=%v", resp, err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 4 {
+		t.Errorf("expected 4 Wait calls (2 fail, 1 tick, 1 paired), got %d", got)
+	}
+}
+
+// Persistent failure must still give up (and let the caller delete the
+// session) rather than retry forever against a dead server.
+func TestWaitForReceiver_GivesUpAfterConsecutiveFailures(t *testing.T) {
+	shrinkWaitRetryStep(t)
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusBadGateway)
+	}))
+	defer ts.Close()
+
+	_, err := waitForReceiver(context.Background(), signaling.New(ts.URL, "test"), "abc-defg-jkm")
+	if err == nil {
+		t.Fatal("expected an error from a persistently failing server")
+	}
+	if got := atomic.LoadInt32(&calls); got != waitMaxConsecFails {
+		t.Errorf("expected exactly %d Wait calls, got %d", waitMaxConsecFails, got)
+	}
+}
+
+// A reaped session (server-side TTL) is not transient: surface the
+// dedicated expired error immediately.
+func TestWaitForReceiver_SessionReapedSurfacesExpired(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer ts.Close()
+
+	_, err := waitForReceiver(context.Background(), signaling.New(ts.URL, "test"), "abc-defg-jkm")
+	if !errors.Is(err, fserrors.ErrSessionExpired) {
+		t.Errorf("expected ErrSessionExpired for a reaped session, got %v", err)
+	}
+}
 
 // timeAfter500ms is the shared deadline for the deadlock-regression
 // tests. Used as a generous upper bound on "drainBoth/drainLoser must

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -95,7 +95,8 @@ func confirmUninstall(f *flags) bool {
 		fmt.Fprintf(os.Stderr, "    - config dir: %s\n", cfgDir)
 	}
 	fmt.Fprint(os.Stderr, "  Continue? [y/N] ")
-	switch readLine(os.Stdin) {
+	line, _ := readLine(os.Stdin)
+	switch line {
 	case "y", "yes":
 		return true
 	default:

--- a/docs/security.md
+++ b/docs/security.md
@@ -90,7 +90,9 @@ Effectively nothing:
 
 - **No access log. No per-transfer log line.** The default log level
   only emits lifecycle events — startup, shutdown, and errors.
-- **No IP addresses or share codes in logs**, at any level.
+- **No IP addresses or share codes in logs** at the default level.
+  (`FSEND_LOG_LEVEL=debug` logs both for troubleshooting — don't run a
+  privacy-sensitive server at debug level.)
 - **No database, no persistence layer.** Pairing state never touches
   disk — it lives in RAM, evicts within an hour at most (ten minutes
   once a transfer has paired), and is gone forever on restart.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -59,14 +59,14 @@ sending, then confirms. Pass `--yes` to skip.
 | Flag | Purpose |
 |---|---|
 | `--yes` | Auto-accept. |
-| `--out <dir>` | Receive into this directory (created if missing). Default: cwd. |
+| `--out <dir>` | Receive into this directory (must already exist). Default: cwd. |
 | `--out -` | Stream the payload to stdout instead of saving a file (single file, text, or piped stream — not directories). Retries are disabled: emitted bytes can't be rewound. |
 | `--overwrite` | Replace existing files instead of failing with `E013`. |
 | `--pass <password>` | Supply the sender's password non-interactively. Also `FSEND_PASS`. |
 
 ```sh
 fsend abc-defg-jkm
-fsend --yes --out ~/Downloads/incoming abc-defg-jkm
+fsend --yes --out ~/Downloads abc-defg-jkm
 fsend --yes --out - abc-defg-jkm > dump.sql   # pipe-to-pipe with the sender's `… | fsend`
 FSEND_PASS=swordfish fsend --yes abc-defg-jkm
 ```

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -195,5 +195,7 @@ var terminalSentinels = []error{
 	fserrors.ErrServerRetired,
 	fserrors.ErrWrongPassword,      // wrong password is one-shot per session
 	fserrors.ErrCodeAlreadyClaimed, // sender already paired; no retry will recover
-	context.Canceled,               // user hit Ctrl-C
+	fserrors.ErrWriteFailed,        // peer's (or our) disk problem; retrying won't fix it
+	fserrors.ErrDiskFull,
+	context.Canceled, // user hit Ctrl-C
 }

--- a/internal/transfer/archive.go
+++ b/internal/transfer/archive.go
@@ -240,6 +240,13 @@ func addToTar(tw *tar.Writer, abs string, relTop string, st os.FileInfo, m exclu
 		return nil
 
 	default:
+		// FIFOs block os.Open until a writer appears (hanging the send
+		// before the code even prints) and sockets/devices can't be
+		// copied — skip them, mirroring the extract side's handling of
+		// exotic tar types.
+		if !mode.IsRegular() {
+			return nil
+		}
 		hdr.Typeflag = tar.TypeReg
 		hdr.Size = st.Size()
 		if err := tw.WriteHeader(hdr); err != nil {

--- a/internal/transfer/archive_test.go
+++ b/internal/transfer/archive_test.go
@@ -7,8 +7,11 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
+	"syscall"
 	"testing"
+	"time"
 
 	"github.com/polius/fsend/internal/fserrors"
 )
@@ -147,6 +150,43 @@ func TestBuildArchive_ExcludePatterns(t *testing.T) {
 				t.Errorf("expected %q to be excluded, but found it", bad)
 			}
 		}
+	}
+}
+
+// A FIFO inside a sent folder used to hang BuildArchive forever
+// (os.Open on a fifo blocks until a writer appears — before the share
+// code was even printed); a socket aborted the whole send. Both must be
+// skipped.
+func TestBuildArchive_SkipsSpecialFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("no mkfifo on windows")
+	}
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "real.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(srcDir, "pipe.fifo"), 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	done := make(chan struct{})
+	var arc *ArchiveResult
+	var err error
+	go func() {
+		arc, err = BuildArchive([]string{srcDir}, nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("BuildArchive hung on the fifo")
+	}
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer os.Remove(arc.Path)
+	if arc.NumFiles != 1 {
+		t.Errorf("NumFiles = %d, want 1 (fifo skipped)", arc.NumFiles)
 	}
 }
 

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -149,6 +149,14 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 		if ft != wire.TypeFileInfo {
 			return fmt.Errorf("%w: expected FILE_INFO, got %v", fserrors.ErrProtocolError, ft)
 		}
+		// Streaming exempts a file from the declared-size cap and the
+		// root-hash check. Only a stdin transfer legitimately needs that;
+		// accepting it elsewhere would let a sender who advertised a
+		// small size stream unbounded, unverified bytes.
+		if info.Streaming && hello.TransferKind != wire.TransferStdin {
+			declineTransfer(s, wire.ErrCodeProtocolError, "streaming file in non-stdin transfer")
+			return fmt.Errorf("%w: streaming FILE_INFO in a non-stdin transfer", fserrors.ErrProtocolError)
+		}
 		if err := recvOneFile(ctx, s, &info, opts, archiveMode); err != nil {
 			return err
 		}
@@ -366,6 +374,11 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 		}
 	}
 	if err != nil {
+		// FILE_ACCEPT is already out, so the sender is streaming chunks:
+		// abort the data stream and say why (same shape as a mid-loop
+		// write failure), or the sender misreads this as a network drop.
+		_ = s.Data.Close()
+		declineTransfer(s, wire.ErrCodeWriteFailed, "open failed: "+err.Error())
 		return fmt.Errorf("%w: open partial: %v", fserrors.ErrWriteFailed, err)
 	}
 	defer func() { _ = f.Close() }()
@@ -374,9 +387,13 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 	// with what the sender will start writing from resumeOffset.
 	if action == wire.ActionResume {
 		if err := f.Truncate(int64(resumeOffset)); err != nil {
+			_ = s.Data.Close()
+			declineTransfer(s, wire.ErrCodeWriteFailed, "truncate failed: "+err.Error())
 			return fmt.Errorf("%w: truncate partial: %v", fserrors.ErrWriteFailed, err)
 		}
 		if _, err := f.Seek(int64(resumeOffset), io.SeekStart); err != nil {
+			_ = s.Data.Close()
+			declineTransfer(s, wire.ErrCodeWriteFailed, "seek failed: "+err.Error())
 			return fmt.Errorf("%w: seek: %v", fserrors.ErrWriteFailed, err)
 		}
 	}
@@ -457,6 +474,14 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 
 		if len(plain) > 0 {
 			if _, err := f.Write(plain); err != nil {
+				// Abort the data stream first (Close cancels the QUIC
+				// read side) so the sender's chunk writes fail fast
+				// instead of blocking on flow control, then say why —
+				// otherwise the sender misreads our exit as a network
+				// drop and burns retries telling the user to check
+				// their connection.
+				_ = s.Data.Close()
+				declineTransfer(s, wire.ErrCodeWriteFailed, "write failed: "+err.Error())
 				return classifyWriteErr("write", err)
 			}
 			// blake3.Hasher.Write never returns an error — it just
@@ -629,6 +654,9 @@ func recvPayloadToSink(ctx context.Context, s *Streams, info *wire.FileInfo, opt
 		}
 		if len(plain) > 0 {
 			if _, err := opts.Sink.Write(plain); err != nil {
+				// Same shape as the file path: abort data, then explain.
+				_ = s.Data.Close()
+				declineTransfer(s, wire.ErrCodeWriteFailed, "write failed: "+err.Error())
 				return classifyWriteErr("sink write", err)
 			}
 			_, _ = verifier.Write(plain)
@@ -748,6 +776,8 @@ func tryReadPeerError(r io.Reader) error {
 		return fserrors.ErrPartialMismatch
 	case wire.ErrCodeFileHashMismatch:
 		return fserrors.ErrHashMismatch
+	case wire.ErrCodeWriteFailed:
+		return fmt.Errorf("%w: receiver: %s", fserrors.ErrWriteFailed, ef.Message)
 	default:
 		return fmt.Errorf("%w: peer reported %d: %s", fserrors.ErrProtocolError, ef.Code, ef.Message)
 	}

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -368,7 +368,17 @@ func writeChunk(s *Streams, info *wire.FileInfo, chunkIndex uint32, plain []byte
 		}
 	}
 	c.Payload = payload
-	return wire.WriteChunk(s.Data, c)
+	if err := wire.WriteChunk(s.Data, c); err != nil {
+		// The receiver cancels the data stream when its local write
+		// fails and posts the reason on control. Surface that instead
+		// of the bare stream error, which classifies as a transient
+		// network drop and triggers pointless retries.
+		if reason := tryReadPeerError(s.Control); reason != nil {
+			return reason
+		}
+		return err
+	}
+	return nil
 }
 
 func blakeHash32(b []byte) [32]byte {

--- a/internal/transfer/streaming_guard_test.go
+++ b/internal/transfer/streaming_guard_test.go
@@ -1,0 +1,88 @@
+package transfer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/wire"
+)
+
+// TestRecv_RejectsStreamingFileInNonStdinTransfer locks in the guard
+// against the size-cap/hash-check bypass: Streaming exempts a file from
+// the declared-size cap and the BLAKE3 root check, so a malicious
+// sender could advertise a small single-file transfer at the accept
+// prompt and then mark its FILE_INFO Streaming to pour unbounded,
+// unverified bytes onto the receiver's disk. Only TransferStdin may
+// carry streaming items.
+func TestRecv_RejectsStreamingFileInNonStdinTransfer(t *testing.T) {
+	dstDir := t.TempDir()
+	sender, receiver := pipePair()
+
+	hello := &wire.SenderHello{
+		ProtocolVersion: wire.ProtocolVersion,
+		TransferKind:    wire.TransferSingleFile,
+		TotalFiles:      1,
+		TotalBytes:      5, // what the accept prompt would show
+		DisplayName:     "small.bin",
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var recvErr error
+	go func() {
+		defer wg.Done()
+		recvErr = Recv(context.Background(), &receiver, RecvOptions{
+			TargetDir: dstDir,
+			Accept:    func(_ wire.SenderHello) bool { return true },
+		})
+		_ = receiver.Control.Close()
+		_ = receiver.Data.Close()
+	}()
+
+	var gotFrameType wire.FrameType
+	go func() {
+		defer wg.Done()
+		defer sender.Control.Close()
+		defer sender.Data.Close()
+		_ = wire.WriteControl(sender.Control, wire.TypeHello, hello)
+
+		var ack wire.ReceiverHello
+		_, _ = wire.ReadControl(sender.Control, &ack)
+		if !ack.Accepts {
+			return
+		}
+
+		// Malicious: Streaming on a single-file transfer (zero root,
+		// non-resumable → would also skip the final hash check).
+		fi := wire.FileInfo{
+			Index:        0,
+			RelativePath: "small.bin",
+			Size:         5,
+			Mode:         0o644,
+			Streaming:    true,
+			Resumable:    false,
+		}
+		_ = wire.WriteControl(sender.Control, wire.TypeFileInfo, &fi)
+
+		var ef wire.ErrorFrame
+		gotFrameType, _ = wire.ReadControl(sender.Control, &ef)
+	}()
+
+	wg.Wait()
+
+	if !errors.Is(recvErr, fserrors.ErrProtocolError) {
+		t.Errorf("expected ErrProtocolError for streaming FILE_INFO in single-file transfer, got %v", recvErr)
+	}
+	if gotFrameType != wire.TypeError {
+		t.Errorf("sender should receive an ERROR frame, got frame type %v", gotFrameType)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "small.bin"+partialSuffix)); err == nil {
+		t.Error("receiver opened a partial for the rejected file")
+	}
+}

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -62,11 +62,11 @@ func (p *plainProgress) add(n int64) {
 	}
 	p.lastLine = time.Now()
 	if p.total > 0 {
-		fmt.Fprintf(p.w, "  %d%%  %s / %s\n",
+		_, _ = fmt.Fprintf(p.w, "  %d%%  %s / %s\n",
 			p.current*100/p.total, HumanBytes(p.current), HumanBytes(p.total))
 		return
 	}
-	fmt.Fprintf(p.w, "  %s\n", HumanBytes(p.current))
+	_, _ = fmt.Fprintf(p.w, "  %s\n", HumanBytes(p.current))
 }
 
 func (p *plainProgress) setTotal(total int64, complete bool) {


### PR DESCRIPTION
Fixes the release blockers and high-stakes findings from the 2026-06-11 holistic audit (5 parallel deep reviews + live scenario battery). Every fix was validated empirically against a live binary — both on a local server and the production server.

## Functional blockers

- **Mistyped code reported E017 "rate limited" and locked the IP out.** The join retry loop made ~12 tight joins per 15s budget; every join (including 404s) counts against the server's per-IP new-session bucket, so a single wrong code self-tripped the limiter. Now: ~7 sparse joins (500ms→4s backoff), stop on the first 429, and report the truthful **E002** when the server throttles a loop that only ever saw "not found". *Verified on the production server: exit 2 / E002, immediate retry also E002 in 4s.* (Infra follow-up, not in this PR: raise `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` on the deployed server — it's set below the default 30.)
- **One transient Wait failure killed the shared code.** The sender's wait loop treated any non-404 error as fatal and *deleted the session* — a wifi roam or laptop sleep/wake while "Waiting for receiver" meant later receivers got "code expired". Extracted `waitForReceiver` retries with backoff, bounded by **consecutive** failures (deliberately not wall-clock, so a long sleep doesn't expire the budget on wake). *Verified: 50s server SIGSTOP mid-wait → sender survives, transfer completes checksum-clean; server killed outright → clean E001 after ~31s.*

## Consent / integrity

- **EOF at the accept prompt auto-accepted the transfer.** `fsend <code> </dev/null` (cron, CI) wrote files to disk — and could pre-consent an overwrite — with nobody answering. `readLine` now distinguishes closed-stdin from bare Enter; EOF declines with a hint to use `--yes`. Plain Enter still means yes.
- **`Streaming=true` bypassed the declared-size cap and the BLAKE3 root check.** The receiver never cross-checked it against the transfer kind, so a sender that displayed "5 MB" at the prompt could fill the disk with unverified bytes (defeating the #36 protection). Streaming FILE_INFOs are now rejected unless the hello declared `TransferStdin`. Locked in by a malicious-sender protocol test.
- **A FIFO inside a sent folder hung the send forever** (`os.Open` blocks before the code even prints); a `.sock` file aborted the whole transfer. `BuildArchive` now skips non-regular files, mirroring the extract side.

## Failure-path UX

- **Sender hung forever if the receiver died after joining.** The first QUIC accept is now bounded (60s), and post-pairing failures wrap a sentinel that **aborts the LAN race** — necessary because a receiver that joined via the server has already failed LAN discovery, so the old code kept waiting on a doomed LAN listener even after the accept timed out. *Verified with a curl fake-join: exits in ~76s with an accurate E014; previously infinite.*
- **Sender blamed the network for receiver-side disk failures.** Receiver write failures (open/truncate/seek/mid-chunk/sink) now cancel the data stream and post an ERROR frame; the sender's `writeChunk` peeks control on a data-write failure and surfaces role-aware **E009** ("The receiver could not write the file to disk") instead of E020 retry churn. The `CancelRead` ordering avoids the flow-control deadlock a naive ERROR-frame fix would introduce. `ErrWriteFailed`/`ErrDiskFull` added to the retry terminal sentinels.

## Docs / lint

- security.md no longer claims codes/IPs are absent from logs "at any level" (debug logs both); states the exception explicitly.
- usage.md `--out` row now matches the code's deliberate fail-fast behavior (must exist).
- Two `errcheck` violations in `uxlog.go` fixed — first CI run after billing is restored will be green.

## Not in this PR (audit follow-ups)

Relay bootstrap ACK, ICE/relay split-brain, relay metrics/global byte caps; infra items (CI billing, installer endpoint, deployed rate-limit env). The Linux+avahi mDNS concern from the audit was **empirically disproven** (Go stdlib sets SO_REUSEADDR and wildcard-rewrites multicast binds; real LAN transfer verified in a container alongside avahi) — no code change needed.

## Testing

- Full suite + e2e with `-race`, fresh: all pass. `go vet` + `golangci-lint`: clean.
- New regression tests: join rate-limit→E002 (×2), `waitForReceiver` retry/give-up/expired (×3), streaming-bypass guard, FIFO skip, readLine EOF contract.
- Live battery: wrong code (production server), EOF-accept, FIFO folder, read-only `--out`, 50s outage, server death, fake join, stdin pipe, `--text` UTF-8, password wrong/right, collision E013, `--overwrite`, 300 MB kill-and-resume — every payload checksum-verified, all exit codes correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)