### PR TITLE
fix(ci): unbreak cross-platform CI and move to Go 1.26

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - run: go build ./...
       - run: go vet ./...
@@ -31,7 +31,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - run: go test -race -timeout 300s ./...
 
@@ -41,7 +41,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
       - uses: golangci/golangci-lint-action@v9
         with:
           version: latest
@@ -53,7 +53,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - run: go install golang.org/x/tools/cmd/deadcode@latest
       - run: |
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - env:
           CGO_ENABLED: "0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - run: go build ./...
       - run: go vet ./...
@@ -38,7 +38,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.25"
+          go-version: "1.26"
           cache: true
       - uses: sigstore/cosign-installer@v3
       - uses: goreleaser/goreleaser-action@v7

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.25-alpine AS builder
+FROM golang:1.26-alpine AS builder
 # Injected by docker.yml so released images don't report "fsend dev".
 ARG VERSION=dev
 ARG COMMIT=unknown

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/polius/fsend
 
-go 1.25.11
+go 1.25.0
 
 require (
 	github.com/adrg/xdg v0.5.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/polius/fsend
 
-go 1.25.0
+go 1.26.0
 
 require (
 	github.com/adrg/xdg v0.5.3

--- a/internal/transfer/archive_test.go
+++ b/internal/transfer/archive_test.go
@@ -7,11 +7,8 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
-	"runtime"
 	"sort"
-	"syscall"
 	"testing"
-	"time"
 
 	"github.com/polius/fsend/internal/fserrors"
 )
@@ -180,43 +177,6 @@ func TestBuildArchive_ExcludePatterns(t *testing.T) {
 				t.Errorf("expected %q to be excluded, but found it", bad)
 			}
 		}
-	}
-}
-
-// A FIFO inside a sent folder used to hang BuildArchive forever
-// (os.Open on a fifo blocks until a writer appears — before the share
-// code was even printed); a socket aborted the whole send. Both must be
-// skipped.
-func TestBuildArchive_SkipsSpecialFiles(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("no mkfifo on windows")
-	}
-	srcDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(srcDir, "real.txt"), []byte("data"), 0o644); err != nil {
-		t.Fatal(err)
-	}
-	if err := syscall.Mkfifo(filepath.Join(srcDir, "pipe.fifo"), 0o600); err != nil {
-		t.Fatalf("mkfifo: %v", err)
-	}
-
-	done := make(chan struct{})
-	var arc *ArchiveResult
-	var err error
-	go func() {
-		arc, err = BuildArchive([]string{srcDir}, nil)
-		close(done)
-	}()
-	select {
-	case <-done:
-	case <-time.After(10 * time.Second):
-		t.Fatal("BuildArchive hung on the fifo")
-	}
-	if err != nil {
-		t.Fatalf("BuildArchive: %v", err)
-	}
-	defer os.Remove(arc.Path)
-	if arc.NumFiles != 1 {
-		t.Errorf("NumFiles = %d, want 1 (fifo skipped)", arc.NumFiles)
 	}
 }
 

--- a/internal/transfer/archive_unix_test.go
+++ b/internal/transfer/archive_unix_test.go
@@ -1,0 +1,46 @@
+//go:build unix
+
+package transfer
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+	"time"
+)
+
+// A FIFO inside a sent folder used to hang BuildArchive forever
+// (os.Open on a fifo blocks until a writer appears — before the share
+// code was even printed); a socket aborted the whole send. Both must be
+// skipped. syscall.Mkfifo only exists on unix, so this lives in a
+// build-tagged file — go vet/test on windows can't compile it otherwise.
+func TestBuildArchive_SkipsSpecialFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "real.txt"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(srcDir, "pipe.fifo"), 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	done := make(chan struct{})
+	var arc *ArchiveResult
+	var err error
+	go func() {
+		arc, err = BuildArchive([]string{srcDir}, nil)
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("BuildArchive hung on the fifo")
+	}
+	if err != nil {
+		t.Fatalf("BuildArchive: %v", err)
+	}
+	defer os.Remove(arc.Path)
+	if arc.NumFiles != 1 {
+		t.Errorf("NumFiles = %d, want 1 (fifo skipped)", arc.NumFiles)
+	}
+}


### PR DESCRIPTION
## Problem

The latest full CI run ([27374532561](https://github.com/polius/fsend/actions/runs/27374532561)) failed on two platforms while ubuntu and all cross-compiles passed:

| Job | Step | Error |
|-----|------|-------|
| `test (macos-latest)` | `go build ./...` | `go.mod requires go >= 1.25.11 (running go 1.25.10; GOTOOLCHAIN=local)` |
| `test (windows-latest)` | `go vet ./...` | `internal/transfer/archive_test.go:198: undefined: syscall.Mkfifo` |

## Root causes

- **macOS:** `go.mod` pinned `go 1.25.11`, a patch newer than the runner's 1.25.10. CI's `setup-go` (`go-version: "1.25"`) resolved to 1.25.10 and sets `GOTOOLCHAIN=local`, blocking auto-download. Pinning a bleeding-edge patch breaks CI whenever a new patch lands before runner images update.
- **Windows:** the FIFO test called unix-only `syscall.Mkfifo` unconditionally, so the test package couldn't *compile* on Windows. The `runtime.GOOS == "windows"` skip is a runtime guard and can't prevent the compile failure.

## Fix

1. **Windows vet:** move `TestBuildArchive_SkipsSpecialFiles` to `internal/transfer/archive_unix_test.go` behind `//go:build unix`, dropping the now-pointless runtime skip and the unused `runtime`/`syscall`/`time` imports.
2. **Toolchain:** move the project to the current stable **Go 1.26** for the first release, keeping every reference in lockstep so the `go.mod` minimum and the installed toolchain can't drift (the original failure mode):
   - `go.mod`: `go 1.26.0` (minimum form, not a patch pin)
   - `checks.yml` / `release.yml`: `setup-go` `go-version: "1.26"`
   - `Dockerfile`: `golang:1.26-alpine` builder

## Verification (Go 1.26 toolchain)

- `go vet ./...` — native and `GOOS=windows` ✅
- `GOOS=darwin go build ./...` ✅
- `go test ./...` — full suite passes ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)