### PR TITLE
fix: second holistic-audit round — data loss, consent, server code-blindness, UX honesty

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,9 @@ jobs:
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
+            # Tag-pushes only: a workflow_dispatch from a branch must not
+            # repoint `latest` at an untagged build.
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, '-') }}
       # Mirrors the goreleaser ldflags so the image doesn't report "fsend dev".
       - id: buildmeta
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,26 @@ permissions:
   id-token: write
 
 jobs:
+  # Same as checks.yml's test job: tag pushes don't run PR checks, so
+  # gate the release on a fresh run.
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.25"
+          cache: true
+      - run: go build ./...
+      - run: go vet ./...
+      - run: go test -timeout 120s ./...
+
   goreleaser:
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -738,6 +738,88 @@ func TestPromptAccept_YesAcceptsAcrossKinds(t *testing.T) {
 	}
 }
 
+func TestPromptAccept_MultiFileNamesShown(t *testing.T) {
+	got := captureStderr(t, func() {
+		h := wire.SenderHello{
+			TransferKind: wire.TransferMultiFile,
+			TotalFiles:   3,
+			TotalBytes:   100,
+			FileNames:    []string{"a.bin", "b.bin", "c.bin"},
+		}
+		ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
+		_ = ui.promptAccept(h)
+	})
+	for _, name := range []string{"a.bin", "b.bin", "c.bin"} {
+		if !strings.Contains(got, name) {
+			t.Errorf("prompt missing %q:\n%s", name, got)
+		}
+	}
+	if strings.Contains(got, "more") {
+		t.Errorf("complete list must not print an overflow line:\n%s", got)
+	}
+}
+
+func TestPromptAccept_MultiFileNamesCapped(t *testing.T) {
+	names := make([]string, 8)
+	for i := range names {
+		names[i] = fmt.Sprintf("file%d.bin", i)
+	}
+	got := captureStderr(t, func() {
+		h := wire.SenderHello{
+			TransferKind: wire.TransferMultiFile,
+			TotalFiles:   20,
+			TotalBytes:   100,
+			FileNames:    names,
+		}
+		ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
+		_ = ui.promptAccept(h)
+	})
+	// First five shown, the rest summarised against TotalFiles.
+	if !strings.Contains(got, "file4.bin") {
+		t.Errorf("fifth name missing:\n%s", got)
+	}
+	if strings.Contains(got, "file5.bin") {
+		t.Errorf("display cap exceeded:\n%s", got)
+	}
+	if !strings.Contains(got, "and 15 more") {
+		t.Errorf("overflow line missing:\n%s", got)
+	}
+}
+
+func TestPromptAccept_MultiFileNoNamesFromOldSender(t *testing.T) {
+	// Pre-FileNames senders leave the list nil; the prompt falls back to
+	// the bare count with no name lines and no overflow line.
+	got := captureStderr(t, func() {
+		h := wire.SenderHello{TransferKind: wire.TransferMultiFile, TotalFiles: 3, TotalBytes: 100}
+		ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
+		_ = ui.promptAccept(h)
+	})
+	if !strings.Contains(got, "3 files") {
+		t.Errorf("count line missing:\n%s", got)
+	}
+	if strings.Contains(got, "more") {
+		t.Errorf("overflow line must not render without names:\n%s", got)
+	}
+}
+
+func TestSummaryParts_ResumeShowsMovedAndHonestRate(t *testing.T) {
+	// 200 MB total, 50 MB moved in 1s → size annotated with the moved
+	// clause and the rate computed from moved, not total.
+	total, moved := int64(200_000_000), int64(50_000_000)
+	parts := strings.Join(summaryParts(total, moved, "sent", time.Second, mustLANInfo()), "  ·  ")
+	if !strings.Contains(parts, "200 MB (50 MB sent)") {
+		t.Errorf("missing moved clause: %s", parts)
+	}
+	if !strings.Contains(parts, "50 MB/s") {
+		t.Errorf("rate must derive from moved bytes: %s", parts)
+	}
+	// Non-resumed: no annotation, rate from the full size.
+	parts = strings.Join(summaryParts(total, total, "sent", time.Second, mustLANInfo()), "  ·  ")
+	if strings.Contains(parts, "(") || !strings.Contains(parts, "200 MB/s") {
+		t.Errorf("non-resumed summary changed shape: %s", parts)
+	}
+}
+
 func TestPromptAccept_PasswordChipRendered(t *testing.T) {
 	got := captureStderr(t, func() {
 		h := wire.SenderHello{

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -644,6 +644,41 @@ func TestCollectItems_Directory_BuildsArchive(t *testing.T) {
 	}
 }
 
+// --exclude only affects directory bundling; anywhere else it was
+// silently ignored — now a usage error.
+func TestCollectItems_ExcludeWithoutDirectory(t *testing.T) {
+	dir := t.TempDir()
+	fp := filepath.Join(dir, "f.txt")
+	if err := os.WriteFile(fp, []byte("body"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, tc := range []struct {
+		name  string
+		f     *flags
+		paths []string
+	}{
+		{"plain_file", &flags{excludes: []string{"*.log"}}, []string{fp}},
+		{"text", &flags{excludes: []string{"*.log"}, textArg: "hi"}, nil},
+		{"stdin", &flags{excludes: []string{"*.log"}}, []string{"-"}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, _, _, _, _, err := collectItems(tc.f, tc.paths)
+			if !errors.Is(err, fserrors.ErrUsage) {
+				t.Fatalf("err = %v, want ErrUsage", err)
+			}
+			if !strings.Contains(err.Error(), "--exclude only applies when sending a directory") {
+				t.Errorf("err = %q, want --exclude hint", err)
+			}
+		})
+	}
+	// A directory among the inputs keeps --exclude valid.
+	_, _, _, _, cleanup, err := collectItems(&flags{excludes: []string{"*.log"}}, []string{dir})
+	if err != nil {
+		t.Fatalf("directory with --exclude must not error: %v", err)
+	}
+	cleanup()
+}
+
 // ---------------------------------------------------------------------------
 // prompts.go readLine
 // ---------------------------------------------------------------------------

--- a/cmd/fsend/internet_test.go
+++ b/cmd/fsend/internet_test.go
@@ -158,7 +158,7 @@ func TestClassifyRelayDrop_MapsReasons(t *testing.T) {
 	}{
 		{
 			name:       "cap_hit_with_limit_includes_value",
-			body:       `{"state":"evicted","reason":"cap_hit","limit_bytes":104857600}`,
+			body:       `{"state":"evicted","reason":"cap_hit","limit_bytes":100000000}`,
 			runErr:     errors.New("idle timeout"),
 			wantErr:    fserrors.ErrRelayCapHit,
 			wantDetail: "Server limit: 100 MB",

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -151,7 +151,7 @@ func renderError(err error, debug bool) int {
 	// Surface wrap context as a second line so users see WHY without
 	// having to enable --debug. Used for:
 	//   - usage / source-not-found: the missing path or bad flag.
-	//   - relay-limit hits: the server's configured limit ("100 MiB").
+	//   - relay-limit hits: the server's configured limit ("100 MB").
 	detail := ""
 	// E001 and E018 name the server it tried so a stale --connect entry
 	// is self-diagnosing instead of reading as a network outage.

--- a/cmd/fsend/prompts.go
+++ b/cmd/fsend/prompts.go
@@ -23,6 +23,12 @@ func readLine(r io.Reader) (line string, eof bool) {
 	if r != os.Stdin {
 		br = bufio.NewReader(r)
 	}
+	return readLineFrom(br)
+}
+
+// readLineFrom is readLine for callers that loop over one prompt (and so
+// must hold a single buffered reader to avoid losing bytes between reads).
+func readLineFrom(br *bufio.Reader) (line string, eof bool) {
 	raw, err := br.ReadString('\n')
 	return strings.ToLower(strings.TrimSpace(raw)), err != nil && raw == ""
 }

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -78,7 +79,8 @@ func runReceive(f *flags, c string) error {
 		return runReceiveOverInternet(ctx, f, c, cfg, spin)
 	}
 
-	addr := q.IP.String() + ":" + strconv.Itoa(q.Port)
+	// JoinHostPort so an IPv6 announce dials as "[addr]:port".
+	addr := net.JoinHostPort(q.IP.String(), strconv.Itoa(q.Port))
 	if f.debug && !f.quiet {
 		fmt.Fprintln(os.Stderr, "    sender address:", addr)
 	}

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -220,6 +220,23 @@ func renderArtifact(w io.Writer, h wire.SenderHello, outDir string, f *flags) {
 	case wire.TransferMultiFile:
 		_, _ = fmt.Fprintf(w, "      %s  ·  %s%s\n",
 			uxlog.CountNoun(int(h.TotalFiles), "file"), uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)
+		// Name what you're consenting to. FileNames is peer-supplied —
+		// sanitize like DisplayName. Capped at a handful here; the wire
+		// list itself is capped at wire.MaxHelloFileNames, and when it is
+		// complete the engine enforces that only these names land
+		// (transfer.Recv). Empty for pre-FileNames senders.
+		const nameDisplayCap = 5
+		shown := min(len(h.FileNames), nameDisplayCap)
+		for _, n := range h.FileNames[:shown] {
+			name := sanitizeForDisplay(n, 128)
+			if name == "" {
+				name = "(unnamed)"
+			}
+			_, _ = fmt.Fprintf(w, "        %s\n", name)
+		}
+		if more := int(h.TotalFiles) - shown; more > 0 && shown > 0 {
+			_, _ = fmt.Fprintf(w, "        %s\n", uxlog.Dim(fmt.Sprintf("… and %d more", more)))
+		}
 	case wire.TransferText:
 		_, _ = fmt.Fprintf(w, "      text  ·  %s%s\n",
 			uxlog.HumanBytes(int64(h.TotalBytes)), pwChip)

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -40,7 +40,8 @@ type receiverUI struct {
 	hello          *wire.SenderHello
 	files          []string
 	prev           map[uint32]uint64
-	total          int64
+	total          int64 // bytes received this run (excludes resumed prefixes)
+	skipped        int64 // resumed prefixes already on disk; see onResume
 	bar            *uxlog.Progress
 	firstByte      time.Time // latched on first progress byte; see finishReceive
 	totalBytesHint int64
@@ -99,6 +100,7 @@ func (ui *receiverUI) recvOptions(hostname string) transfer.RecvOptions {
 		Password:      ui.f.passArg,
 		PromptPass:    receiverPasswordPrompt(ui.ctx, ui.f),
 		ProgressFn:    ui.progress,
+		OnResume:      ui.onResume,
 		OnFileDone:    ui.onFileDone,
 	}
 	if ui.sink {
@@ -225,6 +227,29 @@ func (ui *receiverUI) confirmOverwrite(relPath string, existing int64, incoming 
 	}
 }
 
+// onResume announces a resumed file and fast-forwards the bookkeeping
+// past the on-disk prefix: the bar starts at the resume point, but the
+// prefix is booked as skipped, not received — so the summary's rate
+// reflects only bytes that actually moved. On a mid-run retry prev
+// already covers the prefix (we received those bytes ourselves).
+func (ui *receiverUI) onResume(fileIndex uint32, offset, total uint64) {
+	ui.mu.Lock()
+	if offset > ui.prev[fileIndex] {
+		d := int64(offset - ui.prev[fileIndex])
+		ui.prev[fileIndex] = offset
+		ui.skipped += d
+		if ui.bar == nil && !ui.f.quiet {
+			ui.bar = uxlog.New(ui.totalBytesHint)
+		}
+		ui.bar.Add(d)
+	}
+	quiet := ui.f.quiet
+	ui.mu.Unlock()
+	if !quiet {
+		uxlog.Println(fmt.Sprintf("  %s %s", uxlog.Info(), resumeNotice(offset, total)))
+	}
+}
+
 func (ui *receiverUI) progress(fileIndex uint32, bytesWritten uint64) {
 	ui.mu.Lock()
 	defer ui.mu.Unlock()
@@ -246,10 +271,12 @@ func (ui *receiverUI) onFileDone(path string) {
 	ui.mu.Unlock()
 }
 
-func (ui *receiverUI) bytes() int64 {
+// bytes returns the landed total (received + resumed prefixes) and the
+// bytes that actually moved this run, for the summary line.
+func (ui *receiverUI) bytes() (total, moved int64) {
 	ui.mu.Lock()
 	defer ui.mu.Unlock()
-	return ui.total
+	return ui.total + ui.skipped, ui.total
 }
 
 // close flushes the progress bar. Idempotent: callers flush explicitly
@@ -293,10 +320,12 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 		if err := printTextPayload(files); err != nil {
 			return err
 		}
-		printRecvSummary(f, "Received text", ui.bytes(), elapsed, ui.pathInfo)
+		total, moved := ui.bytes()
+		printRecvSummary(f, "Received text", total, moved, elapsed, ui.pathInfo)
 		return nil
 	}
-	printRecvSummary(f, ui.headline(h, files), ui.bytes(), elapsed, ui.pathInfo)
+	total, moved := ui.bytes()
+	printRecvSummary(f, ui.headline(h, files), total, moved, elapsed, ui.pathInfo)
 	return nil
 }
 
@@ -351,15 +380,16 @@ func (ui *receiverUI) headline(h *wire.SenderHello, files []string) string {
 
 // printRecvSummary renders the post-transfer success line. headline is
 // the fully-formed "Saved X to Y" / "Received" clause; the parts that
-// follow scan size → time → route. Suppressed under --quiet.
-func printRecvSummary(f *flags, headline string, bytes int64, elapsed time.Duration, path connpath.Info) {
+// follow scan size → time → route. On a resumed transfer moved < total
+// and the size gains a "(X received)" clause. Suppressed under --quiet.
+func printRecvSummary(f *flags, headline string, total, moved int64, elapsed time.Duration, path connpath.Info) {
 	if f.quiet {
 		return
 	}
 	if headline == "" {
 		headline = "Received"
 	}
-	parts := summaryParts(bytes, elapsed, path)
+	parts := summaryParts(total, moved, "received", elapsed, path)
 	fmt.Fprintf(os.Stderr, "%s %s  ·  %s\n", uxlog.Check(), headline, strings.Join(parts, "  ·  "))
 	printUpdateNotice(f)
 }

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -359,6 +360,13 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 				"to set a server password use --connect host:port,password",
 				fserrors.ErrUsage, f.posArgs[0])
 		}
+		// `fsend --connect abc-defg-jkm`: the code rides with the flag and
+		// would be persisted as the server host. Strict IsCode only —
+		// LooksLikeCode would reject legitimate hyphenated hostnames.
+		if len(f.connectArgsRaw) == 1 && code.IsCode(f.connectArgsRaw[0]) {
+			return fmt.Errorf("%w: --connect consumed %q as the server address; to receive: fsend %s",
+				fserrors.ErrUsage, f.connectArgsRaw[0], f.connectArgsRaw[0])
+		}
 		return runConnect(f)
 	}
 
@@ -381,6 +389,13 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		}
 	}
 
+	// `--pass=` (explicitly empty): the user asked for a password gate but
+	// supplied none — proceeding would run the transfer unprotected.
+	if cmd.Flags().Changed("pass") && f.passArg == "" {
+		return fmt.Errorf("%w: --pass requires a non-empty password (bare --pass prompts interactively)",
+			fserrors.ErrUsage)
+	}
+
 	// `fsend --pass file.pdf`: the value rides with the flag, so the file
 	// is consumed as the password — and with piped stdin that silently
 	// opens a session sending the wrong content. If the flag's value
@@ -390,6 +405,12 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		len(f.posArgs) == 0 && !cmd.Flags().Changed("text") {
 		if st, err := os.Stat(f.passArg); err == nil && !st.IsDir() {
 			return fmt.Errorf("%w: --pass consumed %q as the password; to send that file: fsend %s --pass",
+				fserrors.ErrUsage, f.passArg, f.passArg)
+		}
+		// Same trap with a (possibly mistyped) receive code as the value:
+		// with piped stdin it would silently stream stdin, code-as-password.
+		if code.IsCode(f.passArg) || code.LooksLikeCode(f.passArg) {
+			return fmt.Errorf("%w: --pass consumed %q as the password; to receive with a password: fsend %s --pass",
 				fserrors.ErrUsage, f.passArg, f.passArg)
 		}
 	}
@@ -426,7 +447,7 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		if len(f.posArgs) != 1 {
 			return fmt.Errorf("%w: --receive requires exactly one positional argument (the code)", fserrors.ErrUsage)
 		}
-		return runReceive(f, f.posArgs[0])
+		return startReceive(f, f.posArgs[0])
 	}
 
 	// --text is unambiguously send mode. An explicitly empty value
@@ -466,7 +487,7 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		if _, err := os.Stat(arg); err == nil {
 			return promptCodeOrPath(f, arg)
 		}
-		return runReceive(f, arg)
+		return startReceive(f, arg)
 	}
 	// Codes copied through iMessage / WhatsApp / Slack often have the
 	// first letter auto-capitalized. If the lowercased form is a valid
@@ -475,7 +496,7 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	// match the regex) falls through to send.
 	if lowered := strings.ToLower(arg); lowered != arg && code.IsCode(lowered) {
 		if _, err := os.Stat(arg); os.IsNotExist(err) {
-			return runReceive(f, lowered)
+			return startReceive(f, lowered)
 		}
 	}
 	return runSend(f, []string{arg})
@@ -499,22 +520,50 @@ func applyEnvFallbacks(f *flags, cmd *cobra.Command) {
 	}
 }
 
+// startReceive rejects send-only flags before handing off to runReceive,
+// so `fsend <code> --exclude '*.log'` fails fast instead of silently
+// ignoring the flag.
+func startReceive(f *flags, c string) error {
+	if len(f.excludes) > 0 {
+		return errExcludeMisuse()
+	}
+	return runReceive(f, c)
+}
+
 // promptCodeOrPath handles the rare collision case where a CLI arg both
 // matches the code regex AND names a real file in CWD.
 func promptCodeOrPath(f *flags, arg string) error {
-	fmt.Fprintf(os.Stderr, "\n  %q matches a code AND is a local file.\n", arg)
-	fmt.Fprintf(os.Stderr, "  [s]end this file, or [r]eceive with this code? (r): ")
-
-	resp, _ := readLine(os.Stdin)
-	switch resp {
-	case "s", "send":
+	send, err := askCodeOrPath(stdinReader(), arg)
+	if err != nil {
+		return err
+	}
+	if send {
 		return runSend(f, []string{arg})
-	case "r", "receive", "":
-		// Default on bare <enter>: receive. Codes are the surprising
-		// case (a filename happens to match the regex); receiving is
-		// almost always what the user meant.
-		return runReceive(f, arg)
-	default:
-		return fmt.Errorf("%w: choose 's' or 'r'", fserrors.ErrUsage)
+	}
+	return startReceive(f, arg)
+}
+
+// askCodeOrPath runs the send-or-receive disambiguation prompt. Default
+// on bare <enter>: receive — codes are the surprising case (a filename
+// happens to match the regex), so receiving is almost always what the
+// user meant. EOF must not take that default (see the readLine contract);
+// unrecognized input re-prompts instead of hard-erroring on a typo.
+func askCodeOrPath(br *bufio.Reader, arg string) (send bool, err error) {
+	fmt.Fprintf(os.Stderr, "\n  %q matches a code AND is a local file.\n", arg)
+	for {
+		fmt.Fprintf(os.Stderr, "  [s]end this file, or [r]eceive with this code? (r): ")
+		resp, eof := readLineFrom(br)
+		if eof {
+			fmt.Fprintln(os.Stderr)
+			return false, fmt.Errorf("%w: no input to answer the code-vs-file prompt; pass --receive (or --send) to choose without a prompt",
+				fserrors.ErrUsage)
+		}
+		switch resp {
+		case "s", "send":
+			return true, nil
+		case "r", "receive", "":
+			return false, nil
+		}
+		fmt.Fprintln(os.Stderr, "  Please answer s or r.")
 	}
 }

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"errors"
 	"io"
 	"strings"
@@ -73,6 +74,40 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 			[]string{"--connect=default,hunter2"},
 			"--connect default takes no password",
 		},
+		{
+			// Regression: `--pass=` skipped every password path, so the
+			// user believed the transfer was gated when it wasn't.
+			"pass_empty_value",
+			[]string{"--pass="},
+			"--pass requires a non-empty password",
+		},
+		{
+			// Regression: a code-shaped --pass value with piped stdin
+			// silently opened a send session, code-as-password. (Space
+			// form `--pass <code>` is unaffected: NoOptDefVal keeps the
+			// code positional.)
+			"pass_code_value",
+			[]string{"--pass=abc-defg-jkm"},
+			"to receive with a password: fsend abc-defg-jkm --pass",
+		},
+		{
+			// LooksLikeCode near-miss (digit 1 for letter) gets the same hint.
+			"pass_mistyped_code_value",
+			[]string{"--pass=abc-defg-jk1"},
+			"to receive with a password: fsend abc-defg-jk1 --pass",
+		},
+		{
+			// Same trap on --connect: the code would be persisted as the
+			// server host.
+			"connect_code_value",
+			[]string{"--connect=abc-defg-jkm"},
+			"to receive: fsend abc-defg-jkm",
+		},
+		{
+			"exclude_on_receive",
+			[]string{"--receive", "abc-defg-jkm", "--exclude=*.log"},
+			"--exclude only applies when sending a directory",
+		},
 	}
 	for _, c := range cases {
 		c := c
@@ -93,6 +128,52 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 			}
 		})
 	}
+}
+
+// askCodeOrPath must not consent on EOF and must re-prompt on a typo
+// instead of hard-erroring (same policy as promptAccept).
+func TestAskCodeOrPath(t *testing.T) {
+	ask := func(t *testing.T, in string) (send bool, stderr string, err error) {
+		t.Helper()
+		stderr = captureStderr(t, func() {
+			send, err = askCodeOrPath(bufio.NewReader(strings.NewReader(in)), "abc-defg-jkm")
+		})
+		return
+	}
+
+	t.Run("eof_aborts", func(t *testing.T) {
+		_, _, err := ask(t, "")
+		if !errors.Is(err, fserrors.ErrUsage) {
+			t.Fatalf("EOF must abort with ErrUsage, got %v", err)
+		}
+		if !strings.Contains(err.Error(), "--receive") {
+			t.Errorf("error should point at --receive/--send: %v", err)
+		}
+	})
+
+	t.Run("enter_defaults_to_receive", func(t *testing.T) {
+		send, _, err := ask(t, "\n")
+		if err != nil || send {
+			t.Errorf("bare Enter = (%v, %v), want receive", send, err)
+		}
+	})
+
+	t.Run("send_answer", func(t *testing.T) {
+		send, _, err := ask(t, "s\n")
+		if err != nil || !send {
+			t.Errorf("'s' = (%v, %v), want send", send, err)
+		}
+	})
+
+	t.Run("typo_reprompts", func(t *testing.T) {
+		send, stderr, err := ask(t, "x\nr\n")
+		if err != nil || send {
+			t.Errorf("typo then 'r' = (%v, %v), want receive", send, err)
+		}
+		if !strings.Contains(stderr, "Please answer s or r") {
+			t.Errorf("missing re-prompt hint:\n%s", stderr)
+		}
+	})
 }
 
 func TestBoldHelpHeaders(t *testing.T) {

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -73,8 +73,10 @@ func runSend(f *flags, paths []string) error {
 
 	// Print the artifact (code + receive command) exactly once, here,
 	// before any path is attempted. Both LAN and internet paths use the
-	// same locally-generated code — LAN announces it via mDNS, and the
-	// pairing server adopts it via the suggested-code field on Create.
+	// same locally-generated code — LAN announces an argon2id-derived
+	// name via mDNS, and the internet path registers the code's argon2id
+	// slot with the pairing server (the raw code never leaves this
+	// machine except via the user). The code shown here is final.
 	// The returned spinner animates "Waiting for receiver" until the
 	// pair coordinator stops it (on pair success or before printing an
 	// intermediate notice).

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -391,42 +391,61 @@ func totalBytes(items []transfer.SourceItem) int64 {
 // newSenderProgress builds a per-file delta-accumulating ProgressFn that
 // drives a single overall progress bar. Returns a close func the caller
 // should defer (no-op when --quiet), the ProgressFn for transfer.Send,
-// a sentBytes getter that callers use to render the post-transfer summary
-// — reflects actual bytes moved, which matters under resume —, and an
-// onStreamingEOF hook that latches the bar to the real total when an
-// unknown-size streaming item EOFs.
+// an onResume hook that announces a resumed file and books its on-disk
+// prefix as skipped rather than moved, a stats getter the post-transfer
+// summary uses (moved = bytes actually sent this run; skipped = resumed
+// prefixes), and an onStreamingEOF hook that latches the bar to the real
+// total when an unknown-size streaming item EOFs.
 //
-// Under --quiet the bar is suppressed but sentBytes still accumulates so
-// summary rendering (in non-quiet callers) stays accurate without
+// Under --quiet the bar and the resume notice are suppressed but the
+// counters still accumulate so summary rendering stays accurate without
 // branching on the flag in two places.
-func newSenderProgress(f *flags, items []transfer.SourceItem) (closeFn func(), progressFn func(fileIndex uint32, bytesSent uint64), sentBytes func() int64, onStreamingEOF func(fileIndex uint32, finalBytes uint64)) {
+func newSenderProgress(f *flags, items []transfer.SourceItem) (closeFn func(), progressFn func(fileIndex uint32, bytesSent uint64), onResume func(fileIndex uint32, offset, total uint64), stats func() (moved, skipped int64), onStreamingEOF func(fileIndex uint32, finalBytes uint64)) {
 	prev := make(map[uint32]uint64)
-	var total int64
-	if f.quiet {
-		return func() {},
-			func(fi uint32, b uint64) {
-				d := b - prev[fi]
-				prev[fi] = b
-				total += int64(d)
-			},
-			func() int64 { return total },
-			func(uint32, uint64) {}
+	var moved, skipped int64
+	// bar is nil under --quiet; uxlog renders nil-safe.
+	var bar *uxlog.Progress
+	if !f.quiet {
+		// For streaming items the up-front total is 0 (size unknown). The
+		// bar renders an indeterminate progress; SetTotal is called from
+		// onStreamingEOF once the producer EOFs.
+		bar = uxlog.New(totalBytes(items))
 	}
-	// For streaming items the up-front total is 0 (size unknown). The
-	// bar renders an indeterminate progress; SetTotal is called from
-	// onStreamingEOF once the producer EOFs.
-	bar := uxlog.New(totalBytes(items))
 	return bar.Done,
 		func(fi uint32, b uint64) {
 			d := b - prev[fi]
 			prev[fi] = b
 			bar.Add(int64(d))
-			total += int64(d)
+			moved += int64(d)
 		},
-		func() int64 { return total },
+		func(fi uint32, offset, total uint64) {
+			// Fast-forward the per-file counter past the receiver's
+			// prefix so it isn't booked as moved; on a mid-run retry
+			// prev already covers it (the bytes were sent by us).
+			if offset > prev[fi] {
+				d := int64(offset - prev[fi])
+				prev[fi] = offset
+				skipped += d
+				bar.Add(d)
+			}
+			if !f.quiet {
+				uxlog.Println(fmt.Sprintf("  %s %s", uxlog.Info(), resumeNotice(offset, total)))
+			}
+		},
+		func() (int64, int64) { return moved, skipped },
 		func(_ uint32, finalBytes uint64) {
 			bar.SetTotal(int64(finalBytes), true)
 		}
+}
+
+// resumeNotice renders the "Resuming from 141 MB (71%)" clause shared by
+// both roles' resume lines.
+func resumeNotice(offset, total uint64) string {
+	s := "Resuming from " + uxlog.HumanBytes(int64(offset))
+	if total > 0 {
+		s += fmt.Sprintf(" (%d%%)", offset*100/total)
+	}
+	return s
 }
 
 // printSendSummary renders the post-transfer success line on the sender.
@@ -436,26 +455,34 @@ func newSenderProgress(f *flags, items []transfer.SourceItem) (closeFn func(), p
 //
 // Suppressed under --quiet (the bare code on stdout is the contract;
 // nothing on stderr).
-func printSendSummary(f *flags, bytes int64, elapsed time.Duration, path connpath.Info) {
+func printSendSummary(f *flags, total, moved int64, elapsed time.Duration, path connpath.Info) {
 	if f.quiet {
 		return
 	}
-	parts := summaryParts(bytes, elapsed, path)
+	parts := summaryParts(total, moved, "sent", elapsed, path)
 	fmt.Fprintf(os.Stderr, "%s Sent  ·  %s\n", uxlog.Check(), strings.Join(parts, "  ·  "))
 	printUpdateNotice(f)
 }
 
 // summaryParts builds the bytes/duration/path/rate sequence that both
-// send and recv summaries share. Rate is appended only when humanRate
-// has a meaningful answer (above the noise floor) so tiny transfers
-// don't print a misleading "13 B/s" figure.
-func summaryParts(bytes int64, elapsed time.Duration, path connpath.Info) []string {
+// send and recv summaries share. moved is the byte count actually
+// transferred this run; on a resumed transfer it is below total, the
+// size gains a "(X sent)"/"(X received)" clause (verb per role), and
+// the rate is computed from moved so it reflects real throughput rather
+// than crediting the resumed prefix. Rate is appended only when
+// HumanRate has a meaningful answer (above the noise floor) so tiny
+// transfers don't print a misleading "13 B/s" figure.
+func summaryParts(total, moved int64, verb string, elapsed time.Duration, path connpath.Info) []string {
+	size := uxlog.HumanBytes(total)
+	if moved < total {
+		size += " (" + uxlog.HumanBytes(moved) + " " + verb + ")"
+	}
 	parts := []string{
-		uxlog.HumanBytes(bytes),
+		size,
 		uxlog.HumanDuration(elapsed),
 		path.Tag(),
 	}
-	if r := uxlog.HumanRate(bytes, elapsed); r != "" {
+	if r := uxlog.HumanRate(moved, elapsed); r != "" {
 		parts = append(parts, r)
 	}
 	return parts

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -116,6 +116,11 @@ func runSend(f *flags, paths []string) error {
 // for the sender's "Sending …" line; "" means use the per-kind default.
 func collectItems(f *flags, paths []string) ([]transfer.SourceItem, wire.TransferKind, uint32, string, func(), error) {
 	noop := func() {}
+	// --exclude is consulted only when bundling a directory; for text and
+	// stdin (and, below, plain files) it would be silently ignored.
+	if len(f.excludes) > 0 && (f.textArg != "" || (len(paths) == 1 && paths[0] == "-")) {
+		return nil, 0, 0, "", noop, errExcludeMisuse()
+	}
 	if f.textArg != "" {
 		return synthesizeText(f.textArg), wire.TransferText, 0, "", noop, nil
 	}
@@ -130,6 +135,9 @@ func collectItems(f *flags, paths []string) ([]transfer.SourceItem, wire.Transfe
 	hasDir, err := containsDirectory(paths)
 	if err != nil {
 		return nil, 0, 0, "", noop, err
+	}
+	if !hasDir && len(f.excludes) > 0 {
+		return nil, 0, 0, "", noop, errExcludeMisuse()
 	}
 	if hasDir {
 		items, numFiles, cleanup, err := buildArchiveItem(paths, f.excludes)
@@ -170,6 +178,12 @@ func collectItems(f *flags, paths []string) ([]transfer.SourceItem, wire.Transfe
 		return items, wire.TransferSingleFile, 0, filepath.Base(paths[0]), noop, nil
 	}
 	return items, wire.TransferMultiFile, 0, uxlog.CountNoun(len(paths), "file"), noop, nil
+}
+
+// errExcludeMisuse is returned wherever --exclude would be silently
+// ignored: a receive, or a send with no directory to bundle.
+func errExcludeMisuse() error {
+	return fmt.Errorf("%w: --exclude only applies when sending a directory", fserrors.ErrUsage)
 }
 
 // mapLocalReadErr promotes a permission failure on a local source file

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -140,8 +140,9 @@ var errPairedGone = fmt.Errorf("%w: the receiver paired but the connection could
 // returns once the receiver has paired and the QUIC SenderHandshake
 // over the established data path is up.
 //
-// The function owns the server-side session lifecycle: it Creates with
-// our suggested code, long-polls Wait until a receiver Joins, runs ICE
+// The function owns the server-side session lifecycle: it Creates a
+// session keyed by our code's argon2id slot (the server never learns
+// the code itself), long-polls Wait until a receiver Joins, runs ICE
 // (falling back to a server-side relay on failure), then runs the QUIC
 // handshake. The cleanup func threaded onto the returned pairing
 // guarantees the server session is Deleted and resources released on
@@ -256,7 +257,7 @@ func waitForReceiver(ctx context.Context, client *signaling.Client, code string)
 // The debug --mode flag short-circuits the ladder:
 //   - modeDirect: only ICE; surface the ICE error if it fails (no relay fallback).
 //   - modeRelay:  skip ICE entirely; allocate the relay immediately.
-func establishInternetDataPath(ctx context.Context, f *flags, client *signaling.Client, created *server.CreateSessionResponse, waitResp *server.WaitResponse) (net.PacketConn, connpath.Info, error) {
+func establishInternetDataPath(ctx context.Context, f *flags, client *signaling.Client, created *signaling.CreateResult, waitResp *server.WaitResponse) (net.PacketConn, connpath.Info, error) {
 	if f != nil && f.mode == modeRelay {
 		return allocAndDialRelay(ctx, client, created.SessionID, created.RoleToken)
 	}

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -547,7 +547,7 @@ func runSenderTransferOverInternet(ctx context.Context, f *flags, items []transf
 // both paths in this helper keeps the two transfer entry points purely
 // declarative.
 func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.SourceItem, kind wire.TransferKind, totalFiles uint32, displayName string, pathInfo connpath.Info, firstRes *quicconn.AcceptResult, reaccept func(context.Context) (*quicconn.AcceptResult, error)) error {
-	closeProg, progressFn, sentBytes, onStreamingEOF := newSenderProgress(f, items)
+	closeProg, progressFn, onResume, stats, onStreamingEOF := newSenderProgress(f, items)
 	defer closeProg()
 
 	// Time from the first byte, not from here — the receiver may sit at
@@ -590,18 +590,21 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 				DisplayName:    displayName,
 				Password:       f.passArg,
 				ProgressFn:     progress,
+				OnResume:       onResume,
 				OnStreamingEOF: onStreamingEOF,
 			})
 		})
 	if err != nil {
 		return err
 	}
-	// Use the actual bytes counter so resumed transfers reflect what
-	// moved on the wire — not the full source size. printSendSummary
+	// moved counts the bytes this run pushed on the wire; skipped is the
+	// resumed prefix the receiver already had. The summary shows the
+	// full size but bases the rate on moved alone. printSendSummary
 	// no-ops under --quiet, so the outer guard isn't needed.
-	bytes := sentBytes()
-	if bytes == 0 {
-		bytes = totalBytes(items)
+	moved, skipped := stats()
+	total := moved + skipped
+	if total == 0 {
+		total, moved = totalBytes(items), totalBytes(items)
 	}
 	// Flush the bar first so its terminal frame lands above the summary
 	// (the deferred call is then a no-op).
@@ -610,7 +613,7 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 	if !firstByte.IsZero() {
 		elapsed = time.Since(firstByte)
 	}
-	printSendSummary(f, bytes, elapsed, pathInfo)
+	printSendSummary(f, total, moved, elapsed, pathInfo)
 	return nil
 }
 

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -165,7 +165,7 @@ func loadServerConfig() serverRuntimeConfig {
 		udpAddr:              envOr("FSEND_UDP_ADDR", ":443"),
 		maxSessionsPerIP:     envInt("FSEND_MAX_SESSIONS_PER_IP", 5),
 		maxNewSessionsPerMin: envInt("FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN", 30),
-		maxBytesPerSession:   envBytes("FSEND_MAX_RELAY_BYTES_PER_SESSION", 100*1024*1024),
+		maxBytesPerSession:   envBytes("FSEND_MAX_RELAY_BYTES_PER_SESSION", 100*1000*1000),
 		serverPassword:       os.Getenv("FSEND_SERVER_PASSWORD"),
 	}
 	switch strings.ToLower(os.Getenv("FSEND_LOG_LEVEL")) {
@@ -308,9 +308,9 @@ CONFIGURATION (environment variables — all optional)
   FSEND_LOG_LEVEL                       Default info
   FSEND_MAX_SESSIONS_PER_IP             Default 5
   FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN Default 30
-  FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MiB, counted in wire bytes
+  FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MB, counted in wire bytes
                                         after compression (accepts e.g.
-                                        "100MiB", "500m", "104857600")
+                                        "100MB", "500m", "104857600")
   FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every
                                         endpoint except /v1/health requires the
                                         X-Fsend-Auth header to match. Clients:

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -298,7 +298,7 @@ EXAMPLE
 
   Internet-exposed: put a TLS-terminating reverse proxy in front of :8080.
   File data over UDP/443 is already end-to-end encrypted, but the HTTP
-  pairing channel carries the share code, bearer tokens, and the
+  pairing channel carries session slots, bearer tokens, and the
   FSEND_SERVER_PASSWORD header in plaintext.
   See deploy/compose/docker-compose.yml for a Caddy + Let's Encrypt setup.
 

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -68,7 +68,10 @@ func serverCmd() *cobra.Command {
 // from environment-driven config, traps SIGINT/SIGTERM, and blocks until
 // shutdown.
 func runServer() error {
-	cfg := loadServerConfig()
+	cfg, err := loadServerConfig()
+	if err != nil {
+		return fmt.Errorf("%w: %v", fserrors.ErrServerStartup, err)
+	}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.logLevel}))
 	slog.SetDefault(logger)
 
@@ -159,14 +162,21 @@ type serverRuntimeConfig struct {
 	serverPassword       string
 }
 
-func loadServerConfig() serverRuntimeConfig {
+func loadServerConfig() (serverRuntimeConfig, error) {
 	cfg := serverRuntimeConfig{
-		httpAddr:             envOr("FSEND_HTTP_ADDR", ":8080"),
-		udpAddr:              envOr("FSEND_UDP_ADDR", ":443"),
-		maxSessionsPerIP:     envInt("FSEND_MAX_SESSIONS_PER_IP", 5),
-		maxNewSessionsPerMin: envInt("FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN", 30),
-		maxBytesPerSession:   envBytes("FSEND_MAX_RELAY_BYTES_PER_SESSION", 100*1000*1000),
-		serverPassword:       os.Getenv("FSEND_SERVER_PASSWORD"),
+		httpAddr:       envOr("FSEND_HTTP_ADDR", ":8080"),
+		udpAddr:        envOr("FSEND_UDP_ADDR", ":443"),
+		serverPassword: os.Getenv("FSEND_SERVER_PASSWORD"),
+	}
+	var err error
+	if cfg.maxSessionsPerIP, err = envInt("FSEND_MAX_SESSIONS_PER_IP", 5); err != nil {
+		return cfg, err
+	}
+	if cfg.maxNewSessionsPerMin, err = envInt("FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN", 30); err != nil {
+		return cfg, err
+	}
+	if cfg.maxBytesPerSession, err = envBytes("FSEND_MAX_RELAY_BYTES_PER_SESSION", 100*1000*1000); err != nil {
+		return cfg, err
 	}
 	switch strings.ToLower(os.Getenv("FSEND_LOG_LEVEL")) {
 	case "debug":
@@ -178,7 +188,7 @@ func loadServerConfig() serverRuntimeConfig {
 	default:
 		cfg.logLevel = slog.LevelInfo
 	}
-	return cfg
+	return cfg, nil
 }
 
 func envOr(name, def string) string {
@@ -203,64 +213,55 @@ func udpPortFromAddr(addr string) (int, error) {
 	return p, nil
 }
 
-func envInt(name string, def int) int {
-	if v := os.Getenv(name); v != "" {
-		if n, err := strconv.Atoi(v); err == nil {
-			return n
-		}
+func envInt(name string, def int) (int, error) {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return def, nil
 	}
-	return def
+	n, err := strconv.Atoi(v)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("%s=%q: not a non-negative integer", name, v)
+	}
+	return n, nil
 }
 
-// envBytes reads a byte count with optional unit suffix ("100MiB", "50k",
-// "1048576") from name, falling back to def on missing or unparseable
-// input. Suffixes are case-insensitive; b/k/m/g/t are decimal (1000),
-// kib/mib/gib/tib are binary (1024).
-func envBytes(name string, def uint64) uint64 {
-	v := os.Getenv(name)
+// envBytes reads a byte count with optional decimal unit suffix
+// ("500MB", "1.5gb", "104857600") from name. Suffixes are
+// case-insensitive and decimal (KB = 1000) to match the units fsend
+// displays everywhere; binary forms ("MiB", "1ki") are rejected rather
+// than guessed at. Unset/blank → def; anything else unparseable is an
+// error — silently running with the default would hide an operator's
+// typo'd cap.
+func envBytes(name string, def uint64) (uint64, error) {
+	v := strings.TrimSpace(os.Getenv(name))
 	if v == "" {
-		return def
-	}
-	v = strings.TrimSpace(v)
-	if v == "" {
-		return def
+		return def, nil
 	}
 	i := 0
 	for i < len(v) && (v[i] == '.' || (v[i] >= '0' && v[i] <= '9')) {
 		i++
 	}
 	num, suf := v[:i], strings.ToLower(strings.TrimSpace(v[i:]))
-	if num == "" {
-		return def
-	}
-	n, err := strconv.ParseFloat(num, 64)
-	if err != nil || n < 0 {
-		return def
-	}
 	var mul float64
 	switch suf {
 	case "", "b":
 		mul = 1
-	case "k", "kb":
+	case "kb":
 		mul = 1000
-	case "ki", "kib":
-		mul = 1024
-	case "m", "mb":
+	case "mb":
 		mul = 1000 * 1000
-	case "mi", "mib":
-		mul = 1024 * 1024
-	case "g", "gb":
+	case "gb":
 		mul = 1000 * 1000 * 1000
-	case "gi", "gib":
-		mul = 1024 * 1024 * 1024
-	case "t", "tb":
+	case "tb":
 		mul = 1000 * 1000 * 1000 * 1000
-	case "ti", "tib":
-		mul = 1024 * 1024 * 1024 * 1024
 	default:
-		return def
+		return 0, fmt.Errorf("%s=%q: unknown unit %q (use B, KB, MB, GB, TB, or a plain byte count)", name, v, suf)
 	}
-	return uint64(n * mul)
+	n, err := strconv.ParseFloat(num, 64)
+	if err != nil || n < 0 {
+		return 0, fmt.Errorf("%s=%q: not a byte count (use B, KB, MB, GB, TB, or a plain byte count)", name, v)
+	}
+	return uint64(n * mul), nil
 }
 
 // healthCheck pings the local server's /v1/health on the configured
@@ -309,8 +310,9 @@ CONFIGURATION (environment variables — all optional)
   FSEND_MAX_SESSIONS_PER_IP             Default 5
   FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN Default 30
   FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MB, counted in wire bytes
-                                        after compression (accepts e.g.
-                                        "100MB", "500m", "104857600")
+                                        after compression (accepts B, KB, MB,
+                                        GB, TB, or a plain byte count, e.g.
+                                        "100MB", "500KB", "104857600")
   FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every
                                         endpoint except /v1/health requires the
                                         X-Fsend-Auth header to match. Clients:

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -14,6 +14,7 @@ import (
 const (
 	srvKiB = 1024
 	srvMiB = 1024 * 1024
+	srvMB  = 1000 * 1000
 	srvGiB = 1024 * 1024 * 1024
 	srvTiB = 1024 * 1024 * 1024 * 1024
 )
@@ -149,8 +150,8 @@ func TestServerLoadConfigDefaults(t *testing.T) {
 	if cfg.maxNewSessionsPerMin != 30 {
 		t.Errorf("maxNewSessionsPerMin: got %d, want 30", cfg.maxNewSessionsPerMin)
 	}
-	if cfg.maxBytesPerSession != 100*srvMiB {
-		t.Errorf("maxBytesPerSession: got %d, want %d", cfg.maxBytesPerSession, 100*srvMiB)
+	if cfg.maxBytesPerSession != 100*srvMB {
+		t.Errorf("maxBytesPerSession: got %d, want %d", cfg.maxBytesPerSession, 100*srvMB)
 	}
 	if cfg.logLevel != slog.LevelInfo {
 		t.Errorf("logLevel: got %v, want info", cfg.logLevel)

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -11,13 +11,7 @@ import (
 	"time"
 )
 
-const (
-	srvKiB = 1024
-	srvMiB = 1024 * 1024
-	srvMB  = 1000 * 1000
-	srvGiB = 1024 * 1024 * 1024
-	srvTiB = 1024 * 1024 * 1024 * 1024
-)
+const srvMB = 1000 * 1000
 
 func srvFreePortTCP(t *testing.T) int {
 	t.Helper()
@@ -60,16 +54,18 @@ func TestServerEnvOr(t *testing.T) {
 func TestServerEnvInt(t *testing.T) {
 	const k = "FSEND_TEST_ENV_INT"
 	os.Unsetenv(k)
-	if got := envInt(k, 42); got != 42 {
-		t.Errorf("unset: got %d, want 42", got)
+	if got, err := envInt(k, 42); err != nil || got != 42 {
+		t.Errorf("unset: got %d, %v; want 42", got, err)
 	}
 	t.Setenv(k, "7")
-	if got := envInt(k, 42); got != 7 {
-		t.Errorf("set: got %d, want 7", got)
+	if got, err := envInt(k, 42); err != nil || got != 7 {
+		t.Errorf("set: got %d, %v; want 7", got, err)
 	}
-	t.Setenv(k, "not-a-number")
-	if got := envInt(k, 42); got != 42 {
-		t.Errorf("bad: got %d, want 42", got)
+	for _, bad := range []string{"not-a-number", "-1", "1.5"} {
+		t.Setenv(k, bad)
+		if _, err := envInt(k, 42); err == nil {
+			t.Errorf("%q: want error, got nil", bad)
+		}
 	}
 }
 
@@ -77,33 +73,37 @@ func TestServerEnvBytes(t *testing.T) {
 	const k = "FSEND_TEST_ENV_BYTES"
 	const def uint64 = 100
 	cases := []struct {
-		in   string
-		want uint64
+		in      string
+		want    uint64
+		wantErr bool
 	}{
-		{"", def},
-		{"500", 500},
-		{"500b", 500},
-		{"500B", 500},
-		{"1k", 1000},
-		{"1kb", 1000},
-		{"1KB", 1000},
-		{"1ki", 1024},
-		{"1KiB", srvKiB},
-		{"1m", 1000 * 1000},
-		{"1MB", 1000 * 1000},
-		{"1MiB", srvMiB},
-		{"100MiB", 100 * srvMiB},
-		{"1g", 1000 * 1000 * 1000},
-		{"1GiB", srvGiB},
-		{"1t", 1000 * 1000 * 1000 * 1000},
-		{"1TiB", srvTiB},
-		{"  10MiB  ", 10 * srvMiB},
-		{"1.5MiB", uint64(1.5 * float64(srvMiB))},
-		{"0", 0},
-		{"-1", def},
-		{"not-a-number", def},
-		{"100ZZ", def},
-		{"M", def},
+		{in: "", want: def},
+		{in: "500", want: 500},
+		{in: "500b", want: 500},
+		{in: "500B", want: 500},
+		{in: "1kb", want: 1000},
+		{in: "1KB", want: 1000},
+		{in: "1MB", want: 1000 * 1000},
+		{in: "100mb", want: 100 * srvMB},
+		{in: "1GB", want: 1000 * 1000 * 1000},
+		{in: "1TB", want: 1000 * 1000 * 1000 * 1000},
+		{in: "  10MB  ", want: 10 * srvMB},
+		{in: "1.5MB", want: uint64(1.5 * float64(srvMB))},
+		{in: "0", want: 0},
+		// Binary and single-letter suffixes are rejected, not guessed at:
+		// fsend displays decimal units everywhere, and a silent fallback
+		// would hide the misconfiguration.
+		{in: "1KiB", wantErr: true},
+		{in: "100MiB", wantErr: true},
+		{in: "1GiB", wantErr: true},
+		{in: "500m", wantErr: true},
+		{in: "1k", wantErr: true},
+		{in: "1g", wantErr: true},
+		{in: "-1", wantErr: true},
+		{in: "not-a-number", wantErr: true},
+		{in: "100ZZ", wantErr: true},
+		{in: "M", wantErr: true},
+		{in: "MB", wantErr: true},
 	}
 	for _, c := range cases {
 		t.Run(c.in, func(t *testing.T) {
@@ -112,8 +112,15 @@ func TestServerEnvBytes(t *testing.T) {
 			} else {
 				t.Setenv(k, c.in)
 			}
-			if got := envBytes(k, def); got != c.want {
-				t.Errorf("envBytes(%q): got %d, want %d", c.in, got, c.want)
+			got, err := envBytes(k, def)
+			if c.wantErr {
+				if err == nil {
+					t.Fatalf("envBytes(%q): want error, got %d", c.in, got)
+				}
+				return
+			}
+			if err != nil || got != c.want {
+				t.Errorf("envBytes(%q): got %d, %v; want %d", c.in, got, err, c.want)
 			}
 		})
 	}
@@ -137,7 +144,10 @@ func clearServerEnv(t *testing.T) {
 
 func TestServerLoadConfigDefaults(t *testing.T) {
 	clearServerEnv(t)
-	cfg := loadServerConfig()
+	cfg, err := loadServerConfig()
+	if err != nil {
+		t.Fatalf("loadServerConfig: %v", err)
+	}
 	if cfg.httpAddr != ":8080" {
 		t.Errorf("httpAddr: got %q, want :8080", cfg.httpAddr)
 	}
@@ -164,8 +174,11 @@ func TestServerLoadConfigOverrides(t *testing.T) {
 	t.Setenv("FSEND_UDP_ADDR", ":29999")
 	t.Setenv("FSEND_MAX_SESSIONS_PER_IP", "12")
 	t.Setenv("FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN", "120")
-	t.Setenv("FSEND_MAX_RELAY_BYTES_PER_SESSION", "250MiB")
-	cfg := loadServerConfig()
+	t.Setenv("FSEND_MAX_RELAY_BYTES_PER_SESSION", "250MB")
+	cfg, err := loadServerConfig()
+	if err != nil {
+		t.Fatalf("loadServerConfig: %v", err)
+	}
 	if cfg.httpAddr != ":19999" {
 		t.Errorf("httpAddr: got %q", cfg.httpAddr)
 	}
@@ -178,8 +191,26 @@ func TestServerLoadConfigOverrides(t *testing.T) {
 	if cfg.maxNewSessionsPerMin != 120 {
 		t.Errorf("maxNewSessionsPerMin: got %d", cfg.maxNewSessionsPerMin)
 	}
-	if cfg.maxBytesPerSession != 250*srvMiB {
+	if cfg.maxBytesPerSession != 250*srvMB {
 		t.Errorf("maxBytesPerSession: got %d", cfg.maxBytesPerSession)
+	}
+}
+
+func TestServerLoadConfigRejectsBadValues(t *testing.T) {
+	// A typo'd limit must stop the server, not silently run the default.
+	cases := map[string]string{
+		"FSEND_MAX_RELAY_BYTES_PER_SESSION":     "1GiB",
+		"FSEND_MAX_SESSIONS_PER_IP":             "many",
+		"FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN": "-1",
+	}
+	for k, v := range cases {
+		t.Run(k+"="+v, func(t *testing.T) {
+			clearServerEnv(t)
+			t.Setenv(k, v)
+			if _, err := loadServerConfig(); err == nil {
+				t.Fatalf("%s=%q: want error, got nil", k, v)
+			}
+		})
 	}
 }
 
@@ -200,7 +231,10 @@ func TestServerLoadConfigLogLevels(t *testing.T) {
 			if input != "" {
 				t.Setenv("FSEND_LOG_LEVEL", input)
 			}
-			cfg := loadServerConfig()
+			cfg, err := loadServerConfig()
+			if err != nil {
+				t.Fatalf("loadServerConfig: %v", err)
+			}
 			if cfg.logLevel != want {
 				t.Errorf("FSEND_LOG_LEVEL=%q: got %v, want %v", input, cfg.logLevel, want)
 			}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -15,13 +15,15 @@ or [run your own](self-hosting.md).
 Two computers on the same Wi-Fi can find each other with mDNS. Across
 the internet they can't — random machines behind random NATs have no
 way to find each other on their own. That's what the pairing server is
-for: a shared rendezvous keyed by the share code.
+for: a shared rendezvous keyed by a one-way *slot* derived from the
+share code (an argon2id stretch — both peers compute it locally and
+identically).
 
 It plays two roles, and only the first is always needed:
 
-- **Pairing** — both sides post the code; the server tells each one
-  where the other is. It learns the code (it has to, to match the
-  sides) but nothing about the file.
+- **Pairing** — both sides post the slot; the server tells each one
+  where the other is. It never learns the code itself (only the
+  memory-hard stretch of it) and nothing about the file.
 - **Relay** *(fallback only)* — when NAT topology blocks a direct
   connection, the server forwards encrypted UDP between the peers.
   Details below.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -169,7 +169,9 @@ For the full threat-model discussion, see [Security](security.md).
 
 The codes carry comparable entropy. Both tools document one-shot
 auto-generated codes. The operational difference is fsend's bounded
-server-side TTL and the fact that its code is always system-generated:
+server-side TTL and the fact that its code is always randomly generated
+(by the client — it never reaches the server, which only sees a one-way
+slot derived from it):
 a leaked code is useful for at most one receiver, lives only as long as
 the sender keeps the process running, and is hard-capped at one hour by
 the server. croc's README does not specify an equivalent server-side

--- a/docs/development.md
+++ b/docs/development.md
@@ -102,7 +102,7 @@ FSEND_HTTP_ADDR=":18080" /tmp/fsend server --health-check
 | `FSEND_HTTP_ADDR` | `:8080` | Signaling listener |
 | `FSEND_UDP_ADDR` | `:443` | Relay listener (UDP) |
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
-| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MiB` | |
+| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MB` | |
 
 Full list: `/tmp/fsend server --help`. For deployment, ports, and all
 tunables, see [Self-hosting](self-hosting.md).

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,7 +18,10 @@ peer-authentication layer:
 A network eavesdropper is stopped by TLS. An active MITM that
 terminates TLS itself (including a malicious pairing server or relay)
 ends up with a different channel binding on each side and is caught by
-the SPAKE2 confirmation before any file data flows.
+the SPAKE2 confirmation before any file data flows. This holds even
+against the pairing server because it never learns the share code — it
+sees only an argon2id-stretched *slot* derived from it (see below) —
+so it cannot run the SPAKE2 handshake with either side.
 
 ## Post-quantum forward secrecy
 
@@ -51,16 +54,20 @@ need a meeting point to swap addresses before they can talk directly.
 ```
    Sender                   Pairing server                  Receiver
       │                  ┌───────────────────┐                │
-      │  "I'm here,      │   matchmaker:     │  "I have code  │
-      │   code abc-..."  │   pair two peers  │   abc-..."     │
-      │ ────────────────►│   who share the   │◄────────────── │
-      │                  │   same code       │                │
+      │  "I'm here,      │   matchmaker:     │  "I have slot  │
+      │   slot 3f9a..."  │   pair two peers  │   3f9a..."     │
+      │ ────────────────►│   who derived the │◄────────────── │
+      │                  │   same slot       │                │
       │                  └─────────┬─────────┘                │
       │                            │                          │
       │   "here are each other's public addresses — go talk"  │
       │                            │                          │
       └────── direct peer-to-peer (server steps aside) ───────┘
 ```
+
+Both sides derive the *slot* — a one-way argon2id stretch of the share
+code — locally and identically, so they meet at the same rendezvous
+without the server ever seeing the code itself.
 
 That's the whole job: introduce the two peers, then get out of the way.
 In the typical cross-network case the file flows peer-to-peer and the
@@ -78,7 +85,8 @@ carrier moving sealed envelopes. It moves the parcel; it can't open it.
 | File contents                                     | ✗ never         |
 | File names, sizes, hashes                         | ✗ never         |
 | Ciphertext (on the relay-fallback path)           | ✓ as opaque bytes — not decryptable, not even by the server's operator |
-| The share code and your IP                        | ✓ briefly, in memory only, for pairing — never written to disk |
+| The share code                                    | ✗ never — only an argon2id-stretched slot derived from it; recovering the code from a slot is a memory-hard brute-force of the whole code space |
+| Your IP                                           | ✓ briefly, in memory only, for pairing — never written to disk |
 
 End-to-end encryption means even the operator of the server can't
 decrypt traffic that goes through it. The encryption keys never leave
@@ -90,9 +98,10 @@ Effectively nothing:
 
 - **No access log. No per-transfer log line.** The default log level
   only emits lifecycle events — startup, shutdown, and errors.
-- **No IP addresses or share codes in logs** at the default level.
-  (`FSEND_LOG_LEVEL=debug` logs both for troubleshooting — don't run a
-  privacy-sensitive server at debug level.)
+- **No IP addresses in logs** at the default level, and share codes
+  never reach the server at all. (`FSEND_LOG_LEVEL=debug` logs IPs and
+  session slots for troubleshooting — don't run a privacy-sensitive
+  server at debug level.)
 - **No database, no persistence layer.** Pairing state never touches
   disk — it lives in RAM, evicts within an hour at most (ten minutes
   once a transfer has paired), and is gone forever on restart.
@@ -107,6 +116,14 @@ Codes look like `abc-defg-jkm` — three letter-groups (3-4-3) from the
 23-letter alphabet `abcdefghjkmnpqrstuvwxyz` (`i`, `l`, `o` are
 excluded for legibility). Codes are:
 
+- **Never sent to the pairing server** — both peers register and join
+  with a *slot*: a fixed-salt argon2id stretch of the code (64 MiB,
+  hex-encoded). The server matches the two peers that derived the same
+  slot. Recovering a code from a leaked slot means a memory-hard search
+  of the ~2^45 code space — ~2^44 argon2id evaluations at 64 MiB each
+  on average — which is what makes the SPAKE2 channel binding effective
+  *against the server itself*: not knowing the code, it cannot run the
+  handshake with either side.
 - **One-shot** — once claimed by a receiver, the same code can't be reused.
 - **Server-side TTL** — codes expire on the server after one hour if no
   receiver pairs, or after ten minutes once a receiver has paired. Ctrl-C

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -150,4 +150,4 @@ All optional; defaults shown. Set under the `environment:` block in
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
 | `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit. |
-| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MiB` | Wire bytes after compression. Accepts `500m`, `1GiB`, `104857600`. |
+| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MB` | Wire bytes after compression. Accepts `500m`, `1GiB`, `104857600`. |

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -133,7 +133,9 @@ The client only speaks plain HTTP to loopback (`localhost`, `127.0.0.1`,
 reachable from the same machine with `fsend --connect 127.0.0.1:8080`,
 but clients on other hosts need TLS in front of it (see above). **Do
 not** expose a no-TLS server to the public internet — signaling carries
-share codes and bearer tokens in cleartext.
+session slots and bearer tokens in cleartext. (The share code itself
+never crosses the wire — the server only ever sees an argon2id-stretched
+slot derived from it — but the slots and tokens still deserve TLS.)
 
 ## Configuration
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -150,4 +150,4 @@ All optional; defaults shown. Set under the `environment:` block in
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
 | `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit. |
-| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MB` | Wire bytes after compression. Accepts `500m`, `1GiB`, `104857600`. |
+| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MB` | Wire bytes after compression. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`104857600`). |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -148,7 +148,7 @@ Caddy + Docker stack.
 
 ## Exit codes
 
-Stable from v0.1.0. `0` means success; non-zero codes map to a specific
+Stable from v1.0.0. `0` means success; non-zero codes map to a specific
 failure.
 
 | Code  | When it happens |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -142,7 +142,7 @@ docker run -p 443:443/udp -p 8080:8080/tcp poliuscorp/fsend server
 
 Internet-exposed deployments need a TLS-terminating reverse proxy in
 front of `:8080` — file data on UDP/443 is already end-to-end encrypted,
-but the HTTP pairing channel carries share codes and bearer tokens in
+but the HTTP pairing channel carries session slots and bearer tokens in
 plaintext. See [Self-hosting](self-hosting.md) for the ready-made
 Caddy + Docker stack.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -71,9 +71,10 @@ fsend --yes --out - abc-defg-jkm > dump.sql   # pipe-to-pipe with the sender's `
 FSEND_PASS=swordfish fsend --yes abc-defg-jkm
 ```
 
-Cancelled transfers leave a `.fsend-partial` sidecar and resume on the
-next run. If the source has changed since, the sidecar is discarded
-automatically.
+Interrupted transfers leave a `.fsend-partial` sidecar. Codes are
+one-shot, so to resume the sender runs `fsend` again and the receiver
+uses the fresh code — the transfer picks up where it left off. If the
+source has changed since, the sidecar is discarded automatically.
 
 ## Choosing a server (`--connect`)
 
@@ -181,6 +182,8 @@ failure.
 | `28`  | `E028` — pairing server requires a password (missing or wrong). |
 | `29`  | `E029` — server closed the connection because no data was flowing. |
 | `30`  | `E030` — `fsend server` could not start (port in use or no permission to bind). |
+| `31`  | `E031` — transfer requires a password the receiver didn't have (`--pass` / `FSEND_PASS`). |
+| `32`  | `E032` — the other side cancelled the transfer. |
 | `99`  | `E099` — unexpected error. Run with `--debug` and file an issue. |
 | `130` | `E026` — cancelled by user (Ctrl-C / SIGTERM). |
 

--- a/internal/code/slot.go
+++ b/internal/code/slot.go
@@ -1,0 +1,64 @@
+package code
+
+import (
+	"encoding/hex"
+	"errors"
+	"regexp"
+	"sync"
+
+	"golang.org/x/crypto/argon2"
+)
+
+// Slot returns the pairing-server lookup key for a code: 16 bytes of
+// argon2id, hex-encoded (32 lowercase hex chars).
+//
+// The server keys sessions on the slot, never the code: the code is the
+// PAKE secret, and a server that learned it could run the SPAKE2
+// handshake with each peer and MITM the transfer. The code has only
+// ~45 bits of entropy, so a fast hash would let anyone holding a slot
+// recover the code by offline brute force. argon2id makes each guess
+// cost ~64 MiB of memory and tens of milliseconds (same parameters as
+// internal/landisc, which solves the identical problem for the mDNS
+// name), putting the 2^44-average search out of practical reach.
+//
+// The salt is a fixed domain label — the peers share no prior state, so
+// a per-session salt is impossible; the memory-hardness carries the
+// defense. Distinct from the landisc salt so the two derived values
+// can't be cross-correlated. Memoized because the sender re-derives on
+// every /wait long-poll.
+func Slot(code string) string {
+	slotMu.Lock()
+	defer slotMu.Unlock()
+	if code == slotCode {
+		return slotVal
+	}
+	v := hex.EncodeToString(argon2.IDKey([]byte(code), []byte("fsend-slot-v1"), 2, 64*1024, 4, 16))
+	slotCode, slotVal = code, v
+	return v
+}
+
+var (
+	slotMu   sync.Mutex
+	slotCode string
+	slotVal  string
+)
+
+// SlotLen is the length of an encoded slot.
+const SlotLen = 32
+
+// slotPattern matches exactly what Slot produces. The server validates
+// inbound slots against it so the session table can't be polluted with
+// arbitrary strings.
+var slotPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
+
+// ErrInvalidSlot is returned when a string is not a well-formed slot.
+var ErrInvalidSlot = errors.New("invalid slot format")
+
+// ValidateSlot returns nil if s is shaped like a slot, ErrInvalidSlot
+// otherwise.
+func ValidateSlot(s string) error {
+	if !slotPattern.MatchString(s) {
+		return ErrInvalidSlot
+	}
+	return nil
+}

--- a/internal/code/slot_test.go
+++ b/internal/code/slot_test.go
@@ -1,0 +1,59 @@
+package code
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSlot_ShapeAndDeterminism(t *testing.T) {
+	s1 := Slot("abc-defg-jkm")
+	s2 := Slot("abc-defg-jkm")
+	if s1 != s2 {
+		t.Fatalf("Slot is not deterministic: %q vs %q", s1, s2)
+	}
+	if err := ValidateSlot(s1); err != nil {
+		t.Fatalf("Slot output %q fails its own validation: %v", s1, err)
+	}
+	if len(s1) != SlotLen {
+		t.Fatalf("len(slot) = %d, want %d", len(s1), SlotLen)
+	}
+	// The memoization must not leak a stale value across codes.
+	other := Slot("zzz-zzzz-zzz")
+	if other == s1 {
+		t.Fatal("two different codes produced the same slot")
+	}
+	if again := Slot("abc-defg-jkm"); again != s1 {
+		t.Fatalf("re-derivation after a different code changed the slot: %q vs %q", again, s1)
+	}
+}
+
+// The slot must not contain the code (trivially true for hex output,
+// but this is the load-bearing privacy property — keep it pinned).
+func TestSlot_DoesNotEmbedCode(t *testing.T) {
+	const c = "abc-defg-jkm"
+	s := Slot(c)
+	if strings.Contains(s, c) || strings.Contains(s, strings.ReplaceAll(c, "-", "")) {
+		t.Fatalf("slot %q embeds the code", s)
+	}
+}
+
+func TestValidateSlot(t *testing.T) {
+	cases := []struct {
+		in string
+		ok bool
+	}{
+		{"0123456789abcdef0123456789abcdef", true},
+		{"", false},
+		{"abc-defg-jkm", false}, // a raw code is not a slot
+		{"0123456789abcdef0123456789abcde", false},   // too short
+		{"0123456789abcdef0123456789abcdef0", false}, // too long
+		{"0123456789ABCDEF0123456789ABCDEF", false},  // uppercase
+		{"0123456789abcdeg0123456789abcdef", false},  // non-hex
+	}
+	for _, c := range cases {
+		err := ValidateSlot(c.in)
+		if (err == nil) != c.ok {
+			t.Errorf("ValidateSlot(%q) = %v, want ok=%v", c.in, err, c.ok)
+		}
+	}
+}

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -99,6 +99,14 @@ var (
 	// config was invalid. An operator error, not an fsend bug, so it does
 	// not route through the E099 "file an issue" catchall.
 	ErrServerStartup = errors.New("server failed to start")
+	// E031 — the sender requires a password and the receiver had none to
+	// offer (--quiet with no --pass / FSEND_PASS), so the challenge was
+	// never answered. Distinct from E021: no password was entered at all.
+	ErrPasswordRequired = errors.New("password required")
+	// E032 — the peer deliberately cancelled (Ctrl-C) mid-transfer.
+	// Distinct from E020 so the survivor knows the teardown wasn't a
+	// network drop.
+	ErrPeerCancelled = errors.New("peer cancelled the transfer")
 )
 
 // Entry is one row of the user-facing error catalog.
@@ -276,7 +284,12 @@ var catalog = map[error]Entry{
 	ErrTransientFailure: {
 		Code: "E020", Exit: 20,
 		Message: "Transfer was interrupted and retries did not recover.",
-		Action: "Check your network connection and try again — fsend will resume\n" +
+		// Receiver wording: share codes are one-shot, so rerunning the
+		// same `fsend <code>` yields E002 — resume needs a fresh code
+		// from the sender.
+		Action: "Ask the sender to run fsend again, then use the new code — the\n" +
+			"  transfer will resume in this same directory.",
+		SenderAction: "Check your network connection and try again — fsend will resume\n" +
 			"  from where it left off.",
 	},
 	ErrWrongPassword: {
@@ -341,6 +354,22 @@ var catalog = map[error]Entry{
 		Message: "The server could not start.",
 		Action: "Check that the ports are free and you have permission to bind them\n" +
 			"  (FSEND_HTTP_ADDR, FSEND_UDP_ADDR). Binding :443 may need elevated privileges.",
+	},
+	ErrPasswordRequired: {
+		Code: "E031", Exit: 31,
+		Message:       "This transfer requires a password.",
+		Action:        "Rerun with --pass <password> (or set FSEND_PASS).",
+		SenderMessage: "The receiver couldn't supply the password.",
+		SenderAction: "Run fsend again to issue a fresh code, and ask them to rerun with\n" +
+			"  --pass <password> (or FSEND_PASS).",
+	},
+	ErrPeerCancelled: {
+		Code: "E032", Exit: 32,
+		// Only the sender posts cancel notices today, so the base wording
+		// is receiver-facing.
+		Message: "The sender cancelled the transfer.",
+		Action: "Ask the sender to run fsend again, then use the new code — the\n" +
+			"  transfer will resume in this same directory.",
 	},
 }
 

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -352,8 +352,9 @@ var catalog = map[error]Entry{
 	ErrServerStartup: {
 		Code: "E030", Exit: 30,
 		Message: "The server could not start.",
-		Action: "Check that the ports are free and you have permission to bind them\n" +
-			"  (FSEND_HTTP_ADDR, FSEND_UDP_ADDR). Binding :443 may need elevated privileges.",
+		Action: "Fix the setting named above, or check that the ports are free and you\n" +
+			"  have permission to bind them (FSEND_HTTP_ADDR, FSEND_UDP_ADDR).\n" +
+			"  Binding :443 may need elevated privileges.",
 	},
 	ErrPasswordRequired: {
 		Code: "E031", Exit: 31,

--- a/internal/landisc/landisc.go
+++ b/internal/landisc/landisc.go
@@ -231,19 +231,32 @@ func openMulticast() (*ipv4.PacketConn, *ipv6.PacketConn, error) {
 }
 
 // PreferredLocalIP returns the first non-loopback IPv4 address found on
-// this machine's interfaces. Used by Announce to publish a routable LAN IP.
+// this machine's interfaces, or a global-unicast IPv6 on IPv6-only
+// networks. Used by Announce to publish a routable LAN IP.
+//
+// Link-local IPv6 is excluded: it needs a zone, which pion/mdns's
+// LocalAddress can't carry.
 //
 // Falls back to 127.0.0.1 if nothing else is available — useful for
 // loopback-only test environments.
 func PreferredLocalIP() net.IP {
 	addrs, err := net.InterfaceAddrs()
 	if err == nil {
+		var v6 net.IP
 		for _, a := range addrs {
-			if ipnet, ok := a.(*net.IPNet); ok && !ipnet.IP.IsLoopback() {
-				if v4 := ipnet.IP.To4(); v4 != nil {
-					return v4
-				}
+			ipnet, ok := a.(*net.IPNet)
+			if !ok || ipnet.IP.IsLoopback() {
+				continue
 			}
+			if v4 := ipnet.IP.To4(); v4 != nil {
+				return v4
+			}
+			if v6 == nil && ipnet.IP.IsGlobalUnicast() {
+				v6 = ipnet.IP
+			}
+		}
+		if v6 != nil {
+			return v6
 		}
 	}
 	return net.IPv4(127, 0, 0, 1)

--- a/internal/quicconn/auth.go
+++ b/internal/quicconn/auth.go
@@ -48,7 +48,12 @@ const (
 // TLS session. It mixes the TLS RFC 5705 exporter into an HMAC tag —
 // the channel binding that defeats a relay/MITM: an attacker terminating
 // one TLS session with each side gets two different exporters, so the
-// tags can never match.
+// tags can never match. That argument assumes the attacker doesn't know
+// the code (or it could just run SPAKE2 honestly with each side) — which
+// is why the pairing server is never told it: it sees only an
+// argon2id-stretched slot (internal/code.Slot), and recovering the code
+// from a slot is a 2^44-average memory-hard search. The binding
+// therefore holds even against the pairing server and its relay.
 //
 // The tag is also direction-separated (sender and receiver compute
 // different tags) and bound to the SPAKE2 transcript. Direction

--- a/internal/quicconn/quicconn.go
+++ b/internal/quicconn/quicconn.go
@@ -106,7 +106,9 @@ func SenderTLSConfig() (*tls.Config, error) {
 // step in authenticatePeer, which binds the SPAKE2-derived secret to
 // this specific TLS session via the RFC 5705 exporter. A MITM that
 // terminates the TLS session ends up with a different exporter and
-// fails that tag check.
+// fails that tag check — including the pairing server itself, which
+// never learns the code (it sees only the argon2id slot) and so cannot
+// run the PAKE with either side.
 func ReceiverTLSConfig() *tls.Config {
 	return &tls.Config{
 		InsecureSkipVerify: true,

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -63,7 +63,7 @@ const sessionIdleTimeout = 60 * time.Second
 // Default fills in zero values.
 func (c *ServerConfig) Default() {
 	if c.MaxBytesPerSession == 0 {
-		c.MaxBytesPerSession = 100 * 1024 * 1024 // 100 MiB
+		c.MaxBytesPerSession = 100 * 1000 * 1000 // 100 MB (decimal, matches displayed units)
 	}
 	if c.Logger == nil {
 		c.Logger = slog.Default()

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -194,8 +194,10 @@ var terminalSentinels = []error{
 	fserrors.ErrTargetExists,
 	fserrors.ErrServerRetired,
 	fserrors.ErrWrongPassword,      // wrong password is one-shot per session
+	fserrors.ErrPasswordRequired,   // receiver has no password to offer; retrying won't conjure one
 	fserrors.ErrCodeAlreadyClaimed, // sender already paired; no retry will recover
 	fserrors.ErrWriteFailed,        // peer's (or our) disk problem; retrying won't fix it
 	fserrors.ErrDiskFull,
-	context.Canceled, // user hit Ctrl-C
+	fserrors.ErrPeerCancelled, // peer hit Ctrl-C; it isn't coming back
+	context.Canceled,          // user hit Ctrl-C
 }

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -166,6 +166,8 @@ func TestIsTransient_Classification(t *testing.T) {
 		{"wrapped_code_already_claimed_terminal",
 			fmt.Errorf("lan dial: %w", fserrors.ErrCodeAlreadyClaimed), false},
 		{"ctx_canceled_terminal", context.Canceled, false},
+		{"password_required_terminal", fserrors.ErrPasswordRequired, false},
+		{"peer_cancelled_terminal", fserrors.ErrPeerCancelled, false},
 
 		// Wrapped terminal: must still not retry.
 		{"wrapped_hash_mismatch_terminal",

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -6,7 +6,6 @@ import (
 	"crypto/subtle"
 	"encoding/base32"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net"
@@ -103,7 +102,7 @@ type Server struct {
 	cfg      Config
 	started  time.Time
 	mu       sync.Mutex
-	byCode   map[string]*session
+	bySlot   map[string]*session
 	byID     map[string]*session
 	ipCounts map[string]int         // active sessions per source IP
 	ipBucket map[string]*rateBucket // new-session rate limiter per source IP
@@ -151,7 +150,7 @@ func New(cfg Config) *Server {
 	return &Server{
 		cfg:      cfg,
 		started:  time.Now(),
-		byCode:   make(map[string]*session),
+		bySlot:   make(map[string]*session),
 		byID:     make(map[string]*session),
 		ipCounts: make(map[string]int),
 		ipBucket: make(map[string]*rateBucket),
@@ -192,8 +191,8 @@ const AuthHeader = "X-Fsend-Auth"
 func (s *Server) Handler() http.Handler {
 	m := http.NewServeMux()
 	m.HandleFunc("POST /v1/session", s.createSession)
-	m.HandleFunc("POST /v1/session/{code}/join", s.joinSession)
-	m.HandleFunc("POST /v1/session/{code}/wait", s.waitSession)
+	m.HandleFunc("POST /v1/session/{slot}/join", s.joinSession)
+	m.HandleFunc("POST /v1/session/{slot}/wait", s.waitSession)
 	m.HandleFunc("POST /v1/session/{id}/candidates", s.pushCandidates)
 	m.HandleFunc("GET /v1/session/{id}/candidates", s.pullCandidates)
 	m.HandleFunc("DELETE /v1/session/{id}", s.deleteSession)
@@ -348,22 +347,22 @@ func (s *Server) evict(now time.Time) {
 			abandoned := now.Sub(sess.LastSeen) > s.cfg.AbandonedTTL
 			if expired || abandoned {
 				delete(s.byID, id)
-				delete(s.byCode, sess.Code)
+				delete(s.bySlot, sess.Slot)
 				s.releaseIP(sess.SenderRateKey)
 				close(sess.waiters)
 				reason := "expired"
 				if abandoned && !expired {
 					reason = "abandoned"
 				}
-				s.cfg.Logger.Debug("session evicted", "code", sess.Code, "reason", reason)
+				s.cfg.Logger.Debug("session evicted", "slot", sess.Slot, "reason", reason)
 			}
 		case "paired":
 			if now.Sub(sess.PairedAt) > s.cfg.PairedTTL {
 				delete(s.byID, id)
-				delete(s.byCode, sess.Code)
+				delete(s.bySlot, sess.Slot)
 				s.releaseIP(sess.SenderRateKey)
 				s.releaseIP(sess.ReceiverRateKey)
-				s.cfg.Logger.Debug("session evicted", "code", sess.Code, "reason", "paired_ttl")
+				s.cfg.Logger.Debug("session evicted", "slot", sess.Slot, "reason", "paired_ttl")
 			}
 		}
 	}
@@ -397,12 +396,20 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 	clientIP := clientIP(r)
 	rateKey := rateLimitKey(clientIP)
 
-	// Parse body up-front so we can honor a client-suggested code. An
-	// empty/missing body is fine — old clients don't send one and we
-	// fall back to server-side generation as before.
+	// The slot is required and client-derived: the client generates the
+	// code locally and sends only its argon2id stretch (internal/code.Slot).
+	// The server never sees the code, so it can't run the PAKE against
+	// either peer. Validate the shape so the session table only ever
+	// holds well-formed slots.
 	var body CreateSessionRequest
-	if r.Body != nil {
-		_ = decodeJSON(r, &body) // bad json → treat as empty body
+	if err := decodeJSON(r, &body); err != nil {
+		writeJSONError(w, http.StatusBadRequest, "bad json")
+		return
+	}
+	slot := strings.ToLower(strings.TrimSpace(body.Slot))
+	if code.ValidateSlot(slot) != nil {
+		writeJSONError(w, http.StatusBadRequest, "missing or malformed slot")
+		return
 	}
 
 	s.mu.Lock()
@@ -417,34 +424,21 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Adopt the client's code when it's valid and free; otherwise generate.
-	// We do not 409 on a taken suggestion — the client has already shown
-	// the code to the user, and falling back silently is preferable to
-	// asking the user to re-share. The response carries the actual code so
-	// the (rare) collision case is correct, just visibly different.
-	c := strings.ToLower(strings.TrimSpace(body.Code))
-	if c != "" && code.Validate(c) == nil {
-		if _, taken := s.byCode[c]; taken {
-			c = ""
-		}
-	} else {
-		c = ""
-	}
-	if c == "" {
-		var err error
-		c, err = s.generateUniqueCode()
-		if err != nil {
-			s.mu.Unlock()
-			writeJSONError(w, http.StatusInternalServerError, "code generation failed")
-			return
-		}
+	// Taken slot → 409; the client owns code generation, so it retries
+	// with a fresh code+slot. With ~2^45 codes an honest collision is
+	// effectively impossible, so this is bounded-retry insurance, not a
+	// hot path.
+	if _, taken := s.bySlot[slot]; taken {
+		s.mu.Unlock()
+		writeJSONError(w, http.StatusConflict, "slot already in use")
+		return
 	}
 
 	sid := ulid.Make().String()
 	senderTok := newRoleToken()
 	sess := &session{
 		ID:            sid,
-		Code:          c,
+		Slot:          slot,
 		SenderAddr:    clientIP,
 		SenderRateKey: rateKey,
 		SenderICE:     newIceCreds(),
@@ -454,15 +448,14 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		LastSeen:      time.Now(),
 		waiters:       make(chan struct{}),
 	}
-	s.byCode[c] = sess
+	s.bySlot[slot] = sess
 	s.byID[sid] = sess
 	s.ipCounts[rateKey]++
 	s.mu.Unlock()
-	s.cfg.Logger.Debug("session created", "code", c, "ip", clientIP)
+	s.cfg.Logger.Debug("session created", "slot", slot, "ip", clientIP)
 
 	writeJSON(w, http.StatusOK, CreateSessionResponse{
 		SessionID:        sid,
-		Code:             c,
 		YourObservedAddr: r.RemoteAddr,
 		IceCredentials:   sess.SenderICE,
 		TTLSeconds:       int(s.cfg.UnpairedTTL.Seconds()),
@@ -472,21 +465,22 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) joinSession(w http.ResponseWriter, r *http.Request) {
-	c := strings.ToLower(r.PathValue("code"))
+	slot := strings.ToLower(r.PathValue("slot"))
 	clientIP := clientIP(r)
 	rateKey := rateLimitKey(clientIP)
 
 	s.mu.Lock()
 	// Rate-limit symmetrically with createSession: a join is the same
 	// shape of new-session activity from the server's perspective, and
-	// without this an attacker could probe the code space (or churn
-	// joins against a known code) at line rate.
+	// without this an attacker could probe the code space (each guess
+	// submitted as its derived slot) or churn joins against a known
+	// slot at line rate.
 	if !s.allowNewSession(rateKey, time.Now()) {
 		s.mu.Unlock()
 		writeJSONError(w, http.StatusTooManyRequests, "rate limit hit")
 		return
 	}
-	sess, ok := s.byCode[c]
+	sess, ok := s.bySlot[slot]
 	if !ok {
 		s.mu.Unlock()
 		writeJSONError(w, http.StatusNotFound, "code not found")
@@ -519,14 +513,24 @@ func (s *Server) joinSession(w http.ResponseWriter, r *http.Request) {
 		RoleToken:          sess.ReceiverToken,
 	}
 	s.mu.Unlock()
-	s.cfg.Logger.Debug("session paired", "code", c, "ip", clientIP)
+	s.cfg.Logger.Debug("session paired", "slot", slot, "ip", clientIP)
 	writeJSON(w, http.StatusOK, resp)
 }
 
 func (s *Server) waitSession(w http.ResponseWriter, r *http.Request) {
-	c := strings.ToLower(r.PathValue("code"))
+	slot := strings.ToLower(r.PathValue("slot"))
 	s.mu.Lock()
-	sess, ok := s.byCode[c]
+	// Same rate limit as create/join. Without it, /wait is an
+	// unthrottled existence oracle over the slot space (404 vs 204 for
+	// the same lookup join performs). The legitimate sender polls once
+	// per LongPollTimeout (~25s ≈ 2-3/min), far under the default
+	// 30/min budget — see TestWaitRateLimit_PollCadenceStaysUnderBudget.
+	if !s.allowNewSession(rateLimitKey(clientIP(r)), time.Now()) {
+		s.mu.Unlock()
+		writeJSONError(w, http.StatusTooManyRequests, "rate limit hit")
+		return
+	}
+	sess, ok := s.bySlot[slot]
 	if !ok {
 		s.mu.Unlock()
 		writeJSONError(w, http.StatusNotFound, "code not found")
@@ -557,7 +561,7 @@ func (s *Server) waitSession(w http.ResponseWriter, r *http.Request) {
 	case <-waiters:
 		// Re-fetch in case janitor evicted between wakeup and now.
 		s.mu.Lock()
-		final, ok := s.byCode[c]
+		final, ok := s.bySlot[slot]
 		var finalAddr string
 		var finalICE IceCreds
 		if ok {
@@ -673,10 +677,10 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	delete(s.byID, id)
-	delete(s.byCode, sess.Code)
+	delete(s.bySlot, sess.Slot)
 	s.releaseIP(sess.SenderRateKey)
 	s.releaseIP(sess.ReceiverRateKey)
-	s.cfg.Logger.Debug("session deleted", "code", sess.Code)
+	s.cfg.Logger.Debug("session deleted", "slot", sess.Slot)
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -702,21 +706,6 @@ func (s *Server) releaseIP(key string) {
 	if s.ipCounts[key] <= 0 {
 		delete(s.ipCounts, key)
 	}
-}
-
-// generateUniqueCode picks a fresh code that isn't currently in use.
-// Caller must hold s.mu.
-func (s *Server) generateUniqueCode() (string, error) {
-	for i := 0; i < 5; i++ {
-		c, err := code.Generate()
-		if err != nil {
-			return "", err
-		}
-		if _, taken := s.byCode[c]; !taken {
-			return c, nil
-		}
-	}
-	return "", errors.New("could not pick a unique code")
 }
 
 // iceCredEnc is Crockford-style base32 (no padding) used for ICE

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -3,6 +3,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -42,20 +43,32 @@ func postJSON(t *testing.T, url string, body any) *http.Response {
 	return resp
 }
 
-func TestCreateSession_HappyPath(t *testing.T) {
-	srv := newTestServer(t)
-	resp := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{ClientVersion: "test"})
+// Slots are opaque to the server (any 32 lowercase hex chars), so the
+// tests use fixed literals instead of paying the argon2id derivation.
+const (
+	testSlot  = "0123456789abcdef0123456789abcdef"
+	testSlot2 = "fedcba9876543210fedcba9876543210"
+)
+
+// createSession POSTs /v1/session with the given slot and decodes the
+// response. Fails the test on any non-200.
+func createSession(t *testing.T, baseURL, slot string) CreateSessionResponse {
+	t.Helper()
+	resp := postJSON(t, baseURL+"/v1/session", CreateSessionRequest{ClientVersion: "test", Slot: slot})
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
-		t.Fatalf("status = %d", resp.StatusCode)
+		t.Fatalf("create status = %d", resp.StatusCode)
 	}
 	var body CreateSessionResponse
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatal(err)
 	}
-	if body.Code == "" {
-		t.Error("expected non-empty code")
-	}
+	return body
+}
+
+func TestCreateSession_HappyPath(t *testing.T) {
+	srv := newTestServer(t)
+	body := createSession(t, srv.URL, testSlot)
 	if body.SessionID == "" {
 		t.Error("expected non-empty session_id")
 	}
@@ -64,86 +77,53 @@ func TestCreateSession_HappyPath(t *testing.T) {
 	}
 }
 
-// CreateSession honors the client-suggested code when it's well-formed
-// and not already in use. This is what lets the sender register on the
-// pairing server with the same code it has already shown the user
-// from the LAN phase — no code change in the artifact, no E002 race for
-// the receiver.
-func TestCreateSession_AdoptsSuggestedCode(t *testing.T) {
+// Create requires a well-formed client-derived slot. There is no
+// server-side code generation to fall back to — the client owns the
+// code, the server only ever sees the argon2id slot.
+func TestCreateSession_RejectsMissingOrMalformedSlot(t *testing.T) {
 	srv := newTestServer(t)
-	suggested := "abc-defg-jkm"
-	resp := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{Code: suggested})
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		t.Fatalf("status = %d", resp.StatusCode)
-	}
-	var body CreateSessionResponse
-	_ = json.NewDecoder(resp.Body).Decode(&body)
-	if body.Code != suggested {
-		t.Errorf("server should have adopted suggested code %q, got %q", suggested, body.Code)
+	for _, tc := range []struct {
+		name string
+		slot string
+	}{
+		{"missing", ""},
+		{"raw code instead of slot", "abc-defg-jkm"},
+		{"too short", "0123456789abcdef"},
+		{"bad alphabet", "0123456789abcdefXX23456789abcdef"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			resp := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{Slot: tc.slot})
+			defer resp.Body.Close()
+			if resp.StatusCode != 400 {
+				t.Errorf("status = %d, want 400", resp.StatusCode)
+			}
+		})
 	}
 }
 
-// When the suggested code is already taken by another live session, the
-// server falls back to generation rather than 409-ing. The user has
-// already seen and shared the suggestion; surfacing a fresh code in the
-// response is preferable to making them retry. Collisions are rare
-// enough (~17M codes) that the re-render is an edge case.
-func TestCreateSession_TakenSuggestionFallsBackToGenerated(t *testing.T) {
+// A taken slot is a 409 — the client regenerates a fresh code+slot and
+// retries. The server must never silently re-key the session: it has no
+// code to offer, and the client has already shown one to the user.
+func TestCreateSession_TakenSlotConflicts(t *testing.T) {
 	srv := newTestServer(t)
-	suggested := "abc-defg-jkm"
+	_ = createSession(t, srv.URL, testSlot)
 
-	first := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{Code: suggested})
-	defer first.Body.Close()
-	var firstBody CreateSessionResponse
-	_ = json.NewDecoder(first.Body).Decode(&firstBody)
-	if firstBody.Code != suggested {
-		t.Fatalf("setup: first Create should have taken the suggested code")
-	}
-
-	second := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{Code: suggested})
+	second := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{Slot: testSlot})
 	defer second.Body.Close()
-	if second.StatusCode != 200 {
-		t.Fatalf("second Create should succeed (with a fresh code), got status %d", second.StatusCode)
+	if second.StatusCode != 409 {
+		t.Errorf("duplicate slot: status = %d, want 409", second.StatusCode)
 	}
-	var secondBody CreateSessionResponse
-	_ = json.NewDecoder(second.Body).Decode(&secondBody)
-	if secondBody.Code == suggested {
-		t.Errorf("server should have generated a fresh code on collision, got %q", secondBody.Code)
-	}
-	if secondBody.Code == "" {
-		t.Error("server returned an empty code")
-	}
-}
 
-// Malformed suggestions are ignored, not 400'd. The contract is "best
-// effort suggestion"; whatever the client sent, the response is always
-// a valid, usable code.
-func TestCreateSession_InvalidSuggestionFallsBack(t *testing.T) {
-	srv := newTestServer(t)
-	resp := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{Code: "not a real code"})
-	defer resp.Body.Close()
-	if resp.StatusCode != 200 {
-		t.Fatalf("status = %d", resp.StatusCode)
-	}
-	var body CreateSessionResponse
-	_ = json.NewDecoder(resp.Body).Decode(&body)
-	if body.Code == "" || body.Code == "not a real code" {
-		t.Errorf("server should have generated a fresh code, got %q", body.Code)
-	}
+	// A different slot still goes through.
+	_ = createSession(t, srv.URL, testSlot2)
 }
 
 func TestJoin_HappyPath(t *testing.T) {
 	srv := newTestServer(t)
+	create := createSession(t, srv.URL, testSlot)
 
-	// Sender creates.
-	createResp := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{})
-	defer createResp.Body.Close()
-	var create CreateSessionResponse
-	_ = json.NewDecoder(createResp.Body).Decode(&create)
-
-	// Receiver joins.
-	joinResp := postJSON(t, srv.URL+"/v1/session/"+create.Code+"/join", JoinSessionRequest{})
+	// Receiver joins via the same slot (derived from the same code).
+	joinResp := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
 	defer joinResp.Body.Close()
 	if joinResp.StatusCode != 200 {
 		t.Fatalf("join status = %d", joinResp.StatusCode)
@@ -157,7 +137,7 @@ func TestJoin_HappyPath(t *testing.T) {
 
 func TestJoin_NotFound(t *testing.T) {
 	srv := newTestServer(t)
-	resp := postJSON(t, srv.URL+"/v1/session/aaa-bbbb-ccc/join", JoinSessionRequest{})
+	resp := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
 	defer resp.Body.Close()
 	if resp.StatusCode != 404 {
 		t.Errorf("expected 404, got %d", resp.StatusCode)
@@ -166,14 +146,11 @@ func TestJoin_NotFound(t *testing.T) {
 
 func TestJoin_AlreadyClaimed(t *testing.T) {
 	srv := newTestServer(t)
-	create := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{})
-	defer create.Body.Close()
-	var c CreateSessionResponse
-	_ = json.NewDecoder(create.Body).Decode(&c)
+	_ = createSession(t, srv.URL, testSlot)
 
-	r1 := postJSON(t, srv.URL+"/v1/session/"+c.Code+"/join", JoinSessionRequest{})
+	r1 := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
 	r1.Body.Close()
-	r2 := postJSON(t, srv.URL+"/v1/session/"+c.Code+"/join", JoinSessionRequest{})
+	r2 := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
 	defer r2.Body.Close()
 	if r2.StatusCode != 409 {
 		t.Errorf("expected 409 on second join, got %d", r2.StatusCode)
@@ -182,10 +159,7 @@ func TestJoin_AlreadyClaimed(t *testing.T) {
 
 func TestWait_PairedReleases(t *testing.T) {
 	srv := newTestServer(t)
-	create := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{})
-	defer create.Body.Close()
-	var c CreateSessionResponse
-	_ = json.NewDecoder(create.Body).Decode(&c)
+	_ = createSession(t, srv.URL, testSlot)
 
 	// Sender starts waiting in a goroutine.
 	var wg sync.WaitGroup
@@ -193,14 +167,14 @@ func TestWait_PairedReleases(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		resp := postJSON(t, srv.URL+"/v1/session/"+c.Code+"/wait", WaitRequest{})
+		resp := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/wait", WaitRequest{})
 		defer resp.Body.Close()
 		waitStatus = resp.StatusCode
 	}()
 	time.Sleep(50 * time.Millisecond) // ensure waiter is parked
 
 	// Receiver joins → wakeup.
-	jr := postJSON(t, srv.URL+"/v1/session/"+c.Code+"/join", JoinSessionRequest{})
+	jr := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
 	jr.Body.Close()
 
 	wg.Wait()
@@ -211,16 +185,72 @@ func TestWait_PairedReleases(t *testing.T) {
 
 func TestWait_Timeout(t *testing.T) {
 	srv := newTestServer(t)
-	create := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{})
-	defer create.Body.Close()
-	var c CreateSessionResponse
-	_ = json.NewDecoder(create.Body).Decode(&c)
+	_ = createSession(t, srv.URL, testSlot)
 
-	resp := postJSON(t, srv.URL+"/v1/session/"+c.Code+"/wait", WaitRequest{})
+	resp := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/wait", WaitRequest{})
 	defer resp.Body.Close()
 	// LongPollTimeout in test is 500ms.
 	if resp.StatusCode != 204 {
 		t.Errorf("expected 204 on timeout, got %d", resp.StatusCode)
+	}
+}
+
+// /wait must sit behind the same per-IP budget as create/join.
+// Before this, it answered 404/204 unthrottled for the exact lookup
+// join rate-limits — a free existence oracle over the slot space.
+func TestWait_UnknownSlotIsRateLimited(t *testing.T) {
+	s := New(Config{
+		ServerVersion:        "0.0.0-test",
+		UnpairedTTL:          2 * time.Second,
+		PairedTTL:            5 * time.Second,
+		LongPollTimeout:      500 * time.Millisecond,
+		MaxSessionsPerIP:     10,
+		MaxNewSessionsPerMin: 3,
+	})
+	srv := httptest.NewServer(s.Handler())
+	t.Cleanup(srv.Close)
+
+	notFound, throttled := 0, 0
+	for i := 0; i < 6; i++ {
+		resp := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/wait", WaitRequest{})
+		_ = resp.Body.Close()
+		switch resp.StatusCode {
+		case 404:
+			notFound++
+		case 429:
+			throttled++
+		default:
+			t.Fatalf("unexpected status %d at i=%d", resp.StatusCode, i)
+		}
+	}
+	if notFound != 3 || throttled != 3 {
+		t.Errorf("got %d×404 + %d×429, want 3+3 (probes must hit the budget)", notFound, throttled)
+	}
+}
+
+// The sender's legitimate poll cadence must never trip the /wait rate
+// limit: one Create plus a /wait every LongPollTimeout (25s in prod) is
+// ~3 events/min against a 30/min budget — even five concurrent sessions
+// behind one NAT stay comfortably under. Simulated against the bucket
+// directly so the test covers a full hour without sleeping.
+func TestWaitRateLimit_PollCadenceStaysUnderBudget(t *testing.T) {
+	s := New(Config{}) // prod defaults: 30 new sessions/min, 25s long-poll
+	const senders = 5  // MaxSessionsPerIP default — worst legitimate case
+	now := time.Now()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for i := 0; i < senders; i++ {
+		if !s.allowNewSession("1.2.3.4", now) {
+			t.Fatalf("create #%d throttled", i+1)
+		}
+	}
+	for elapsed := time.Duration(0); elapsed < time.Hour; elapsed += s.cfg.LongPollTimeout {
+		for i := 0; i < senders; i++ {
+			if !s.allowNewSession("1.2.3.4", now.Add(elapsed)) {
+				t.Fatalf("wait poll at +%v throttled — legitimate cadence must never 429", elapsed)
+			}
+		}
 	}
 }
 
@@ -249,12 +279,9 @@ func TestHealth(t *testing.T) {
 func TestCandidates_RoutedByRoleToken(t *testing.T) {
 	srv := newTestServer(t)
 
-	cResp := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{})
-	defer cResp.Body.Close()
-	var c CreateSessionResponse
-	_ = json.NewDecoder(cResp.Body).Decode(&c)
+	c := createSession(t, srv.URL, testSlot)
 
-	jResp := postJSON(t, srv.URL+"/v1/session/"+c.Code+"/join", JoinSessionRequest{})
+	jResp := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
 	defer jResp.Body.Close()
 	var j JoinSessionResponse
 	_ = json.NewDecoder(jResp.Body).Decode(&j)
@@ -316,10 +343,7 @@ func TestCandidates_RoutedByRoleToken(t *testing.T) {
 
 func TestDeleteSession(t *testing.T) {
 	srv := newTestServer(t)
-	create := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{})
-	defer create.Body.Close()
-	var c CreateSessionResponse
-	_ = json.NewDecoder(create.Body).Decode(&c)
+	c := createSession(t, srv.URL, testSlot)
 
 	// Delete without the role token must be rejected.
 	noTok, _ := http.NewRequest(http.MethodDelete, srv.URL+"/v1/session/"+c.SessionID, nil)
@@ -344,7 +368,7 @@ func TestDeleteSession(t *testing.T) {
 	}
 
 	// Joining the deleted session should 404.
-	jr := postJSON(t, srv.URL+"/v1/session/"+c.Code+"/join", JoinSessionRequest{})
+	jr := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
 	defer jr.Body.Close()
 	if jr.StatusCode != 404 {
 		t.Errorf("expected 404 after delete, got %d", jr.StatusCode)
@@ -368,7 +392,7 @@ func TestServerPassword_Gate(t *testing.T) {
 
 	post := func(t *testing.T, path string, header string) int {
 		t.Helper()
-		body, _ := json.Marshal(CreateSessionRequest{})
+		body, _ := json.Marshal(CreateSessionRequest{Slot: testSlot})
 		req, _ := http.NewRequest(http.MethodPost, srv.URL+path, bytes.NewReader(body))
 		req.Header.Set("Content-Type", "application/json")
 		if header != "" {
@@ -408,7 +432,7 @@ func TestServerPassword_Gate(t *testing.T) {
 // must not accidentally require auth after this feature lands.
 func TestServerPassword_OpenByDefault(t *testing.T) {
 	srv := newTestServer(t) // no ServerPassword set
-	resp := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{})
+	resp := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{Slot: testSlot})
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		t.Errorf("open server: status = %d, want 200", resp.StatusCode)
@@ -462,12 +486,7 @@ func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 
 			// Pair: create a session and allocate the relay token so
 			// /relay/status has a token to look up.
-			created := postJSON(t, ts.URL+"/v1/session", CreateSessionRequest{})
-			defer created.Body.Close()
-			var cr CreateSessionResponse
-			if err := json.NewDecoder(created.Body).Decode(&cr); err != nil {
-				t.Fatal(err)
-			}
+			cr := createSession(t, ts.URL, testSlot)
 			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/relay/allocate",
 				bytes.NewReader(mustJSON(t, RelayAllocateRequest{SessionID: cr.SessionID})))
 			req.Header.Set("Content-Type", "application/json")
@@ -522,12 +541,7 @@ func TestRelayStatus_RequiresRoleToken(t *testing.T) {
 	ts := httptest.NewServer(s.Handler())
 	defer ts.Close()
 
-	created := postJSON(t, ts.URL+"/v1/session", CreateSessionRequest{})
-	defer created.Body.Close()
-	var cr CreateSessionResponse
-	if err := json.NewDecoder(created.Body).Decode(&cr); err != nil {
-		t.Fatal(err)
-	}
+	cr := createSession(t, ts.URL, testSlot)
 	allocReq, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/relay/allocate",
 		bytes.NewReader(mustJSON(t, RelayAllocateRequest{SessionID: cr.SessionID})))
 	allocReq.Header.Set("Authorization", "Bearer "+cr.RoleToken)
@@ -629,8 +643,11 @@ func TestRateLimit_V6BypassClosed(t *testing.T) {
 
 	ok, throttled := 0, 0
 	for i := 0; i < 20; i++ {
+		// Distinct slot per request so the concurrent-sessions cap is
+		// what bites, not a slot collision.
+		body := mustJSON(t, CreateSessionRequest{Slot: fmt.Sprintf("%032x", i+1)})
 		req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/session",
-			bytes.NewReader([]byte(`{}`)))
+			bytes.NewReader(body))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -713,20 +730,20 @@ func TestEvict_AbandonedSession(t *testing.T) {
 		MaxNewSessionsPerMin: 100,
 	})
 	now := time.Now()
-	mk := func(id, code string, lastSeen time.Time) {
+	mk := func(id, slot string, lastSeen time.Time) {
 		s.byID[id] = &session{
-			ID: id, Code: code, State: "waiting",
+			ID: id, Slot: slot, State: "waiting",
 			SenderRateKey: "1.2.3.4",
 			CreatedAt:     now.Add(-10 * time.Minute),
 			LastSeen:      lastSeen,
 			waiters:       make(chan struct{}),
 		}
-		s.byCode[code] = s.byID[id]
+		s.bySlot[slot] = s.byID[id]
 		s.ipCounts["1.2.3.4"]++
 	}
 	s.mu.Lock()
-	mk("alive", "aaa-aaaa-aaa", now.Add(-30*time.Second))
-	mk("dead", "bbb-bbbb-bbb", now.Add(-6*time.Minute))
+	mk("alive", testSlot, now.Add(-30*time.Second))
+	mk("dead", testSlot2, now.Add(-6*time.Minute))
 	s.mu.Unlock()
 
 	s.evict(now)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -452,7 +452,7 @@ func (f *fakeRelay) Status(t relay.Token) string    { return f.reason }
 func (f *fakeRelay) MaxBytesPerSession() uint64     { return f.maxBytes }
 
 // /v1/relay/status must echo back the operator-set byte ceiling so the
-// CLI can render a concrete error ("server limit 100 MiB") instead of a
+// CLI can render a concrete error ("server limit 100 MB") instead of a
 // generic "limit reached." Cap-hit carries the limit; idle just carries
 // the reason (the timeout is fixed, no value to surface).
 func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
@@ -461,7 +461,7 @@ func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 		reason    string
 		wantBytes uint64
 	}{
-		{name: "cap_hit", reason: relay.ReasonCapHit, wantBytes: 100 * 1024 * 1024},
+		{name: "cap_hit", reason: relay.ReasonCapHit, wantBytes: 100 * 1000 * 1000},
 		{name: "idle", reason: relay.ReasonIdle},
 	}
 	for _, c := range cases {
@@ -478,7 +478,7 @@ func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 			alloc := &fakeRelay{
 				tok:      relay.Token{1, 2, 3, 4},
 				reason:   c.reason,
-				maxBytes: 100 * 1024 * 1024,
+				maxBytes: 100 * 1000 * 1000,
 			}
 			s.WithRelay(alloc, 9999)
 			ts := httptest.NewServer(s.Handler())

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -11,21 +11,20 @@ import (
 
 // CreateSessionRequest is the body of POST /v1/session.
 //
-// Code is optional. When the client supplies one (and it matches the
-// canonical code format and isn't currently in use), the server adopts
-// it instead of generating a fresh one. The client-suggested-code path
-// exists so the sender can register on the pairing server with the
-// same code it already announced on LAN — eliminating the "different
-// code on LAN vs internet" race that otherwise leaves receivers with
-// an E002 from the server. On empty/invalid/taken code, the server
-// silently falls back to generation; the actual code is always echoed
-// back in CreateSessionResponse.Code.
+// Slot is required: the argon2id-stretched lookup key the client derives
+// from its locally-generated code (internal/code.Slot). The raw code
+// never reaches the server — it is the PAKE secret, and a server that
+// knew it could MITM the transfer. The server only matches the two
+// peers that derived the same slot.
 type CreateSessionRequest struct {
 	ClientVersion string `json:"client_version"`
-	Code          string `json:"code,omitempty"`
+	Slot          string `json:"slot"`
 }
 
 // CreateSessionResponse is the success body of POST /v1/session.
+//
+// There is no code (or slot) field: the client generated the code and
+// owns it; the server has nothing to add.
 //
 // RoleToken is an opaque bearer credential the sender includes on
 // subsequent /candidates calls so the server can route candidate batches
@@ -33,7 +32,6 @@ type CreateSessionRequest struct {
 // peers behind the same NAT can't disambiguate.
 type CreateSessionResponse struct {
 	SessionID        string   `json:"session_id"`
-	Code             string   `json:"code"`
 	YourObservedAddr string   `json:"your_observed_addr"`
 	IceCredentials   IceCreds `json:"ice_credentials"`
 	TTLSeconds       int      `json:"ttl_seconds"`
@@ -41,12 +39,12 @@ type CreateSessionResponse struct {
 	RoleToken        string   `json:"role_token"`
 }
 
-// JoinSessionRequest is the body of POST /v1/session/<code>/join.
+// JoinSessionRequest is the body of POST /v1/session/<slot>/join.
 type JoinSessionRequest struct {
 	ClientVersion string `json:"client_version"`
 }
 
-// JoinSessionResponse is the success body of POST /v1/session/<code>/join.
+// JoinSessionResponse is the success body of POST /v1/session/<slot>/join.
 type JoinSessionResponse struct {
 	SessionID          string   `json:"session_id"`
 	YourObservedAddr   string   `json:"your_observed_addr"`
@@ -56,8 +54,8 @@ type JoinSessionResponse struct {
 	RoleToken          string   `json:"role_token"`
 }
 
-// WaitRequest is the body of POST /v1/session/<code>/wait. It carries no
-// fields today — the code in the path is the only input — but is kept as
+// WaitRequest is the body of POST /v1/session/<slot>/wait. It carries no
+// fields today — the slot in the path is the only input — but is kept as
 // a named type so the wire shape has somewhere to grow.
 type WaitRequest struct{}
 
@@ -139,7 +137,7 @@ type IceCreds struct {
 // increment used.
 type session struct {
 	ID              string
-	Code            string
+	Slot            string // argon2id stretch of the code — the server never holds the code itself
 	SenderAddr      string
 	SenderRateKey   string
 	SenderICE       IceCreds

--- a/internal/signaling/client.go
+++ b/internal/signaling/client.go
@@ -3,6 +3,11 @@
 // It speaks the same JSON HTTP API and exposes a tiny Go API to the rest
 // of fsend so the CLI's send and receive flows don't need to know about
 // URL paths, JSON shapes, or long-poll mechanics.
+//
+// The share code never leaves the client: it is the PAKE secret, and a
+// pairing server that learned it could MITM the transfer. Every server
+// round-trip identifies the session by the code's argon2id slot
+// (internal/code.Slot) — in URLs, bodies, everywhere.
 package signaling
 
 import (
@@ -16,6 +21,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/polius/fsend/internal/code"
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/server"
 )
@@ -54,37 +60,72 @@ func (c *Client) WithPassword(pw string) *Client {
 	return c
 }
 
-// Create requests a new session. The returned response carries the code
-// the sender must share out-of-band.
+// CreateResult is Create's return value: the server's session metadata
+// plus the client-owned code. The server never returns (or sees) the
+// code — only its argon2id slot — so it lives here, not in
+// server.CreateSessionResponse.
+type CreateResult struct {
+	server.CreateSessionResponse
+	Code string
+}
+
+// createAttempts bounds how many fresh codes Create tries when the
+// server reports the slot taken (409). With ~2^45 codes an honest
+// collision is effectively impossible, so one retry round-trip is
+// already generous insurance.
+const createAttempts = 3
+
+// Create registers a new session, keyed server-side by the argon2id
+// slot of the code — the raw code is never sent.
 //
-// suggestedCode lets the caller propose the code they've already shown
-// the user (e.g., the LAN-phase code). When non-empty and free on the
-// server, the server adopts it. Empty / invalid / taken values fall
-// back to server-side generation. Callers should always read the actual
-// code from the response, not assume it equals their suggestion.
-func (c *Client) Create(ctx context.Context, suggestedCode string) (*server.CreateSessionResponse, error) {
-	var out server.CreateSessionResponse
-	err := c.do(ctx, http.MethodPost, "/v1/session",
-		server.CreateSessionRequest{ClientVersion: c.version, Code: suggestedCode}, &out, nil)
-	return &out, err
+// codeStr is the code the caller has already shown the user (e.g., the
+// LAN-phase code); a slot collision then surfaces as
+// fserrors.ErrCodeAlreadyClaimed, because silently switching to a code
+// the user never saw would strand the receiver. When codeStr is empty,
+// Create generates the code itself and owns it — a 409 just means
+// regenerate and retry. Callers read the final code from the result.
+func (c *Client) Create(ctx context.Context, codeStr string) (*CreateResult, error) {
+	generated := codeStr == ""
+	for attempt := 1; ; attempt++ {
+		if generated {
+			var err error
+			codeStr, err = code.Generate()
+			if err != nil {
+				return nil, fmt.Errorf("generating code: %w", err)
+			}
+		}
+		var out server.CreateSessionResponse
+		err := c.do(ctx, http.MethodPost, "/v1/session",
+			server.CreateSessionRequest{ClientVersion: c.version, Slot: code.Slot(codeStr)}, &out, nil)
+		if err == nil {
+			return &CreateResult{CreateSessionResponse: out, Code: codeStr}, nil
+		}
+		if generated && errors.Is(err, fserrors.ErrCodeAlreadyClaimed) && attempt < createAttempts {
+			continue
+		}
+		return nil, err
+	}
 }
 
 // Join attempts to pair as a receiver, returning the sender's reflected
-// address and ICE credentials.
-func (c *Client) Join(ctx context.Context, code string) (*server.JoinSessionResponse, error) {
+// address and ICE credentials. The session is addressed by the code's
+// slot; the code itself stays on this machine.
+func (c *Client) Join(ctx context.Context, codeStr string) (*server.JoinSessionResponse, error) {
 	var out server.JoinSessionResponse
-	err := c.do(ctx, http.MethodPost, "/v1/session/"+code+"/join",
+	err := c.do(ctx, http.MethodPost, "/v1/session/"+code.Slot(codeStr)+"/join",
 		server.JoinSessionRequest{ClientVersion: c.version}, &out, nil)
 	return &out, err
 }
 
-// Wait long-polls until a receiver pairs with this session.
+// Wait long-polls until a receiver pairs with this session. Addressed
+// by slot, like Join (code.Slot memoizes, so the repeated polls don't
+// re-pay the argon2id stretch).
 //
 // Returns (nil, nil) on timeout (HTTP 204) — caller should retry until
 // the session TTL expires.
-func (c *Client) Wait(ctx context.Context, code string) (*server.WaitResponse, error) {
+func (c *Client) Wait(ctx context.Context, codeStr string) (*server.WaitResponse, error) {
 	var out server.WaitResponse
-	err := c.do(ctx, http.MethodPost, "/v1/session/"+code+"/wait",
+	err := c.do(ctx, http.MethodPost, "/v1/session/"+code.Slot(codeStr)+"/wait",
 		server.WaitRequest{}, &out, allowNoContent())
 	if errors.Is(err, errNoContent) {
 		return nil, nil

--- a/internal/signaling/client_test.go
+++ b/internal/signaling/client_test.go
@@ -1,14 +1,19 @@
 package signaling
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/polius/fsend/internal/code"
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/server"
 )
@@ -39,7 +44,10 @@ func TestClient_CreateAndJoin_Roundtrip(t *testing.T) {
 		t.Fatalf("Create: %v", err)
 	}
 	if created.Code == "" || created.SessionID == "" {
-		t.Fatal("missing fields in CreateSessionResponse")
+		t.Fatal("missing fields in CreateResult")
+	}
+	if err := code.Validate(created.Code); err != nil {
+		t.Fatalf("client-generated code %q is not canonical: %v", created.Code, err)
 	}
 
 	joined, err := receiver.Join(ctx, created.Code)
@@ -48,6 +56,135 @@ func TestClient_CreateAndJoin_Roundtrip(t *testing.T) {
 	}
 	if joined.SessionID != created.SessionID {
 		t.Errorf("session id mismatch: %q vs %q", joined.SessionID, created.SessionID)
+	}
+}
+
+// The whole point of the slot scheme: the raw code must never cross the
+// wire to the pairing server — not in a URL, not in a body. A server
+// that learned the code could run the SPAKE2 handshake itself and MITM
+// the transfer. This snoops every request of a full Create/Join/Wait
+// round and asserts the code appears nowhere.
+func TestClient_RawCodeNeverSentToServer(t *testing.T) {
+	s := server.New(server.Config{
+		ServerVersion:        "0.0.0-test",
+		UnpairedTTL:          2 * time.Second,
+		LongPollTimeout:      100 * time.Millisecond,
+		MaxSessionsPerIP:     10,
+		MaxNewSessionsPerMin: 100,
+	})
+	inner := s.Handler()
+	var mu sync.Mutex
+	var wire []string // method + URL + headers + body of every request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var hdrs strings.Builder
+		_ = r.Header.Write(&hdrs)
+		mu.Lock()
+		wire = append(wire, r.Method+" "+r.URL.String()+"\n"+hdrs.String()+"\n"+string(body))
+		mu.Unlock()
+		r.Body = io.NopCloser(bytes.NewReader(body))
+		inner.ServeHTTP(w, r)
+	}))
+	t.Cleanup(ts.Close)
+
+	const theCode = "abc-defg-jkm"
+	ctx := context.Background()
+	sender := New(ts.URL, "test")
+	receiver := New(ts.URL, "test")
+
+	created, err := sender.Create(ctx, theCode)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := sender.Wait(ctx, theCode); err != nil { // 204 tick → (nil, nil)
+		t.Fatalf("Wait: %v", err)
+	}
+	if _, err := receiver.Join(ctx, theCode); err != nil {
+		t.Fatalf("Join: %v", err)
+	}
+	if err := sender.Delete(ctx, created.SessionID, created.RoleToken); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+	if len(wire) < 4 {
+		t.Fatalf("captured only %d requests", len(wire))
+	}
+	for _, req := range wire {
+		if strings.Contains(req, theCode) {
+			t.Fatalf("raw code leaked to the server:\n%s", req)
+		}
+		// Belt and braces: nor the hyphen-stripped form.
+		if strings.Contains(req, strings.ReplaceAll(theCode, "-", "")) {
+			t.Fatalf("code (de-hyphenated) leaked to the server:\n%s", req)
+		}
+	}
+}
+
+// When Create generated the code itself, a 409 (slot taken) means
+// "regenerate and retry" — bounded, and invisible to the caller, who
+// reads the final code off the result.
+func TestClient_Create_RetriesFreshCodeOn409(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if atomic.AddInt32(&calls, 1) == 1 {
+			w.WriteHeader(http.StatusConflict)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"session_id":"01TEST","role_token":"tok"}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	created, err := New(ts.URL, "test").Create(context.Background(), "")
+	if err != nil {
+		t.Fatalf("Create should have retried past the 409: %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 2 {
+		t.Errorf("expected 2 Create attempts, got %d", got)
+	}
+	if created.Code == "" || code.Validate(created.Code) != nil {
+		t.Errorf("result must carry a usable code, got %q", created.Code)
+	}
+}
+
+// A persistent 409 must not loop forever: bounded attempts, then the
+// error surfaces.
+func TestClient_Create_GivesUpAfterBoundedRetries(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusConflict)
+	}))
+	t.Cleanup(ts.Close)
+
+	_, err := New(ts.URL, "test").Create(context.Background(), "")
+	if !errors.Is(err, fserrors.ErrCodeAlreadyClaimed) {
+		t.Fatalf("expected ErrCodeAlreadyClaimed after exhausting retries, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != createAttempts {
+		t.Errorf("expected %d attempts, got %d", createAttempts, got)
+	}
+}
+
+// When the caller supplied the code (it's already on the user's screen),
+// Create must NOT silently switch to a fresh one — the receiver would
+// be typing a code whose slot no longer matches. The 409 surfaces.
+func TestClient_Create_CallerCodeConflictSurfaces(t *testing.T) {
+	var calls int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		atomic.AddInt32(&calls, 1)
+		w.WriteHeader(http.StatusConflict)
+	}))
+	t.Cleanup(ts.Close)
+
+	_, err := New(ts.URL, "test").Create(context.Background(), "abc-defg-jkm")
+	if !errors.Is(err, fserrors.ErrCodeAlreadyClaimed) {
+		t.Fatalf("expected ErrCodeAlreadyClaimed, got %v", err)
+	}
+	if got := atomic.LoadInt32(&calls); got != 1 {
+		t.Errorf("caller-supplied code must not be retried, got %d attempts", got)
 	}
 }
 

--- a/internal/transfer/archive.go
+++ b/internal/transfer/archive.go
@@ -135,12 +135,21 @@ func BuildArchive(paths []string, excludes []string) (*ArchiveResult, error) {
 		return nil, err
 	}
 
+	// Tar entries are rooted at each argument's base name, so duplicate
+	// roots (compared case-insensitively — the receiver may be on
+	// macOS/Windows) would silently merge and the extractor would
+	// clobber colliding files. Reject them up front, like Walk.
+	seen := make(map[string]string, len(paths))
 	for _, p := range paths {
 		abs, err := filepath.Abs(p)
 		if err != nil {
 			return failClose(fmt.Errorf("archive: %s: %w", p, err))
 		}
 		root := filepath.Base(abs)
+		if prev, ok := seen[strings.ToLower(root)]; ok {
+			return failClose(fmt.Errorf("%w: %s and %s would both arrive as %q — rename one before sending", fserrors.ErrUsage, prev, p, root))
+		}
+		seen[strings.ToLower(root)] = p
 		st, err := os.Lstat(abs)
 		if err != nil {
 			return failClose(fmt.Errorf("archive: %s: %w", p, err))
@@ -351,26 +360,44 @@ func ExtractArchive(tarPath, targetDir string, overwrite bool) error {
 			if err := assertWithinTarget(filepath.Dir(clean), absTarget); err != nil {
 				return err
 			}
-			if err := removePreexistingSymlink(clean); err != nil {
-				return fmt.Errorf("extract: clear %s: %w", clean, err)
+			// Write through a sidecar and rename into place, mirroring the
+			// non-archive receive path: a mid-extract failure (disk full,
+			// I/O error) must not leave a truncated file at its real name,
+			// indistinguishable from a complete one.
+			tmp := clean + partialSuffix
+			if err := removePreexistingSymlink(tmp); err != nil {
+				return fmt.Errorf("extract: clear %s: %w", tmp, err)
 			}
-			out, err := os.OpenFile(clean, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&os.ModePerm)
+			out, err := os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&os.ModePerm)
 			if errors.Is(err, os.ErrPermission) {
-				// Replacing an existing read-only file: O_TRUNC can't open
-				// it, but overwrite consent was already established
-				// (preflight or --overwrite) — remove and recreate.
-				_ = os.Remove(clean)
-				out, err = os.OpenFile(clean, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&os.ModePerm)
+				// Stale read-only sidecar from an interrupted extract:
+				// O_TRUNC can't open it — remove and recreate.
+				_ = os.Remove(tmp)
+				out, err = os.OpenFile(tmp, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, os.FileMode(hdr.Mode)&os.ModePerm)
 			}
 			if err != nil {
-				return fmt.Errorf("extract: create %s: %w", clean, err)
+				return fmt.Errorf("extract: create %s: %w", tmp, err)
 			}
 			if _, err := io.Copy(out, tr); err != nil {
 				_ = out.Close()
+				_ = os.Remove(tmp)
 				return classifyWriteErr("extract "+clean, err)
 			}
 			if err := out.Close(); err != nil {
+				_ = os.Remove(tmp)
 				return fmt.Errorf("extract: close %s: %w", clean, err)
+			}
+			// os.Rename replaces atomically and overwrites a planted symlink
+			// rather than following it. Overwrite consent was already
+			// established (preflight or --overwrite); a read-only file at
+			// the destination can still block the rename on Windows —
+			// remove and retry.
+			if err := os.Rename(tmp, clean); err != nil {
+				_ = os.Remove(clean)
+				if err := os.Rename(tmp, clean); err != nil {
+					_ = os.Remove(tmp)
+					return fmt.Errorf("extract: finalize %s: %w", clean, err)
+				}
 			}
 			if !hdr.ModTime.IsZero() {
 				_ = os.Chtimes(clean, hdr.ModTime, hdr.ModTime)

--- a/internal/transfer/archive_test.go
+++ b/internal/transfer/archive_test.go
@@ -95,6 +95,36 @@ func TestBuildArchive_Deterministic(t *testing.T) {
 	}
 }
 
+// Two top-level args with the same base name would silently merge under
+// one tar root and the second's files would clobber the first's on
+// extract — both sides reporting success. Must be rejected up front,
+// case-insensitively (the receiver may be on macOS/Windows), mirroring
+// the multi-file Walk guard.
+func TestBuildArchive_RejectsDuplicateRootBasenames(t *testing.T) {
+	for _, tc := range []struct{ name, second string }{
+		{"exact duplicate", "photos"},
+		{"case-insensitive duplicate", "PHOTOS"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			root := t.TempDir()
+			a := filepath.Join(root, "a", "photos")
+			b := filepath.Join(root, "b", tc.second)
+			for _, d := range []string{a, b} {
+				if err := os.MkdirAll(d, 0o755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(d, "pic.jpg"), []byte(d), 0o644); err != nil {
+					t.Fatal(err)
+				}
+			}
+			_, err := BuildArchive([]string{a, b}, nil)
+			if !errors.Is(err, fserrors.ErrUsage) {
+				t.Fatalf("BuildArchive(%q, %q) = %v, want ErrUsage", a, b, err)
+			}
+		})
+	}
+}
+
 func TestBuildArchive_ExcludePatterns(t *testing.T) {
 	srcDir := t.TempDir()
 	for _, p := range []string{
@@ -417,6 +447,47 @@ func TestExtractArchive_ConflictWithoutOverwrite(t *testing.T) {
 	}
 	if got, _ := os.ReadFile(clashPath); string(got) != "from archive" {
 		t.Errorf("overwrite did not replace clash.txt: %q", got)
+	}
+}
+
+// A mid-extract failure (disk full, I/O error, truncated tar) must not
+// leave a partial file at its final name — that's indistinguishable from
+// a complete one. Extraction writes through a sidecar and renames, like
+// the non-archive receive path; on failure the sidecar is removed.
+func TestExtractArchive_NoFinalFileOnTruncatedStream(t *testing.T) {
+	dir := t.TempDir()
+	target := t.TempDir()
+
+	var buf bytes.Buffer
+	tw := tar.NewWriter(&buf)
+	body := bytes.Repeat([]byte("x"), 64*1024)
+	if err := tw.WriteHeader(&tar.Header{
+		Name: "big.bin", Mode: 0o644, Size: int64(len(body)), Typeflag: tar.TypeReg,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatal(err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// Cut off the tail: the header (first 512 bytes) survives but the
+	// body doesn't, so io.Copy fails mid-file.
+	tarPath := filepath.Join(dir, "trunc.tar")
+	if err := os.WriteFile(tarPath, buf.Bytes()[:1024], 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := ExtractArchive(tarPath, target, false); err == nil {
+		t.Fatal("expected extraction of a truncated tar to fail")
+	}
+	if _, err := os.Stat(filepath.Join(target, "big.bin")); err == nil {
+		t.Error("truncated file landed at its final name")
+	}
+	if _, err := os.Stat(filepath.Join(target, "big.bin"+partialSuffix)); err == nil {
+		t.Error("extraction sidecar not removed on failure")
 	}
 }
 

--- a/internal/transfer/hello_names_test.go
+++ b/internal/transfer/hello_names_test.go
@@ -1,0 +1,129 @@
+package transfer
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/wire"
+)
+
+// TestSend_AdvertisesMultiFileNames asserts that a multi-file HELLO
+// carries the bare file names, so the receiver's consent prompt can
+// show what would land instead of a blind "N files".
+func TestSend_AdvertisesMultiFileNames(t *testing.T) {
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
+	var paths []string
+	for _, n := range []string{"a.txt", "b.txt", "c.txt"} {
+		p := filepath.Join(srcDir, n)
+		if err := os.WriteFile(p, []byte(n), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		paths = append(paths, p)
+	}
+	items, err := Walk(paths)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a, b := pipePair()
+	defer a.Close()
+	defer b.Close()
+
+	var gotHello wire.SenderHello
+	var sendErr, recvErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		sendErr = Send(context.Background(), &a, SendOptions{
+			Items:        items,
+			TransferKind: wire.TransferMultiFile,
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		recvErr = Recv(context.Background(), &b, RecvOptions{
+			TargetDir: dstDir,
+			Accept: func(h wire.SenderHello) bool {
+				gotHello = h
+				return true
+			},
+		})
+	}()
+	wg.Wait()
+
+	if sendErr != nil || recvErr != nil {
+		t.Fatalf("send=%v recv=%v", sendErr, recvErr)
+	}
+	want := []string{"a.txt", "b.txt", "c.txt"}
+	if !reflect.DeepEqual(gotHello.FileNames, want) {
+		t.Errorf("HELLO FileNames = %v, want %v", gotHello.FileNames, want)
+	}
+}
+
+// TestRecv_RejectsUnadvertisedName locks in consent integrity: when the
+// HELLO carried the complete name list, a FILE_INFO whose RelativePath
+// is not among the advertised names is refused before any byte lands.
+func TestRecv_RejectsUnadvertisedName(t *testing.T) {
+	dstDir := t.TempDir()
+
+	sender, receiver := pipePair()
+
+	var recvErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		recvErr = Recv(context.Background(), &receiver, RecvOptions{
+			TargetDir: dstDir,
+			Accept:    func(wire.SenderHello) bool { return true },
+		})
+		_ = receiver.Control.Close()
+		_ = receiver.Data.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		defer sender.Control.Close()
+		defer sender.Data.Close()
+		hello := &wire.SenderHello{
+			ProtocolVersion: wire.ProtocolVersion,
+			TransferKind:    wire.TransferMultiFile,
+			TotalFiles:      1,
+			FileNames:       []string{"advertised.txt"},
+		}
+		_ = wire.WriteControl(sender.Control, wire.TypeHello, hello)
+		var ack wire.ReceiverHello
+		_, _ = wire.ReadControl(sender.Control, &ack)
+		if !ack.Accepts {
+			return
+		}
+		payload := []byte("not what you agreed to")
+		f := wire.FileInfo{
+			Index:        0,
+			RelativePath: "sneaky.txt",
+			Size:         uint64(len(payload)),
+			Mode:         0o644,
+			Blake3Root:   blakeHash32(payload),
+			Resumable:    true,
+		}
+		_ = wire.WriteControl(sender.Control, wire.TypeFileInfo, &f)
+		// Receiver should answer with ERROR, not FILE_ACCEPT.
+		var d wire.FileAcceptDecision
+		_, _ = wire.ReadControl(sender.Control, &d)
+	}()
+	wg.Wait()
+
+	if !errors.Is(recvErr, fserrors.ErrProtocolError) {
+		t.Errorf("want ErrProtocolError, got %v", recvErr)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "sneaky.txt")); !os.IsNotExist(err) {
+		t.Errorf("unadvertised file must not land, stat err=%v", err)
+	}
+}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -146,8 +146,7 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 		if err := ctx.Err(); err != nil {
 			return err
 		}
-		var info wire.FileInfo
-		ft, err := wire.ReadControl(s.Control, &info)
+		ft, body, err := wire.ReadControlRaw(s.Control)
 		if err != nil {
 			return fmt.Errorf("recv: file-info: %w", err)
 		}
@@ -155,12 +154,18 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 			break
 		}
 		if ft == wire.TypeError {
-			// Re-read with payload — we already consumed the header.
-			// Simplification: treat any TypeError as protocol abort.
-			return fmt.Errorf("%w: peer sent ERROR", fserrors.ErrProtocolError)
+			// Sender aborted between files (e.g. Ctrl-C) — surface its
+			// stated reason instead of a generic protocol abort.
+			var ef wire.ErrorFrame
+			_ = wire.Decode(body, &ef)
+			return mapPeerError(ef)
 		}
 		if ft != wire.TypeFileInfo {
 			return fmt.Errorf("%w: expected FILE_INFO, got %v", fserrors.ErrProtocolError, ft)
+		}
+		var info wire.FileInfo
+		if err := wire.Decode(body, &info); err != nil {
+			return fmt.Errorf("recv: file-info: %w", err)
 		}
 		// Streaming exempts a file from the declared-size cap and the
 		// root-hash check. Only a stdin transfer legitimately needs that;
@@ -738,7 +743,11 @@ func receiverPasswordHandshake(s *Streams, opts RecvOptions) error {
 	password := opts.Password
 	if password == "" {
 		if opts.PromptPass == nil {
-			return fserrors.ErrWrongPassword
+			// --quiet with no --pass / FSEND_PASS: nothing to answer the
+			// challenge with. Decline explicitly or the sender misreads
+			// the teardown as a network drop and burns retries on it.
+			declineTransfer(s, wire.ErrCodePasswordRequired, "receiver has no password to offer")
+			return fserrors.ErrPasswordRequired
 		}
 		password, err = opts.PromptPass()
 		if err != nil {
@@ -802,13 +811,28 @@ func tryReadPeerError(r io.Reader) error {
 	if ft != wire.TypeError {
 		return nil
 	}
+	return mapPeerError(ef)
+}
+
+// mapPeerError translates a peer-reported ERROR frame into the
+// user-visible sentinel the CLI surfaces. Single source of truth for
+// both directions; all of these are terminal for the retry layer.
+func mapPeerError(ef wire.ErrorFrame) error {
 	switch ef.Code {
-	case wire.ErrCodePartialMismatch:
-		return fserrors.ErrPartialMismatch
+	case wire.ErrCodeWrongPassword:
+		return fserrors.ErrWrongPassword
+	case wire.ErrCodePasswordRequired:
+		return fserrors.ErrPasswordRequired
 	case wire.ErrCodeFileHashMismatch:
 		return fserrors.ErrHashMismatch
+	case wire.ErrCodePartialMismatch:
+		return fserrors.ErrPartialMismatch
+	case wire.ErrCodeTargetExists:
+		return fserrors.ErrTargetExists
 	case wire.ErrCodeWriteFailed:
 		return fmt.Errorf("%w: receiver: %s", fserrors.ErrWriteFailed, ef.Message)
+	case wire.ErrCodeCancelled:
+		return fserrors.ErrPeerCancelled
 	default:
 		return fmt.Errorf("%w: peer reported %d: %s", fserrors.ErrProtocolError, ef.Code, ef.Message)
 	}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -42,6 +42,10 @@ type RecvOptions struct {
 	Password      string                                      // pre-supplied (--pass or FSEND_PASS); used when sender requires a password
 	PromptPass    func() (string, error)                      // fallback when sender requires a password and Password is empty
 	ProgressFn    func(fileIndex uint32, bytesWritten uint64) // optional
+	// OnResume fires once per file we elected to resume, before any new
+	// bytes arrive. Lets the CLI announce the resume and count only the
+	// tail as moved. offset is chunk-aligned; total is the file's size.
+	OnResume func(fileIndex uint32, offset, total uint64)
 	// ConfirmOverwrite is called when an incoming file would clobber an
 	// existing one and Overwrite is false. true → accept this file as if
 	// Overwrite were set; false or nil → E013 reject.
@@ -141,6 +145,19 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 	}
 	var filesSeen, bytesDeclared uint64
 
+	// Consent integrity: when the HELLO advertised the complete name
+	// list (multi-file with TotalFiles ≤ MaxHelloFileNames), the user
+	// consented to exactly those names — enforce that nothing else
+	// lands. Incomplete (capped) or absent lists can't be enforced.
+	var advertised map[string]bool
+	if hello.TransferKind == wire.TransferMultiFile &&
+		len(hello.FileNames) > 0 && uint32(len(hello.FileNames)) == hello.TotalFiles {
+		advertised = make(map[string]bool, len(hello.FileNames))
+		for _, n := range hello.FileNames {
+			advertised[n] = true
+		}
+	}
+
 	// File loop.
 	for {
 		if err := ctx.Err(); err != nil {
@@ -192,6 +209,10 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 		if strings.ContainsAny(info.RelativePath, `/\`) {
 			declineTransfer(s, wire.ErrCodeProtocolError, "path separator in file name")
 			return fmt.Errorf("%w: RelativePath %q contains a path separator", fserrors.ErrProtocolError, info.RelativePath)
+		}
+		if advertised != nil && !advertised[info.RelativePath] {
+			declineTransfer(s, wire.ErrCodeProtocolError, "file not in advertised name list")
+			return fmt.Errorf("%w: file %q was not among the advertised names", fserrors.ErrProtocolError, info.RelativePath)
 		}
 		if err := recvOneFile(ctx, s, &info, opts, archiveMode); err != nil {
 			return err
@@ -387,6 +408,9 @@ func recvOneFile(ctx context.Context, s *Streams, info *wire.FileInfo, opts Recv
 	}
 	if err := wire.WriteControl(s.Control, wire.TypeFileAccept, &decision); err != nil {
 		return fmt.Errorf("recv: file-accept: %w", err)
+	}
+	if action == wire.ActionResume && opts.OnResume != nil {
+		opts.OnResume(info.Index, resumeOffset, info.Size)
 	}
 
 	// Open the partial sidecar (not the target). On full re-download we

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"syscall"
 	"time"
 
@@ -128,6 +129,18 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 	// the target directory instead of renaming it into place.
 	archiveMode := hello.TransferKind == wire.TransferDirectory
 
+	// The user consented to the HELLO's totals at the accept prompt;
+	// without enforcement they are display-only, and a malicious sender
+	// could advertise "1 file · 5 B" and then stream FILE_INFO frames
+	// until the disk fills. Every kind carries exactly one FILE_INFO
+	// (directory transfers wrap everything in one tar) except multi-file,
+	// which carries TotalFiles.
+	maxFiles := uint64(1)
+	if hello.TransferKind == wire.TransferMultiFile {
+		maxFiles = uint64(hello.TotalFiles)
+	}
+	var filesSeen, bytesDeclared uint64
+
 	// File loop.
 	for {
 		if err := ctx.Err(); err != nil {
@@ -156,6 +169,24 @@ func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
 		if info.Streaming && hello.TransferKind != wire.TransferStdin {
 			declineTransfer(s, wire.ErrCodeProtocolError, "streaming file in non-stdin transfer")
 			return fmt.Errorf("%w: streaming FILE_INFO in a non-stdin transfer", fserrors.ErrProtocolError)
+		}
+		filesSeen++
+		if filesSeen > maxFiles {
+			declineTransfer(s, wire.ErrCodeProtocolError, "more files than HELLO declared")
+			return fmt.Errorf("%w: FILE_INFO count exceeds the %d declared in HELLO", fserrors.ErrProtocolError, maxFiles)
+		}
+		bytesDeclared += info.Size
+		if bytesDeclared > hello.TotalBytes {
+			declineTransfer(s, wire.ErrCodeProtocolError, "declared sizes exceed HELLO total")
+			return fmt.Errorf("%w: declared sizes exceed the %d bytes in HELLO", fserrors.ErrProtocolError, hello.TotalBytes)
+		}
+		// Legitimate senders only ever put bare basenames in RelativePath
+		// (Walk basenames, ArchiveName, synthetic stdin/text names); a
+		// separator means a peer creating directory trees the user never
+		// consented to.
+		if strings.ContainsAny(info.RelativePath, `/\`) {
+			declineTransfer(s, wire.ErrCodeProtocolError, "path separator in file name")
+			return fmt.Errorf("%w: RelativePath %q contains a path separator", fserrors.ErrProtocolError, info.RelativePath)
 		}
 		if err := recvOneFile(ctx, s, &info, opts, archiveMode); err != nil {
 			return err

--- a/internal/transfer/resume_test.go
+++ b/internal/transfer/resume_test.go
@@ -70,6 +70,10 @@ func TestResume_ReusesAlignedPartial(t *testing.T) {
 	sniff := &controlSniffer{inner: b.Control}
 	b.Control = sniff
 
+	// Both sides must surface the resume to their UIs, with the offset
+	// — that's what powers the "Resuming from …" line and keeps the
+	// summary rate honest about bytes actually moved.
+	var sendResumeOff, recvResumeOff uint64
 	var sendErr, recvErr error
 	var wg sync.WaitGroup
 	wg.Add(2)
@@ -78,12 +82,14 @@ func TestResume_ReusesAlignedPartial(t *testing.T) {
 		sendErr = Send(context.Background(), &a, SendOptions{
 			Items:        items,
 			TransferKind: wire.TransferSingleFile,
+			OnResume:     func(_ uint32, off, _ uint64) { sendResumeOff = off },
 		})
 	}()
 	go func() {
 		defer wg.Done()
 		recvErr = Recv(context.Background(), &b, RecvOptions{
 			TargetDir: dstDir,
+			OnResume:  func(_ uint32, off, _ uint64) { recvResumeOff = off },
 		})
 	}()
 	wg.Wait()
@@ -93,6 +99,12 @@ func TestResume_ReusesAlignedPartial(t *testing.T) {
 	}
 	if recvErr != nil {
 		t.Fatalf("recv: %v", recvErr)
+	}
+	if sendResumeOff != prefix {
+		t.Errorf("sender OnResume offset = %d, want %d", sendResumeOff, prefix)
+	}
+	if recvResumeOff != prefix {
+		t.Errorf("receiver OnResume offset = %d, want %d", recvResumeOff, prefix)
 	}
 
 	// Sniffer should have observed ActionResume with offset == prefix.

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -40,6 +40,11 @@ type SendOptions struct {
 	Password    string                                   // empty → no password challenge
 	ProgressFn  func(fileIndex uint32, bytesSent uint64) // called periodically; may be nil
 
+	// OnResume fires once per file the receiver elected to resume, after
+	// the partial-prefix verification passed and before any chunk flows.
+	// Lets the CLI announce the resume and count only the tail as moved.
+	OnResume func(fileIndex uint32, offset, total uint64)
+
 	// OnStreamingEOF fires exactly once per streaming item, immediately
 	// after the EOF chunk has been written. The CLI uses this hook to
 	// latch the progress bar's total to the real byte count (which is
@@ -80,6 +85,16 @@ func send(ctx context.Context, s *Streams, opts SendOptions) error {
 	}
 	for _, it := range opts.Items {
 		hello.TotalBytes += it.Info.Size
+	}
+	// Multi-file: advertise the names (bare basenames from Walk) so the
+	// receiver's consent prompt isn't blind. Capped to bound frame size.
+	if opts.TransferKind == wire.TransferMultiFile {
+		for _, it := range opts.Items {
+			if len(hello.FileNames) == wire.MaxHelloFileNames {
+				break
+			}
+			hello.FileNames = append(hello.FileNames, it.Info.RelativePath)
+		}
 	}
 
 	if err := wire.WriteControl(s.Control, wire.TypeHello, hello); err != nil {
@@ -227,6 +242,9 @@ func sendOneFile(ctx context.Context, s *Streams, it *SourceItem, opts SendOptio
 			})
 			return fserrors.ErrPartialMismatch
 		}
+	}
+	if decision.Action == wire.ActionResume && decision.ResumeOffset > 0 && opts.OnResume != nil {
+		opts.OnResume(it.Info.Index, decision.ResumeOffset, it.Info.Size)
 	}
 
 	// Open source.

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/klauspost/compress/zstd"
 	"github.com/zeebo/blake3"
@@ -52,6 +53,17 @@ type SendOptions struct {
 //  3. For each file: write FILE_INFO, read FILE_ACCEPT, stream chunks if accepted
 //  4. Write TRANSFER_COMPLETE, read TRANSFER_ACK
 func Send(ctx context.Context, s *Streams, opts SendOptions) error {
+	err := send(ctx, s, opts)
+	// A Ctrl-C here looks like a network drop to the receiver, which
+	// burns its retry budget before failing with the wrong diagnosis —
+	// best-effort tell it the teardown is deliberate.
+	if errors.Is(err, context.Canceled) {
+		notifyCancel(s)
+	}
+	return err
+}
+
+func send(ctx context.Context, s *Streams, opts SendOptions) error {
 	totalFiles := opts.TotalFiles
 	if totalFiles == 0 {
 		totalFiles = uint32(len(opts.Items))
@@ -131,15 +143,24 @@ func Send(ctx context.Context, s *Streams, opts SendOptions) error {
 func peerError(body []byte) error {
 	var ef wire.ErrorFrame
 	_ = wire.Decode(body, &ef)
-	switch ef.Code {
-	case wire.ErrCodeTargetExists:
-		return fserrors.ErrTargetExists
-	case wire.ErrCodeFileHashMismatch:
-		return fserrors.ErrHashMismatch
-	case wire.ErrCodeWriteFailed:
-		return fmt.Errorf("%w: receiver: %s", fserrors.ErrWriteFailed, ef.Message)
-	default:
-		return fmt.Errorf("%w: peer reported %d: %s", fserrors.ErrProtocolError, ef.Code, ef.Message)
+	return mapPeerError(ef)
+}
+
+// notifyCancel posts a cancel ERROR so the peer can tell a deliberate
+// Ctrl-C from a network drop. Data closes first so the receiver's chunk
+// read EOFs into its read-control path (same ordering as the
+// partial-mismatch abort). Bounded to a second — the notice must never
+// hold the user's cancel hostage to a wedged peer.
+func notifyCancel(s *Streams) {
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		_ = s.Data.Close()
+		declineTransfer(s, wire.ErrCodeCancelled, "sender cancelled")
+	}()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
 	}
 }
 
@@ -422,13 +443,21 @@ func senderPasswordHandshake(s *Streams, password string) error {
 	if err := wire.WriteControl(s.Control, wire.TypePasswordChallenge, &wire.PasswordChallenge{Nonce: nonce}); err != nil {
 		return fmt.Errorf("send: password challenge: %w", err)
 	}
-	var resp wire.PasswordResponse
-	ft, err := wire.ReadControl(s.Control, &resp)
+	ft, body, err := wire.ReadControlRaw(s.Control)
 	if err != nil {
 		return fmt.Errorf("send: read password response: %w", err)
 	}
+	if ft == wire.TypeError {
+		// Receiver bailed before answering — e.g. it has no password to
+		// offer (--quiet with no --pass). Surface its stated reason.
+		return peerError(body)
+	}
 	if ft != wire.TypePasswordResponse {
 		return fmt.Errorf("%w: expected PASSWORD_RESPONSE, got %v", fserrors.ErrProtocolError, ft)
+	}
+	var resp wire.PasswordResponse
+	if err := wire.Decode(body, &resp); err != nil {
+		return fmt.Errorf("send: decode password response: %w", err)
 	}
 	expected := hmacPassword(password, nonce[:])
 	if subtle.ConstantTimeCompare(expected, resp.HMAC[:]) != 1 {

--- a/internal/transfer/streaming_guard_test.go
+++ b/internal/transfer/streaming_guard_test.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"context"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"sync"
@@ -84,5 +85,175 @@ func TestRecv_RejectsStreamingFileInNonStdinTransfer(t *testing.T) {
 	}
 	if _, err := os.Stat(filepath.Join(dstDir, "small.bin"+partialSuffix)); err == nil {
 		t.Error("receiver opened a partial for the rejected file")
+	}
+}
+
+// runMaliciousSender drives Recv against a hand-scripted sender: HELLO
+// goes out, the ack is drained, script runs on the sender's streams, and
+// the next control frame the sender reads back is returned (TypeError on
+// a guard violation) along with Recv's error.
+func runMaliciousSender(t *testing.T, hello *wire.SenderHello, opts RecvOptions, script func(sender *Streams)) (wire.FrameType, error) {
+	t.Helper()
+	sender, receiver := pipePair()
+	opts.Accept = func(_ wire.SenderHello) bool { return true }
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	var recvErr error
+	go func() {
+		defer wg.Done()
+		recvErr = Recv(context.Background(), &receiver, opts)
+		_ = receiver.Control.Close()
+		_ = receiver.Data.Close()
+	}()
+
+	var gotFrameType wire.FrameType
+	go func() {
+		defer wg.Done()
+		defer sender.Control.Close()
+		defer sender.Data.Close()
+		_ = wire.WriteControl(sender.Control, wire.TypeHello, hello)
+
+		var ack wire.ReceiverHello
+		_, _ = wire.ReadControl(sender.Control, &ack)
+		if !ack.Accepts {
+			return
+		}
+		script(&sender)
+
+		var ef wire.ErrorFrame
+		gotFrameType, _ = wire.ReadControl(sender.Control, &ef)
+	}()
+
+	wg.Wait()
+	return gotFrameType, recvErr
+}
+
+// sendEmptyFile completes one legitimate zero-byte file so the scripted
+// sender can probe what happens after the consented transfer is done.
+func sendEmptyFile(sender *Streams, index uint32, name string) {
+	fi := wire.FileInfo{Index: index, RelativePath: name, Mode: 0o644}
+	_ = wire.WriteControl(sender.Control, wire.TypeFileInfo, &fi)
+	var d wire.FileAcceptDecision
+	_, _ = wire.ReadControl(sender.Control, &d)
+	_ = wire.WriteChunk(sender.Data, &wire.Chunk{
+		FileIndex: index, Flags: wire.FlagLastChunk, Blake3Hash: blakeHash32(nil),
+	})
+}
+
+// TestRecv_RejectsOversoldFileCount: the accept prompt showed "1 file";
+// after that file completes, any further FILE_INFO is a consent bypass
+// and must be refused before a partial is even opened.
+func TestRecv_RejectsOversoldFileCount(t *testing.T) {
+	dstDir := t.TempDir()
+	hello := &wire.SenderHello{
+		ProtocolVersion: wire.ProtocolVersion,
+		TransferKind:    wire.TransferSingleFile,
+		TotalFiles:      1,
+		DisplayName:     "tiny.bin",
+	}
+
+	gotFrameType, recvErr := runMaliciousSender(t, hello, RecvOptions{TargetDir: dstDir}, func(sender *Streams) {
+		sendEmptyFile(sender, 0, "tiny.bin")
+		// Malicious: a second FILE_INFO the user never consented to.
+		fi := wire.FileInfo{Index: 1, RelativePath: "extra.bin", Mode: 0o644}
+		_ = wire.WriteControl(sender.Control, wire.TypeFileInfo, &fi)
+	})
+
+	if !errors.Is(recvErr, fserrors.ErrProtocolError) {
+		t.Errorf("expected ErrProtocolError for FILE_INFO beyond HELLO count, got %v", recvErr)
+	}
+	if gotFrameType != wire.TypeError {
+		t.Errorf("sender should receive an ERROR frame, got frame type %v", gotFrameType)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "extra.bin"+partialSuffix)); err == nil {
+		t.Error("receiver opened a partial for the oversold file")
+	}
+}
+
+// TestRecv_RejectsOversoldTotalBytes: the prompt showed 5 B; a FILE_INFO
+// declaring more must be refused before any bytes hit the disk.
+func TestRecv_RejectsOversoldTotalBytes(t *testing.T) {
+	dstDir := t.TempDir()
+	hello := &wire.SenderHello{
+		ProtocolVersion: wire.ProtocolVersion,
+		TransferKind:    wire.TransferSingleFile,
+		TotalFiles:      1,
+		TotalBytes:      5, // what the accept prompt showed
+		DisplayName:     "small.bin",
+	}
+
+	gotFrameType, recvErr := runMaliciousSender(t, hello, RecvOptions{TargetDir: dstDir}, func(sender *Streams) {
+		fi := wire.FileInfo{
+			Index: 0, RelativePath: "small.bin", Size: 1 << 40, Mode: 0o644,
+		}
+		_ = wire.WriteControl(sender.Control, wire.TypeFileInfo, &fi)
+	})
+
+	if !errors.Is(recvErr, fserrors.ErrProtocolError) {
+		t.Errorf("expected ErrProtocolError for declared size beyond HELLO total, got %v", recvErr)
+	}
+	if gotFrameType != wire.TypeError {
+		t.Errorf("sender should receive an ERROR frame, got frame type %v", gotFrameType)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "small.bin"+partialSuffix)); err == nil {
+		t.Error("receiver opened a partial for the oversold file")
+	}
+}
+
+// TestRecv_RejectsNestedPathInMultiFile: legitimate multi-file senders
+// only ever put bare basenames in RelativePath; a separator means the
+// peer is creating directory trees the user never saw at the prompt.
+func TestRecv_RejectsNestedPathInMultiFile(t *testing.T) {
+	dstDir := t.TempDir()
+	hello := &wire.SenderHello{
+		ProtocolVersion: wire.ProtocolVersion,
+		TransferKind:    wire.TransferMultiFile,
+		TotalFiles:      2,
+		TotalBytes:      1024,
+		DisplayName:     "2 files",
+	}
+
+	gotFrameType, recvErr := runMaliciousSender(t, hello, RecvOptions{TargetDir: dstDir}, func(sender *Streams) {
+		fi := wire.FileInfo{
+			Index: 0, RelativePath: "nested/evil.bin", Size: 5, Mode: 0o644,
+		}
+		_ = wire.WriteControl(sender.Control, wire.TypeFileInfo, &fi)
+	})
+
+	if !errors.Is(recvErr, fserrors.ErrProtocolError) {
+		t.Errorf("expected ErrProtocolError for nested RelativePath in multi-file transfer, got %v", recvErr)
+	}
+	if gotFrameType != wire.TypeError {
+		t.Errorf("sender should receive an ERROR frame, got frame type %v", gotFrameType)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "nested")); err == nil {
+		t.Error("receiver created a directory the user never consented to")
+	}
+}
+
+// TestRecv_SinkRejectsSecondPayload: sink mode emits bytes straight to
+// the caller's writer, so a second payload would silently concatenate —
+// the count guard must cover recvPayloadToSink too.
+func TestRecv_SinkRejectsSecondPayload(t *testing.T) {
+	hello := &wire.SenderHello{
+		ProtocolVersion: wire.ProtocolVersion,
+		TransferKind:    wire.TransferSingleFile,
+		TotalFiles:      1,
+		DisplayName:     "tiny.bin",
+	}
+
+	gotFrameType, recvErr := runMaliciousSender(t, hello, RecvOptions{Sink: io.Discard}, func(sender *Streams) {
+		sendEmptyFile(sender, 0, "tiny.bin")
+		fi := wire.FileInfo{Index: 1, RelativePath: "extra.bin", Mode: 0o644}
+		_ = wire.WriteControl(sender.Control, wire.TypeFileInfo, &fi)
+	})
+
+	if !errors.Is(recvErr, fserrors.ErrProtocolError) {
+		t.Errorf("expected ErrProtocolError for second payload in sink mode, got %v", recvErr)
+	}
+	if gotFrameType != wire.TypeError {
+		t.Errorf("sender should receive an ERROR frame, got frame type %v", gotFrameType)
 	}
 }

--- a/internal/transfer/symlink_security_test.go
+++ b/internal/transfer/symlink_security_test.go
@@ -159,6 +159,9 @@ func TestRecv_RefusesPreplantedPartialSymlink(t *testing.T) {
 		payload[i] = byte(i)
 	}
 	root := blakeHash32(payload)
+	// Declare the payload size honestly so the consented-totals guard
+	// doesn't reject the transfer before the sidecar gate under test.
+	hello.TotalBytes = uint64(len(payload))
 
 	var wg sync.WaitGroup
 	wg.Add(2)

--- a/internal/transfer/transfer_test.go
+++ b/internal/transfer/transfer_test.go
@@ -461,6 +461,113 @@ func TestPasswordHandshake_Wrong(t *testing.T) {
 	}
 }
 
+// TestPasswordHandshake_NoPasswordAvailable covers the quiet receiver
+// with nothing to answer the challenge (--quiet --yes, no --pass /
+// FSEND_PASS → PromptPass nil): both sides must fail terminally with
+// ErrPasswordRequired — the sender via the receiver's decline frame,
+// not a connection teardown it would misread as a network drop.
+func TestPasswordHandshake_NoPasswordAvailable(t *testing.T) {
+	srcDir, dstDir := t.TempDir(), t.TempDir()
+	srcPath := filepath.Join(srcDir, "blob.bin")
+	if err := os.WriteFile(srcPath, []byte("payload"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	items, err := Walk([]string{srcPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a, b := pipePair()
+	defer a.Close()
+	defer b.Close()
+
+	var sendErr, recvErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		sendErr = Send(context.Background(), &a, SendOptions{
+			Items: items, TransferKind: wire.TransferSingleFile, Password: "swordfish",
+		})
+	}()
+	go func() {
+		defer wg.Done()
+		recvErr = Recv(context.Background(), &b, RecvOptions{
+			TargetDir: dstDir, // Password empty, PromptPass nil
+		})
+	}()
+	wg.Wait()
+	if !errors.Is(sendErr, fserrors.ErrPasswordRequired) {
+		t.Errorf("Send err = %v, want ErrPasswordRequired", sendErr)
+	}
+	if !errors.Is(recvErr, fserrors.ErrPasswordRequired) {
+		t.Errorf("Recv err = %v, want ErrPasswordRequired", recvErr)
+	}
+	if _, err := os.Stat(filepath.Join(dstDir, "blob.bin")); err == nil {
+		t.Errorf("destination file was created despite missing password")
+	}
+}
+
+// TestSenderCancel_NotifiesReceiver verifies a sender Ctrl-C mid-transfer
+// posts the cancel notice: the receiver gets the terminal ErrPeerCancelled
+// (no transient "stream closed" it would burn retries on) and keeps its
+// partial sidecar for a later resume.
+func TestSenderCancel_NotifiesReceiver(t *testing.T) {
+	const fileSize = 3 * 1024 * 1024 // several chunks
+
+	srcDir, dstDir := t.TempDir(), t.TempDir()
+	srcPath := filepath.Join(srcDir, "big.bin")
+	payload := make([]byte, fileSize)
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcPath, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	items, err := Walk([]string{srcPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	a, b := pipePair()
+	defer a.Close()
+	defer b.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var sendErr, recvErr error
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		sendErr = Send(ctx, &a, SendOptions{
+			Items: items, TransferKind: wire.TransferSingleFile,
+			// Cancel after the first chunk lands — the Ctrl-C-mid-transfer shape.
+			ProgressFn: func(uint32, uint64) { cancel() },
+		})
+		// Production closes the QUIC session when Send returns; mirror it
+		// so the receiver's stream reads unblock.
+		a.Close()
+	}()
+	go func() {
+		defer wg.Done()
+		recvErr = Recv(context.Background(), &b, RecvOptions{TargetDir: dstDir})
+	}()
+	wg.Wait()
+
+	if !errors.Is(sendErr, context.Canceled) {
+		t.Errorf("Send err = %v, want context.Canceled", sendErr)
+	}
+	if !errors.Is(recvErr, fserrors.ErrPeerCancelled) {
+		t.Errorf("Recv err = %v, want ErrPeerCancelled", recvErr)
+	}
+	// The partial must survive so a fresh code can resume it.
+	if _, err := os.Stat(filepath.Join(dstDir, "big.bin"+partialSuffix)); err != nil {
+		t.Errorf("partial sidecar missing after cancel: %v", err)
+	}
+}
+
 func blakeFile(t *testing.T, path string) [32]byte {
 	t.Helper()
 	f, err := os.Open(path)

--- a/internal/uxlog/format.go
+++ b/internal/uxlog/format.go
@@ -6,15 +6,16 @@ import (
 )
 
 // HumanBytes renders a byte count in compact human-readable form.
-// Sub-KiB values render as whole bytes ("169 B"); larger values use one
-// decimal of precision against 1024-based units ("1.5 MB"). The unit
+// Sub-KB values render as whole bytes ("169 B"); larger values use one
+// decimal of precision against decimal (1000-based) units ("1.5 MB") —
+// matching what Finder/Explorer report for the same file. The unit
 // suffix is always uppercase "B" (bytes), never lowercase "b" (bits).
 //
 // Lives in uxlog (rather than cmd/fsend) so the progress-bar decorators
 // can share the exact same formatter the summary lines use — there's no
 // way for the two to drift apart and surprise the user.
 func HumanBytes(n int64) string {
-	const unit = 1024
+	const unit = 1000
 	if n < unit {
 		return fmt.Sprintf("%d B", n)
 	}
@@ -61,16 +62,17 @@ func HumanDuration(d time.Duration) string {
 // dominates the rate). Callers can omit a trailing "(<rate>)" clause
 // cleanly instead of printing "4.2 GB/s" for a 12 KB transfer.
 //
-// The thresholds are tuned so a one-second 1 MiB transfer reports a
+// The thresholds are tuned so a one-second 1 MB transfer reports a
 // rate (genuinely useful), but a one-second 169 B transfer does not
 // (the number would be dominated by setup time).
 func HumanRate(bytes int64, elapsed time.Duration) string {
 	if elapsed < 100*time.Millisecond || bytes <= 0 {
 		return ""
 	}
-	// Sub-MiB transfers complete in less time than the connection setup
-	// takes, so the computed rate is just noise. Skip.
-	const rateNoiseFloor = 1 << 20
+	// Sub-MB transfers complete in less time than the connection setup
+	// takes, so the computed rate is just noise. Skip. Matches the
+	// HumanBytes "1 MB" boundary so any size displayed in MB has a rate.
+	const rateNoiseFloor = 1000 * 1000
 	if bytes < rateNoiseFloor {
 		return ""
 	}

--- a/internal/uxlog/format_test.go
+++ b/internal/uxlog/format_test.go
@@ -13,11 +13,15 @@ func TestHumanBytes(t *testing.T) {
 	}{
 		{0, "0 B"},
 		{512, "512 B"},
-		{1024, "1 KB"},
-		{1536, "1.5 KB"},
-		{1024 * 1024, "1 MB"},
-		{int64(2.5 * 1024 * 1024), "2.5 MB"},
-		{100 * 1024 * 1024, "100 MB"},
+		{999, "999 B"},
+		{1000, "1 KB"},
+		{1500, "1.5 KB"},
+		// Decimal units, matching Finder/Explorer: 1 KiB is 1.0 KB.
+		{1024, "1.0 KB"},
+		{1000 * 1000, "1 MB"},
+		{2_500_000, "2.5 MB"},
+		{100_000_000, "100 MB"},
+		{1_500_000_000, "1.5 GB"},
 	} {
 		if got := HumanBytes(tc.in); got != tc.want {
 			t.Errorf("HumanBytes(%d) = %q, want %q", tc.in, got, tc.want)
@@ -44,19 +48,19 @@ func TestHumanDuration(t *testing.T) {
 
 func TestHumanRate(t *testing.T) {
 	// Below 100ms is too noisy → empty.
-	if got := HumanRate(1024*1024, 50*time.Millisecond); got != "" {
+	if got := HumanRate(1000*1000, 50*time.Millisecond); got != "" {
 		t.Errorf("sub-100ms should yield empty, got %q", got)
 	}
 	// Zero bytes → empty.
 	if got := HumanRate(0, time.Second); got != "" {
 		t.Errorf("zero bytes should yield empty, got %q", got)
 	}
-	// Sub-MiB is dominated by handshake noise → empty.
-	if got := HumanRate(64*1024, time.Second); got != "" {
-		t.Errorf("sub-MiB should yield empty, got %q", got)
+	// Sub-MB is dominated by handshake noise → empty.
+	if got := HumanRate(64*1000, time.Second); got != "" {
+		t.Errorf("sub-MB should yield empty, got %q", got)
 	}
-	// 1 MiB / 1s ≈ 1.0 MB/s.
-	if got := HumanRate(1024*1024, time.Second); !strings.HasSuffix(got, "/s") {
+	// 1 MB / 1s = 1 MB/s.
+	if got := HumanRate(1000*1000, time.Second); !strings.HasSuffix(got, "/s") {
 		t.Errorf("got %q, want trailing /s", got)
 	}
 }

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -95,11 +95,11 @@ func (p *plainProgress) done() {
 const barWidth = 40
 
 // rateThreshold is the transfer size below which rate + ETA are
-// suppressed. Small transfers (sub-MiB) finish in less time than the
+// suppressed. Small transfers (sub-MB) finish in less time than the
 // PAKE handshake takes; reporting "13 B/s" for a 169 B file is just
-// noise. Above 1 MiB the steady-state throughput dominates and the
-// figure becomes meaningful.
-const rateThreshold = 1 << 20
+// noise. Above 1 MB the steady-state throughput dominates and the
+// figure becomes meaningful. Matches HumanRate's noise floor.
+const rateThreshold = 1000 * 1000
 
 // activeProgress is the bar currently drawing on the terminal, if any.
 // Println routes through it so foreign lines (retry notices) land between

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,8 +1,15 @@
 // Package version exposes build-time injected version metadata.
 //
 // At release time, the build embeds the semver tag and commit SHA via
-// -ldflags. In development, these fall back to "dev" / "unknown".
+// -ldflags. `go install …@vX.Y.Z` builds carry no ldflags but do embed
+// the module version in build info, which init recovers. Plain dev
+// builds fall back to "dev" / "unknown".
 package version
+
+import (
+	"runtime/debug"
+	"strings"
+)
 
 // Version is the semver string (without the leading "v"), e.g. "0.1.0".
 var Version = "dev"
@@ -12,6 +19,28 @@ var Commit = "unknown"
 
 // Date is the build timestamp in RFC3339.
 var Date = "unknown"
+
+func init() {
+	if Version != "dev" {
+		return // ldflags already set it
+	}
+	if bi, ok := debug.ReadBuildInfo(); ok {
+		if v := buildInfoVersion(bi.Main.Version); v != "" {
+			Version = v
+		}
+	}
+}
+
+// buildInfoVersion maps a build-info main-module version onto the
+// ldflags convention (goreleaser injects {{.Version}}, which has no
+// leading "v"). Returns "" when build info carries nothing usable —
+// `go build` from a checkout reports "(devel)".
+func buildInfoVersion(v string) string {
+	if v == "" || v == "(devel)" {
+		return ""
+	}
+	return strings.TrimPrefix(v, "v")
+}
 
 // String returns "fsend X.Y.Z (build abc1234, 2026-06-01)" for release
 // builds. Dev builds (Commit/Date unset) collapse to "fsend dev" so the

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -26,3 +26,20 @@ func TestString(t *testing.T) {
 		}
 	}
 }
+
+// buildInfoVersion feeds the `go install` fallback: module versions are
+// v-prefixed and must match the ldflags convention (no "v"), while a
+// plain `go build` reports "(devel)" and must stay "dev".
+func TestBuildInfoVersion(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"v1.0.0", "1.0.0"},
+		{"v1.0.1-0.20260611000000-abcdef123456", "1.0.1-0.20260611000000-abcdef123456"},
+		{"(devel)", ""},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := buildInfoVersion(c.in); got != c.want {
+			t.Errorf("buildInfoVersion(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}

--- a/internal/wire/payloads.go
+++ b/internal/wire/payloads.go
@@ -27,7 +27,22 @@ type SenderHello struct {
 	// falls back to its pre-DisplayName rendering. Bumping the protocol
 	// version is therefore not required for this field.
 	DisplayName string
+
+	// FileNames lists the bare file names of a multi-file transfer so
+	// the receiver's accept prompt can show what would land on disk
+	// instead of asking for blind consent to "N files". Capped at
+	// MaxHelloFileNames entries to bound the frame size; when the list
+	// is complete (len == TotalFiles) the receiver also enforces that
+	// every received RelativePath is one of these names. Empty for
+	// other transfer kinds and for older senders (additive gob field).
+	FileNames []string
 }
+
+// MaxHelloFileNames caps SenderHello.FileNames. Basenames are ≤255
+// bytes on common filesystems, so 16 names stay far below the 64 KiB
+// control-frame limit while covering most multi-file sends completely
+// (which is what makes name enforcement possible on the receiver).
+const MaxHelloFileNames = 16
 
 // PasswordChallenge is sent by the sender right after a positive
 // HELLO_ACK when SenderHello.HasPassword is true. The nonce is fresh per

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -79,8 +79,8 @@ const (
 type ErrorCode uint16
 
 // ErrorCode values reported in TypeError frames. Only the codes a peer
-// actually emits live here — the receiver's switch in tryReadPeerError
-// is the source of truth for what gets mapped to a user-facing error.
+// actually emits live here — transfer.mapPeerError is the source of
+// truth for what gets mapped to a user-facing error.
 // Numeric values are kept stable so a peer running an older fsend can
 // still recognise them; new codes get fresh numbers.
 const (
@@ -99,6 +99,14 @@ const (
 	// extract, …). Terminal for the sender: retrying won't fix the
 	// receiver's disk.
 	ErrCodeWriteFailed ErrorCode = 13
+	// ErrCodePasswordRequired — sender demanded a password but the
+	// receiver had none to offer (--quiet with no --pass / FSEND_PASS).
+	// Distinct from ErrCodeWrongPassword: no attempt was ever made.
+	ErrCodePasswordRequired ErrorCode = 14
+	// ErrCodeCancelled — the peer cancelled deliberately (Ctrl-C).
+	// Terminal: lets the survivor skip its retry budget instead of
+	// misdiagnosing the teardown as a network drop.
+	ErrCodeCancelled ErrorCode = 15
 )
 
 // Chunk-frame flag bits.

--- a/internal/wire/wire_test.go
+++ b/internal/wire/wire_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"reflect"
 	"strings"
 	"testing"
 	"testing/quick"
@@ -15,9 +16,10 @@ func TestControl_HelloRoundtrip(t *testing.T) {
 		Hostname:        "Pol's MacBook",
 		OS:              "darwin",
 		ClientVersion:   "0.1.0",
-		TransferKind:    TransferSingleFile,
-		TotalFiles:      1,
+		TransferKind:    TransferMultiFile,
+		TotalFiles:      2,
 		TotalBytes:      4404019,
+		FileNames:       []string{"report.pdf", "notes.txt"},
 	}
 	var buf bytes.Buffer
 	if err := WriteControl(&buf, TypeHello, &want); err != nil {
@@ -32,7 +34,8 @@ func TestControl_HelloRoundtrip(t *testing.T) {
 	if ft != TypeHello {
 		t.Errorf("frame type = %v, want TypeHello", ft)
 	}
-	if got != want {
+	// SenderHello carries a slice (FileNames), so == doesn't apply.
+	if !reflect.DeepEqual(got, want) {
 		t.Errorf("roundtrip mismatch:\ngot:  %+v\nwant: %+v", got, want)
 	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -283,7 +283,10 @@ main() {
         [ -n "$vnum" ] || err "could not resolve latest version"
         version="v${vnum}"
     else
+        # Accept "-v 1.0.0" and "-v v1.0.0" alike: release tags are
+        # always v-prefixed, archive names never are.
         vnum="${version#v}"
+        version="v${vnum}"
         info "downloading checksums"
         download "https://github.com/${REPO}/releases/download/${version}/checksums.txt" "$tmp/checksums.txt"
     fi


### PR DESCRIPTION
Addresses all major findings plus the minor polish pass from the second holistic release-readiness audit.

## Majors
- **Archive mode silent data loss**: `fsend a/photos b/photos` no longer merges duplicate root basenames (case-insensitive guard, mirrors the Walk path); extraction now writes via `.fsend-partial` + rename so a mid-extract failure can't leave a truncated file at its final name.
- **Consent enforcement**: the receiver now enforces the HELLO totals it asked the user to approve — FILE_INFO count, cumulative declared bytes, bare-basename paths, and (new) the advertised name list. A malicious sender can no longer oversell "1 file · 5 B" and stream until the disk fills.
- **Pairing server can no longer MITM**: sessions are keyed by an argon2id-stretched *slot* of the code (same construction as the mDNS name); the raw code — the PAKE secret — never reaches the server in any URL, body, or log. Server-side code generation removed; clients always generate locally. Verified live: server debug logs contain only slots. `/wait` now shares the join/create rate limiter (closes the unthrottled code-existence oracle).
- **`fsend --pass <code>` guard**: a code-shaped `--pass`/`--connect` value errors with a redirect hint instead of silently showing help — or worse, streaming stdin with the code as password. `--pass=` (empty) errors instead of silently sending unprotected.
- **Quiet receiver on a password-gated transfer**: receiver now declines properly (new E031 both sides, role-aware) instead of leaving the sender to burn 20s of retries into a misleading E020.

## Minors
- Sender Ctrl-C now sends a best-effort cancel notice — receiver reports "The sender cancelled the transfer" (E032) instantly instead of retrying for 30s and blaming the network.
- Honest resume reporting: "Resuming from 104 MB (34%)" on both sides; summary shows moved bytes and a rate derived from them.
- Multi-file consent prompt lists the file names (carried in HELLO, capped at 16, enforced when complete).
- E020 receiver hint no longer promises the one-shot code will resume; it says to get a fresh code from the sender.
- Code-vs-file collision prompt: EOF aborts instead of consenting; typos re-prompt instead of exiting.
- `--exclude` errors when it can't apply (no directory being sent / receive mode).
- `go install @latest` builds report the real version via build info and update-check correctly.
- IPv6-only LANs: announce a global-unicast IPv6 and dial it with brackets (pion/mdns AAAA verified).
- Sizes are decimal (1000-base) to match their KB/MB/GB labels; default relay cap aligned to 100 MB.
- Release workflow gains a test gate; docker `latest` tag only pushes from tags; `install.sh -v 1.0.0` works without the `v`.
- Docs: security/architecture rewritten for the slot model; usage exit-code table + stale claims fixed.

## Verification
- Full test suite (incl. e2e) and golangci-lint green at every step.
- 13-scenario live end-to-end run on the merged tree against a local server: transfers byte-identical, code-privacy grep clean, all new guards/messages observed firing, no retry-loop regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)