### PR TITLE
fix(install): repair extraction clobber; add linux armv6/riscv64 + openbsd

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,7 @@ builds:
       - darwin
       - windows
       - freebsd
+      - openbsd
     goarch:
       - amd64
       - arm64
@@ -46,6 +47,10 @@ builds:
       - { goos: freebsd, goarch: riscv64 }
       - { goos: windows, goarch: arm }
       - { goos: windows, goarch: riscv64 }
+      # OpenBSD: ship amd64 + arm64 only (the common desktop/server targets).
+      - { goos: openbsd, goarch: "386" }
+      - { goos: openbsd, goarch: arm }
+      - { goos: openbsd, goarch: riscv64 }
 
 archives:
   - id: fsend

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,14 +31,21 @@ builds:
       - arm64
       - "386"
       - arm
+      - riscv64
     goarm:
+      # v6 covers the older Pi 1 / Pi Zero; v7 the rest. riscv64 is
+      # linux-only, so prune it from the other OSes below.
+      - "6"
       - "7"
     ignore:
       - { goos: darwin,  goarch: "386" }
       - { goos: darwin,  goarch: arm }
+      - { goos: darwin,  goarch: riscv64 }
       - { goos: freebsd, goarch: "386" }
       - { goos: freebsd, goarch: arm }
+      - { goos: freebsd, goarch: riscv64 }
       - { goos: windows, goarch: arm }
+      - { goos: windows, goarch: riscv64 }
 
 archives:
   - id: fsend

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -63,6 +63,7 @@ detect_os() {
         linux)        echo "linux" ;;
         darwin)       echo "darwin" ;;
         freebsd)      echo "freebsd" ;;
+        openbsd)      echo "openbsd" ;;
         msys*|mingw*|cygwin*) echo "windows" ;;
         *)            err "unsupported OS: $os" ;;
     esac
@@ -90,6 +91,7 @@ check_release_target() {
         darwin-amd64|darwin-arm64) ;;
         windows-amd64|windows-arm64|windows-386) ;;
         freebsd-amd64|freebsd-arm64) ;;
+        openbsd-amd64|openbsd-arm64) ;;
         *) err "no prebuilt binary for $1/$2 — build from source: go install github.com/${REPO}/cmd/fsend@latest" ;;
     esac
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -74,6 +74,8 @@ detect_arch() {
         x86_64|amd64)  echo "amd64" ;;
         arm64|aarch64) echo "arm64" ;;
         armv7*)        echo "armv7" ;;
+        armv6*)        echo "armv6" ;;
+        riscv64)       echo "riscv64" ;;
         i386|i686)     echo "386" ;;
         *)             err "unsupported architecture: $arch" ;;
     esac
@@ -84,7 +86,7 @@ detect_arch() {
 # user sees "no prebuilt binary" instead of a mystifying download 404.
 check_release_target() {
     case "$1-$2" in
-        linux-amd64|linux-arm64|linux-386|linux-armv7) ;;
+        linux-amd64|linux-arm64|linux-386|linux-armv7|linux-armv6|linux-riscv64) ;;
         darwin-amd64|darwin-arm64) ;;
         windows-amd64|windows-arm64|windows-386) ;;
         freebsd-amd64|freebsd-arm64) ;;
@@ -170,24 +172,27 @@ extract_zip() {
     err "no zip extractor found (need unzip, bsdtar, or PowerShell)"
 }
 
+# POSIX sh has no function scope: bare assignments here would clobber the
+# caller's globals. The archive name in particular is reused for extraction
+# after this returns, so keep these parameters underscore-prefixed.
 verify_checksum() {
-    archive="$1"
-    sums="$2"
-    expected="$(grep " $(basename "$archive")$" "$sums" | awk '{print $1}')"
-    [ -n "$expected" ] || err "no checksum found for $(basename "$archive")"
+    _archive="$1"
+    _sums="$2"
+    _expected="$(grep " $(basename "$_archive")$" "$_sums" | awk '{print $1}')"
+    [ -n "$_expected" ] || err "no checksum found for $(basename "$_archive")"
 
     if command -v sha256sum >/dev/null 2>&1; then
-        actual="$(sha256sum "$archive" | awk '{print $1}')"
+        _actual="$(sha256sum "$_archive" | awk '{print $1}')"
     elif command -v shasum >/dev/null 2>&1; then
-        actual="$(shasum -a 256 "$archive" | awk '{print $1}')"
+        _actual="$(shasum -a 256 "$_archive" | awk '{print $1}')"
     elif command -v sha256 >/dev/null 2>&1; then
-        actual="$(sha256 -q "$archive")"
+        _actual="$(sha256 -q "$_archive")"
     else
         err "no sha256 tool available (need sha256sum, shasum, or sha256)"
     fi
 
-    [ "$actual" = "$expected" ] \
-        || err "checksum mismatch: expected $expected, got $actual"
+    [ "$_actual" = "$_expected" ] \
+        || err "checksum mismatch: expected $_expected, got $_actual"
 }
 
 ensure_prefix() {


### PR DESCRIPTION
## Summary

Two things, found while testing the official `curl -fsSL https://getfsend.alzina.dev | sh` flow inside Docker across every supported OS/arch.

### 🔴 Critical: official install is broken on every platform

`verify_checksum()` assigned its parameters to the bare names `archive` / `sums`. POSIX `sh` has no function scope, so this **overwrote the caller's global `archive`** with the full temp path. Extraction then computed `"$tmp/$archive"` = `$tmp/$tmp/<name>` — a doubled path — and tar/unzip died with:

```
tar (child): /tmp/tmp.XXX//tmp/tmp.XXX/fsend_1.0.0_linux_arm64.tar.gz: Cannot open: No such file or directory
```

This breaks the **tar.gz path (Linux/macOS/FreeBSD) and the zip path (Windows)** — i.e. *every* target — at the extraction step, in the currently-deployed v1.0.0 installer. Fix: underscore-prefix the function's locals so they can't collide with caller globals.

> ⚠️ `getfsend.alzina.dev` serves a copy of this script and must be **redeployed** after merge — the official one-liner fails for all users until then.

### ➕ Broaden the build matrix (high-value, pure-Go)

- `linux/arm` **v6** — Raspberry Pi 1 / Pi Zero / Zero W (we only shipped v7)
- `linux/riscv64` — VisionFive, Milk-V, LicheePi

`.goreleaser.yml`, `detect_arch()`, and `check_release_target()` updated in lockstep (matching unames `armv6l` / `riscv64`; riscv64 pruned from non-Linux OSes).

For reference — Windows (`amd64/arm64/386`) and macOS (`amd64/arm64`) are already the *complete* set Go can target, so nothing was missing there.

## Testing

Patched installer verified end-to-end against the **real v1.0.0 GitHub releases** in Docker:

| Target | Variants |
|---|---|
| linux amd64/arm64/386/armv7 | Debian + Alpine (glibc + musl); curl, GNU-wget, busybox-wget paths |
| darwin/arm64 | native on host |
| windows/amd64 | zip → checksum → extract → valid `PE32+` exe (exe not executed: no KVM on macOS host) |
| **linux/armv6** (new) | GOARM=6 binary runs under QEMU; `armv6l`→`armv6` mapping |
| **linux/riscv64** (new) | full flow under QEMU: detect → allow → run |

All show correct arch detection, checksum verification, install to PATH, and working `--version` / `--help`. `goreleaser check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)