### PR TITLE
ci: auto-merge dependabot minor/patch PRs once checks pass

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,24 @@
+name: dependabot-automerge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  automerge:
+    # Majors are left for human review; minor/patch merge once the
+    # required checks pass. Requires repo auto-merge enabled and a
+    # ruleset marking the checks as required — without required checks,
+    # --auto merges immediately.
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dependabot/fetch-metadata@v2
+        id: meta
+      - if: steps.meta.outputs.update-type != 'version-update:semver-major'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a workflow that flags Dependabot PRs for GitHub auto-merge (squash) when the update is minor or patch; majors stay open for human review.

**Activation prerequisites** (both arrive with the planned public flip):
1. Repo setting **Allow auto-merge** (Settings → General) — available free on public repos.
2. A **ruleset on `main` requiring the `checks` jobs** — without required checks, `--auto` merges immediately; with them, the PR merges only after CI is green.

Safe to merge now: while the repo is private, `gh pr merge --auto` errors out rather than merging directly, so nothing can land unvalidated. Note that merges performed by `GITHUB_TOKEN` don't trigger the push-to-main `checks` run — the PR-level checks are the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)