### PR TITLE
feat(install): add native PowerShell installer for Windows

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -91,6 +91,7 @@ release:
   prerelease: auto
   extra_files:
     - glob: ./scripts/install.sh
+    - glob: ./scripts/install.ps1
 
 changelog:
   use: github

--- a/README.md
+++ b/README.md
@@ -37,13 +37,19 @@ fsend lets any two computers transfer files **directly** to each other — no ac
 
 ## Install
 
+**Linux, macOS, FreeBSD** — x86 and ARM:
+
 ```bash
 curl -fsSL https://getfsend.alzina.dev | sh
 ```
 
-Works on Linux, macOS, FreeBSD, and Windows — x86 and ARM. On Windows, run
-this in a POSIX shell (MSYS / MinGW / Cygwin / Git Bash); the installed
-`fsend.exe` then runs in any terminal once its directory is on your PATH.
+**Windows** — run this in PowerShell:
+
+```powershell
+irm https://getfsend.alzina.dev/install.ps1 | iex
+```
+
+Both installers verify the release's SHA-256 checksum before installing.
 
 <details>
 <summary>Other install methods</summary>

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -46,13 +46,17 @@ func runUninstall(f *flags) error {
 		binPath = resolved
 	}
 
-	// On Windows the running .exe can't delete itself. Best we can do is
-	// print the path and ask the user to remove it by hand. install.ps1 also
-	// puts the install dir on the user PATH; we don't strip it automatically
-	// (the user may share that dir with other tools), so point at it instead.
+	// On Windows a running .exe can't delete its own image, so removeBinary
+	// hands off to a detached helper that deletes it once we exit and strips
+	// the install dir from PATH — keeping uninstall hands-off like elsewhere.
 	if runtime.GOOS == "windows" {
-		fmt.Fprintf(os.Stderr, "  Delete this file to finish uninstall: %s\n", binPath)
-		fmt.Fprintf(os.Stderr, "  If you installed via install.ps1, also remove %s from your PATH.\n", filepath.Dir(binPath))
+		if err := removeBinary(binPath); err != nil {
+			fmt.Fprintf(os.Stderr, "%s Could not remove binary at %s: %v\n", uxlog.Warn(), binPath, err)
+			fmt.Fprintf(os.Stderr, "    Delete it manually to finish: %s\n", binPath)
+			return nil
+		}
+		fmt.Fprintf(os.Stderr, "%s Removed binary: %s\n", uxlog.Check(), binPath)
+		fmt.Fprintln(os.Stderr, "  fsend uninstalled.")
 		return nil
 	}
 

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -46,10 +46,13 @@ func runUninstall(f *flags) error {
 		binPath = resolved
 	}
 
-	// On Windows the running .exe can't delete itself. Best we can do
-	// is print the path and ask the user to remove it by hand.
+	// On Windows the running .exe can't delete itself. Best we can do is
+	// print the path and ask the user to remove it by hand. install.ps1 also
+	// puts the install dir on the user PATH; we don't strip it automatically
+	// (the user may share that dir with other tools), so point at it instead.
 	if runtime.GOOS == "windows" {
 		fmt.Fprintf(os.Stderr, "  Delete this file to finish uninstall: %s\n", binPath)
+		fmt.Fprintf(os.Stderr, "  If you installed via install.ps1, also remove %s from your PATH.\n", filepath.Dir(binPath))
 		return nil
 	}
 

--- a/cmd/fsend/uninstall_other.go
+++ b/cmd/fsend/uninstall_other.go
@@ -1,0 +1,8 @@
+//go:build !windows
+
+package main
+
+// removeBinary is Windows-only; on every other platform runUninstall deletes
+// the binary directly and never calls this. It exists so the windows branch
+// in uninstall.go compiles cross-platform.
+func removeBinary(string) error { return nil }

--- a/cmd/fsend/uninstall_windows.go
+++ b/cmd/fsend/uninstall_windows.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -14,24 +15,29 @@ import (
 // install dir, and strips that dir from the user PATH.
 //
 // A running .exe can't delete its own image on Windows, so the delete is done
-// by a detached cmd that retries until this process exits and releases the
-// lock. The PATH edit happens here, synchronously, since it doesn't depend on
-// the binary being gone.
+// by a detached PowerShell that Wait-Process'es on our PID, then removes the
+// file the instant we exit and the lock drops. PowerShell (not cmd) with
+// single-quoted literal paths keeps double quotes out of the command line,
+// avoiding the cmd.exe/CreateProcess escaping pitfalls that mangle paths.
+// The PATH edit happens here, synchronously — it doesn't need the exe gone.
 func removeBinary(binPath string) error {
 	dir := filepath.Dir(binPath)
 	removeUserPathEntry(dir)
 
-	// `del` clears fsend.exe; the loop's leading ping gives us time to exit so
-	// the lock is released. Plain `rmdir` (no /s) only removes the dir if it's
-	// now empty, leaving any unrelated files the user put there untouched.
-	arg := fmt.Sprintf(
-		`for /L %%i in (1,1,10) do (ping 127.0.0.1 -n 2 >nul & del /f /q "%s" 2>nul) & rmdir "%s" 2>nul`,
-		binPath, dir)
-	cmd := exec.Command("cmd", "/C", arg)
+	// Remove-Item on the dir without -Recurse only deletes it if now empty,
+	// leaving any unrelated files the user put there untouched.
+	script := fmt.Sprintf(
+		`Wait-Process -Id %d -ErrorAction SilentlyContinue; `+
+			`Start-Sleep -Milliseconds 300; `+
+			`Remove-Item -LiteralPath %s -Force -ErrorAction SilentlyContinue; `+
+			`Remove-Item -LiteralPath %s -Force -ErrorAction SilentlyContinue`,
+		os.Getpid(), psSingleQuote(binPath), psSingleQuote(dir))
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive",
+		"-WindowStyle", "Hidden", "-Command", script)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		HideWindow: true,
-		// DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP: outlive us, no console.
-		CreationFlags: 0x00000008 | 0x00000200,
+		// CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP: hidden, outlives us.
+		CreationFlags: 0x08000000 | 0x00000200,
 	}
 	return cmd.Start()
 }

--- a/cmd/fsend/uninstall_windows.go
+++ b/cmd/fsend/uninstall_windows.go
@@ -1,0 +1,55 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+)
+
+// removeBinary deletes the running fsend.exe and (if it ends up empty) its
+// install dir, and strips that dir from the user PATH.
+//
+// A running .exe can't delete its own image on Windows, so the delete is done
+// by a detached cmd that retries until this process exits and releases the
+// lock. The PATH edit happens here, synchronously, since it doesn't depend on
+// the binary being gone.
+func removeBinary(binPath string) error {
+	dir := filepath.Dir(binPath)
+	removeUserPathEntry(dir)
+
+	// `del` clears fsend.exe; the loop's leading ping gives us time to exit so
+	// the lock is released. Plain `rmdir` (no /s) only removes the dir if it's
+	// now empty, leaving any unrelated files the user put there untouched.
+	arg := fmt.Sprintf(
+		`for /L %%i in (1,1,10) do (ping 127.0.0.1 -n 2 >nul & del /f /q "%s" 2>nul) & rmdir "%s" 2>nul`,
+		binPath, dir)
+	cmd := exec.Command("cmd", "/C", arg)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow: true,
+		// DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP: outlive us, no console.
+		CreationFlags: 0x00000008 | 0x00000200,
+	}
+	return cmd.Start()
+}
+
+// removeUserPathEntry drops dir from the HKCU user PATH. PowerShell is always
+// present on Windows, so we shell out to it rather than pull in a registry
+// dependency. Best-effort: a failure just leaves a harmless stale PATH entry.
+func removeUserPathEntry(dir string) {
+	ps := fmt.Sprintf(
+		`$d=%s; $p=[Environment]::GetEnvironmentVariable('Path','User'); `+
+			`if($p){[Environment]::SetEnvironmentVariable('Path', `+
+			`(($p -split ';' | Where-Object { $_ -and $_ -ne $d }) -join ';'), 'User')}`,
+		psSingleQuote(dir))
+	_ = exec.Command("powershell", "-NoProfile", "-NonInteractive", "-Command", ps).Run()
+}
+
+// psSingleQuote wraps s in a PowerShell single-quoted string (only ' needs
+// escaping, by doubling — backslashes are literal inside single quotes).
+func psSingleQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "''") + "'"
+}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -17,7 +17,7 @@
     .\install.ps1 -Prefix C:\tools\bin -Version 1.2.3
 
 .PARAMETER Prefix
-  Install directory (default: %LOCALAPPDATA%\fsend\bin). Env: FSEND_PREFIX.
+  Install directory (default: %LOCALAPPDATA%\Programs\fsend). Env: FSEND_PREFIX.
 
 .PARAMETER Version
   Version to install, e.g. 1.2.3 or v1.2.3 (default: latest). Env: FSEND_VERSION.
@@ -56,7 +56,7 @@ Usage:
   .\install.ps1 [-Prefix DIR] [-Version VERSION]
 
 Parameters (or matching env var):
-  -Prefix DIR        Install location      (default: %LOCALAPPDATA%\fsend\bin; env FSEND_PREFIX)
+  -Prefix DIR        Install location      (default: %LOCALAPPDATA%\Programs\fsend; env FSEND_PREFIX)
   -Version VERSION   Version to install    (default: latest; env FSEND_VERSION)
   -Help              Show this help and exit
 
@@ -117,7 +117,11 @@ try {
         Download "https://github.com/$Repo/releases/download/$Version/checksums.txt" $checksums
     }
 
-    if (-not $Prefix) { $Prefix = Join-Path $env:LOCALAPPDATA 'fsend\bin' }
+    # %LOCALAPPDATA%\Programs (per-user, no admin) — deliberately NOT under
+    # %LOCALAPPDATA%\fsend, which is the config dir: `fsend --uninstall`
+    # RemoveAll's the config dir, and Windows can't delete a running .exe
+    # nested inside it ("Access is denied"). Keep the two trees separate.
+    if (-not $Prefix) { $Prefix = Join-Path $env:LOCALAPPDATA 'Programs\fsend' }
     Info "installing fsend $Version for windows-$arch into $Prefix"
 
     $archive = "fsend_${vnum}_windows_${arch}.zip"

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,165 @@
+<#
+.SYNOPSIS
+  fsend installer for Windows (PowerShell).
+
+.DESCRIPTION
+  Downloads the latest fsend release, verifies its SHA-256 checksum, and
+  installs fsend.exe into a directory on your PATH. PowerShell 5.1+ (in-box
+  on Windows 10/11) is the only requirement — no Git Bash needed.
+
+  Quick install:
+    irm https://getfsend.alzina.dev/install.ps1 | iex
+
+  With options, set env vars before piping:
+    $env:FSEND_VERSION='1.2.3'; irm https://getfsend.alzina.dev/install.ps1 | iex
+
+  Or download and run with parameters:
+    .\install.ps1 -Prefix C:\tools\bin -Version 1.2.3
+
+.PARAMETER Prefix
+  Install directory (default: %LOCALAPPDATA%\fsend\bin). Env: FSEND_PREFIX.
+
+.PARAMETER Version
+  Version to install, e.g. 1.2.3 or v1.2.3 (default: latest). Env: FSEND_VERSION.
+
+.LINK
+  https://github.com/polius/fsend/blob/main/scripts/install.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$Prefix  = $env:FSEND_PREFIX,
+    [string]$Version = $env:FSEND_VERSION,
+    [switch]$Help
+)
+
+$ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
+
+$Repo   = 'polius/fsend'
+$Binary = 'fsend.exe'
+
+function Info($m) { Write-Host "› $m" -ForegroundColor Cyan }
+function Ok($m)   { Write-Host "✓ $m" -ForegroundColor Green }
+
+# throw, not exit: the install one-liner runs via `irm ... | iex` *in the
+# user's own session*, so `exit` would close their terminal. throw halts,
+# shows the message in red, leaves an interactive window open, and still
+# yields a non-zero exit code under `powershell -File install.ps1`.
+function Err($m)  { Write-Host "✗ $m" -ForegroundColor Red; throw }
+
+function Show-Usage {
+    Write-Host @'
+fsend installer (Windows / PowerShell)
+
+Usage:
+  irm https://getfsend.alzina.dev/install.ps1 | iex
+  .\install.ps1 [-Prefix DIR] [-Version VERSION]
+
+Parameters (or matching env var):
+  -Prefix DIR        Install location      (default: %LOCALAPPDATA%\fsend\bin; env FSEND_PREFIX)
+  -Version VERSION   Version to install    (default: latest; env FSEND_VERSION)
+  -Help              Show this help and exit
+
+Source: https://github.com/polius/fsend/blob/main/scripts/install.ps1
+'@
+}
+
+if ($Help) { Show-Usage; return }
+
+# Windows releases cover amd64/arm64/386 only. PROCESSOR_ARCHITECTURE reports
+# the *process* arch, so a 32-bit PowerShell on 64-bit Windows would read x86 —
+# PROCESSOR_ARCHITEW6432 carries the true machine arch in that case.
+function Get-Arch {
+    $a = $env:PROCESSOR_ARCHITECTURE
+    if ($env:PROCESSOR_ARCHITEW6432) { $a = $env:PROCESSOR_ARCHITEW6432 }
+    switch ($a) {
+        'AMD64' { 'amd64' }
+        'ARM64' { 'arm64' }
+        'x86'   { '386' }
+        default { Err "unsupported architecture: $a" }
+    }
+}
+
+function Download($url, $out) {
+    try {
+        Invoke-WebRequest -Uri $url -OutFile $out -UseBasicParsing
+    } catch {
+        Err "download failed: $url"
+    }
+}
+
+# Windows PowerShell 5.1 defaults to TLS 1.0/1.1; GitHub requires 1.2+.
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+$arch = Get-Arch
+
+$tmp = Join-Path ([System.IO.Path]::GetTempPath()) ("fsend-" + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $tmp | Out-Null
+
+try {
+    $checksums = Join-Path $tmp 'checksums.txt'
+
+    if (-not $Version -or $Version -eq 'latest') {
+        # Resolve "latest" through the release-asset redirect, not the GitHub
+        # API (unauthenticated API is capped at 60/hr per IP). checksums.txt is
+        # needed anyway, and the version is recovered from the archive names in
+        # it — tags are always v-prefixed.
+        Info 'looking up latest release...'
+        Download "https://github.com/$Repo/releases/latest/download/checksums.txt" $checksums
+        $line = Get-Content $checksums | Where-Object { $_ -match 'fsend_([^_]+)_' } | Select-Object -First 1
+        if ($line -match 'fsend_([^_]+)_') { $vnum = $Matches[1] } else { Err 'could not resolve latest version' }
+        $Version = "v$vnum"
+    } else {
+        # Accept "1.2.3" and "v1.2.3" alike: tags are v-prefixed, archive names are not.
+        $vnum = $Version -replace '^v', ''
+        $Version = "v$vnum"
+        Info 'downloading checksums'
+        Download "https://github.com/$Repo/releases/download/$Version/checksums.txt" $checksums
+    }
+
+    if (-not $Prefix) { $Prefix = Join-Path $env:LOCALAPPDATA 'fsend\bin' }
+    Info "installing fsend $Version for windows-$arch into $Prefix"
+
+    $archive = "fsend_${vnum}_windows_${arch}.zip"
+    Info "downloading $archive"
+    Download "https://github.com/$Repo/releases/download/$Version/$archive" (Join-Path $tmp $archive)
+
+    Info 'verifying checksum'
+    $row = Get-Content $checksums | Where-Object { $_ -match ("\s" + [regex]::Escape($archive) + "$") } | Select-Object -First 1
+    if (-not $row) { Err "no checksum found for $archive" }
+    $expected = (($row -split '\s+') | Where-Object { $_ })[0].ToLower()
+    $actual   = (Get-FileHash -Algorithm SHA256 -Path (Join-Path $tmp $archive)).Hash.ToLower()
+    if ($actual -ne $expected) { Err "checksum mismatch: expected $expected, got $actual" }
+    Ok 'checksum verified'
+
+    Info 'extracting'
+    Expand-Archive -LiteralPath (Join-Path $tmp $archive) -DestinationPath $tmp -Force
+    $src = Join-Path $tmp $Binary
+    if (-not (Test-Path $src)) { Err "binary $Binary not found in archive" }
+
+    New-Item -ItemType Directory -Force -Path $Prefix | Out-Null
+    $dst = Join-Path $Prefix $Binary
+    Move-Item -Force -Path $src -Destination $dst
+    Ok "installed: $dst"
+
+    # Persist Prefix on the user's PATH (no admin needed). SetEnvironmentVariable
+    # with 'User' writes the registry; $env:PATH is patched so this session works
+    # immediately without a restart.
+    $userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    if (-not $userPath) { $userPath = '' }
+    if (($userPath -split ';') -notcontains $Prefix) {
+        [Environment]::SetEnvironmentVariable('Path', ($userPath.TrimEnd(';') + ';' + $Prefix).TrimStart(';'), 'User')
+        $env:PATH = $env:PATH + ';' + $Prefix
+        Ok "added $Prefix to your user PATH (open a new terminal for other apps to see it)"
+    }
+
+    $ver = (& $dst --version 2>$null | Select-Object -First 1)
+    if ($ver) { Ok "verify: $ver" }
+
+    Write-Host ''
+    Write-Host 'Next: send a file with  fsend <path>'
+    Write-Host '      see all options:  fsend --help'
+}
+finally {
+    Remove-Item -Recurse -Force -Path $tmp -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## What

Adds a native PowerShell installer (`scripts/install.ps1`) so Windows users can install fsend without first installing a POSIX shell:

```powershell
irm https://getfsend.alzina.dev/install.ps1 | iex
```

Until now the only `curl | sh` path required Git Bash / MSYS / Cygwin — a third-party prerequisite that defeats the point of a one-liner.

## How `install.ps1` works (mirrors `install.sh`)

- Arch detection (`amd64`/`arm64`/`386`, incl. `PROCESSOR_ARCHITEW6432` for 32-bit PS on 64-bit Windows)
- Resolves `latest` from `checksums.txt` (avoids the 60/hr unauthenticated GitHub API limit)
- Accepts `1.2.3` and `v1.2.3`; `-Prefix`/`-Version` params + `FSEND_PREFIX`/`FSEND_VERSION` env vars
- **SHA-256 verification** before install
- `Expand-Archive`, install to `%LOCALAPPDATA%\fsend\bin`, add to user PATH (no admin needed)
- Halts via `throw`, not `exit` — `exit` would close the user's terminal in the `irm | iex` path (it runs in the current session, unlike `curl | sh` which runs in a subshell)

## Other changes

- **`.goreleaser.yml`** — ship `install.ps1` as a release asset alongside `install.sh`
- **`cmd/fsend/uninstall.go`** — Windows uninstall now also points at the install dir to remove from PATH (the entry `install.ps1` adds; we don't strip it automatically since the user may share that dir)
- **`README.md`** — split Install into per-platform one-liners

## Deploy note (out of repo)

The `irm .../install.ps1` URL goes live once a Cloudflare Redirect Rule maps `getfsend.alzina.dev/install.ps1` → `raw.githubusercontent.com/.../scripts/install.ps1` (mirroring the existing `install.sh` redirect).

## Testing

⚠️ Not yet executed on Windows — `pwsh` wasn't available in the dev environment. Logic was audited by review; **to be smoke-tested on a real Windows machine** before merge:

```powershell
powershell -NoProfile -File .\install.ps1 -Help
powershell -NoProfile -File .\install.ps1
fsend --version
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)