### PR TITLE
fix: clamp negative since, valid compose relay cap, slim docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,3 +6,5 @@ deploy
 scripts
 *.md
 LICENSE
+dist
+fsend

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -18,12 +18,12 @@ services:
     ports:
       - "443:443/udp"
     environment:
-      # All env vars are optional; defaults shown.
+      # All env vars are optional.
       FSEND_HTTP_ADDR: ":8080"
       FSEND_UDP_ADDR: ":443"
       FSEND_LOG_LEVEL: "info"
       # Abuse limits — tune to your bandwidth budget.
-      FSEND_MAX_RELAY_BYTES_PER_SESSION: "100MiB"
+      FSEND_MAX_RELAY_BYTES_PER_SESSION: "1GB"
       FSEND_MAX_SESSIONS_PER_IP: "5"
       FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN: "30"
       # Password to restrict server access (empty = open); clients use `fsend --connect <domain>,<password>`.

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -626,6 +626,9 @@ func (s *Server) pullCandidates(w http.ResponseWriter, r *http.Request) {
 		// Skip silently on parse error — clients that send garbage just
 		// get the full candidate list starting at 0, which is harmless.
 		_, _ = fmt.Sscanf(v, "%d", &since)
+		if since < 0 {
+			since = 0 // negative would panic the slice below
+		}
 	}
 	tok := bearerToken(r)
 	s.mu.Lock()

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -341,6 +341,44 @@ func TestCandidates_RoutedByRoleToken(t *testing.T) {
 	}
 }
 
+// A negative since used to slice theirs[-1:] and panic the handler.
+func TestPullCandidates_NegativeSince(t *testing.T) {
+	srv := newTestServer(t)
+
+	c := createSession(t, srv.URL, testSlot)
+
+	jResp := postJSON(t, srv.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
+	defer jResp.Body.Close()
+	var j JoinSessionResponse
+	_ = json.NewDecoder(jResp.Body).Decode(&j)
+
+	body, _ := json.Marshal(CandidatesPushRequest{Candidates: []string{"receiver-cand-1"}})
+	req, _ := http.NewRequest(http.MethodPost, srv.URL+"/v1/session/"+c.SessionID+"/candidates", bytes.NewReader(body))
+	req.Header.Set("Authorization", "Bearer "+j.RoleToken)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	resp.Body.Close()
+
+	req, _ = http.NewRequest(http.MethodGet, srv.URL+"/v1/session/"+c.SessionID+"/candidates?since=-1", nil)
+	req.Header.Set("Authorization", "Bearer "+c.RoleToken)
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("since=-1 request failed (handler panic?): %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("since=-1: status = %d, want 200", resp.StatusCode)
+	}
+	var out CandidatesPullResponse
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	if len(out.Candidates) != 1 || out.Candidates[0] != "receiver-cand-1" {
+		t.Errorf("since=-1 candidates = %v, want [receiver-cand-1]", out.Candidates)
+	}
+}
+
 func TestDeleteSession(t *testing.T) {
 	srv := newTestServer(t)
 	c := createSession(t, srv.URL, testSlot)


### PR DESCRIPTION
Final-readiness fixes from the production review:

- **Reachable panic on the pairing server** — `GET /v1/session/{id}/candidates?since=-1` passed `Sscanf` and panicked the handler via `theirs[-1:]`. Clamped to 0; regression test added (`TestPullCandidates_NegativeSince`).
- **Compose deployment crash-looped out of the box** — `FSEND_MAX_RELAY_BYTES_PER_SESSION: "100MiB"` is rejected by `envBytes` (decimal units only), so `runServer` errored at startup and `restart: unless-stopped` masked it as a loop. Set to `1GB` and dropped the now-inaccurate "defaults shown" comment.
- **Docker build context bloat** — `.dockerignore` now excludes `dist/` (206 MB) and the stray root `fsend` binary (20 MB); patterns are root-anchored so `cmd/fsend` is unaffected. Final image was never bloated (multi-stage scratch), only local build context/builder layer.

Verified: `go test -race -count=1 ./internal/server/` green, `golangci-lint` 0 issues, `go build`/`go vet` clean. (CI will still show the billing failure.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)