### PR TITLE
install + CLI: openssl checksum fallback, trimmed --help, new --update

### DIFF
--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -164,7 +164,8 @@ func renderError(err error, debug bool) int {
 		errors.Is(err, fserrors.ErrSourceNotFound) ||
 		errors.Is(err, fserrors.ErrRelayCapHit) ||
 		errors.Is(err, fserrors.ErrRelayIdleTimeout) ||
-		errors.Is(err, fserrors.ErrServerStartup)) {
+		errors.Is(err, fserrors.ErrServerStartup) ||
+		errors.Is(err, fserrors.ErrUpdateFailed)) {
 		if extra := extractDetail(err.Error()); extra != "" {
 			detail = extra
 		}

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -270,23 +270,8 @@ ADVANCED FLAGS
   --debug                Verbose logging to stderr (also: FSEND_DEBUG=1)
   --uninstall            Remove the fsend binary and its config dir
 
-ENVIRONMENT
-  FSEND_PASS             Used as --pass when the flag is not given
-                         (keeps the password out of argv)
-  FSEND_NO_UPDATE_CHECK  Set to 1 to disable the daily check for a newer
-                         fsend release
-
-SELF-HOSTING
-  fsend server                 Run your own pairing + relay server
-                               (env-var config — see "fsend server --help")
-
-SHELL COMPLETIONS
-  fsend completion <shell>     Print a completion script
-                               (bash, zsh, fish, powershell)
-
 LEARN MORE
-  Docs    https://github.com/polius/fsend
-  Issues  https://github.com/polius/fsend/issues
+  https://github.com/polius/fsend
 `
 
 // boldHelpHeaders wraps the ALL-CAPS section headers (USAGE, EXAMPLES,
@@ -307,7 +292,7 @@ func boldHelpHeaders(tpl string) string {
 }
 
 // isHelpHeader reports whether line is a column-0 ALL-CAPS section
-// header ("COMMON FLAGS", "SELF-HOSTING", …). Body lines are indented,
+// header ("COMMON FLAGS", "ADVANCED FLAGS", …). Body lines are indented,
 // and the version header line starts lowercase, so neither matches.
 func isHelpHeader(line string) bool {
 	if line == "" || (line[0] < 'A' || line[0] > 'Z') {

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -46,6 +46,7 @@ type flags struct {
 	// Misc
 	quiet     bool
 	debug     bool
+	update    bool
 	uninstall bool
 
 	// First-positional args, recorded after parsing.
@@ -131,6 +132,7 @@ Examples:
 
 	// Misc
 	c.Flags().BoolVar(&f.debug, "debug", false, "verbose logging to stderr")
+	c.Flags().BoolVar(&f.update, "update", false, "update fsend to the latest release")
 	c.Flags().BoolVar(&f.uninstall, "uninstall", false, "remove the fsend binary and config dir")
 
 	c.Flags().StringVar(&f.mode, "mode", "", "")
@@ -268,6 +270,7 @@ ADVANCED FLAGS
   --connect default      Revert to the compiled-in default server
   --send / --receive     Force mode (skip code/path auto-detect)
   --debug                Verbose logging to stderr (also: FSEND_DEBUG=1)
+  --update               Update fsend to the latest release
   --uninstall            Remove the fsend binary and its config dir
 
 LEARN MORE
@@ -332,7 +335,7 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	// surprised by "I asked for both --connect and --send and only the
 	// first ran."
 	if cmd.Flags().Changed("connect") {
-		for _, conflict := range []string{"send", "receive", "text", "pass", "yes", "out", "overwrite", "name", "exclude", "mode", "uninstall"} {
+		for _, conflict := range []string{"send", "receive", "text", "pass", "yes", "out", "overwrite", "name", "exclude", "mode", "update", "uninstall"} {
 			if cmd.Flags().Changed(conflict) {
 				return fmt.Errorf("%w: --connect cannot be combined with --%s", fserrors.ErrUsage, conflict)
 			}
@@ -355,7 +358,14 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		return runConnect(f)
 	}
 
-	// --uninstall is a maintenance command; never combine with transfer.
+	// --update / --uninstall are maintenance commands; never combine
+	// with transfer or with each other.
+	if f.update && f.uninstall {
+		return fmt.Errorf("%w: --update and --uninstall are mutually exclusive", fserrors.ErrUsage)
+	}
+	if f.update {
+		return runUpdate()
+	}
 	if f.uninstall {
 		return runUninstall(f)
 	}

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -184,7 +184,7 @@ func TestBoldHelpHeaders(t *testing.T) {
 		t.Setenv("FORCE_COLOR", "1")
 		got := boldHelpHeaders(helpTemplate)
 		for _, header := range []string{"USAGE", "EXAMPLES", "COMMON FLAGS",
-			"ADVANCED FLAGS", "ENVIRONMENT", "SELF-HOSTING", "LEARN MORE"} {
+			"ADVANCED FLAGS", "LEARN MORE"} {
 			if !strings.Contains(got, "\x1b[1m"+header+"\x1b[0m") {
 				t.Errorf("header %q not bolded", header)
 			}

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -108,6 +108,16 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 			[]string{"--receive", "abc-defg-jkm", "--exclude=*.log"},
 			"--exclude only applies when sending a directory",
 		},
+		{
+			"connect_with_update",
+			[]string{"--connect=host:443", "--update"},
+			"--connect cannot be combined with --update",
+		},
+		{
+			"update_with_uninstall",
+			[]string{"--update", "--uninstall"},
+			"--update and --uninstall are mutually exclusive",
+		},
 	}
 	for _, c := range cases {
 		c := c

--- a/cmd/fsend/selfupdate.go
+++ b/cmd/fsend/selfupdate.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/update"
+	"github.com/polius/fsend/internal/uxlog"
+	"github.com/polius/fsend/internal/version"
+)
+
+// runUpdate replaces the running binary with the latest release by
+// re-running the platform installer (runInstaller, per-OS) pinned to
+// the directory the binary lives in. The installer — not fsend — does
+// the download and checksum verification, so the update path can never
+// drift from a fresh install.
+func runUpdate() error {
+	current := strings.TrimPrefix(version.Version, "v")
+	if current == "" || current == "dev" {
+		return fmt.Errorf("%w: this is a dev build with no release to compare against", fserrors.ErrUpdateFailed)
+	}
+
+	fmt.Fprintln(os.Stderr, "  Checking the latest release...")
+	latest, ok := update.Latest(context.Background())
+	if !ok {
+		return fmt.Errorf("%w: could not look up the latest release", fserrors.ErrUpdateFailed)
+	}
+	if !update.Newer(latest, current) {
+		fmt.Fprintf(os.Stderr, "%s fsend %s is already the latest version.\n", uxlog.Check(), current)
+		return nil
+	}
+
+	binPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("%w: locating the fsend binary: %v", fserrors.ErrUpdateFailed, err)
+	}
+	// Resolve symlinks so the install lands on the real binary and an
+	// on-PATH `~/.local/bin/fsend → /opt/fsend/fsend` link keeps working.
+	if resolved, rerr := filepath.EvalSymlinks(binPath); rerr == nil && resolved != "" {
+		binPath = resolved
+	}
+
+	fmt.Fprintf(os.Stderr, "  Updating fsend %s → %s in %s\n", current, latest, filepath.Dir(binPath))
+	if err := runInstaller(binPath); err != nil {
+		return fmt.Errorf("%w: %v", fserrors.ErrUpdateFailed, err)
+	}
+	return nil
+}

--- a/cmd/fsend/selfupdate_other.go
+++ b/cmd/fsend/selfupdate_other.go
@@ -1,0 +1,36 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+// installerScript is the documented install one-liner, with a wget
+// fallback mirroring the script's own download() support. The installer
+// reads PREFIX from the environment.
+const installerScript = `
+if command -v curl >/dev/null 2>&1; then
+    curl -fsSL https://getfsend.alzina.dev | sh
+elif command -v wget >/dev/null 2>&1; then
+    wget -qO- https://getfsend.alzina.dev | sh
+else
+    echo "need curl or wget to download the installer" >&2
+    exit 1
+fi
+`
+
+// runInstaller re-runs the install script pinned (via PREFIX) to the
+// directory binPath lives in, inheriting stdio so installer progress —
+// and a possible sudo prompt — reach the user. Unix lets the installer
+// rename over the running binary, so no move-aside dance is needed.
+func runInstaller(binPath string) error {
+	cmd := exec.Command("sh", "-c", installerScript)
+	cmd.Env = append(os.Environ(), "PREFIX="+filepath.Dir(binPath))
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/cmd/fsend/selfupdate_test.go
+++ b/cmd/fsend/selfupdate_test.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/version"
+)
+
+// Dev builds have no release version to compare against, so --update
+// must refuse up front — before any output or network I/O.
+func TestRunUpdate_DevBuildRefused(t *testing.T) {
+	orig := version.Version
+	version.Version = "dev"
+	t.Cleanup(func() { version.Version = orig })
+
+	err := runUpdate()
+	if !errors.Is(err, fserrors.ErrUpdateFailed) {
+		t.Fatalf("got %v, want wrapping ErrUpdateFailed", err)
+	}
+	if !strings.Contains(err.Error(), "dev build") {
+		t.Errorf("got %q, want a dev-build explanation", err.Error())
+	}
+}

--- a/cmd/fsend/selfupdate_windows.go
+++ b/cmd/fsend/selfupdate_windows.go
@@ -1,0 +1,57 @@
+//go:build windows
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+)
+
+// runInstaller re-runs the PowerShell installer pinned (via
+// FSEND_PREFIX) to the directory binPath lives in. Windows locks a
+// running .exe against overwrite but not rename, so the current image
+// is moved aside first, restored if the installer fails, and the
+// leftover .old is deleted once this process exits.
+func runInstaller(binPath string) error {
+	old := binPath + ".old"
+	_ = os.Remove(old) // stale leftover from an interrupted update
+	if err := os.Rename(binPath, old); err != nil {
+		return fmt.Errorf("moving the running fsend.exe aside: %v", err)
+	}
+
+	cmd := exec.Command("powershell", "-NoProfile", "-Command",
+		"irm https://getfsend.alzina.dev/install.ps1 | iex")
+	cmd.Env = append(os.Environ(), "FSEND_PREFIX="+filepath.Dir(binPath))
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		_ = os.Rename(old, binPath)
+		return err
+	}
+	removeFileAfterExit(old)
+	return nil
+}
+
+// removeFileAfterExit deletes path once this process exits and the
+// image lock drops — same detached-PowerShell trick as removeBinary
+// (uninstall_windows.go). Best-effort: a survivor is reaped by the
+// next --update.
+func removeFileAfterExit(path string) {
+	script := fmt.Sprintf(
+		`Wait-Process -Id %d -ErrorAction SilentlyContinue; `+
+			`Start-Sleep -Milliseconds 300; `+
+			`Remove-Item -LiteralPath %s -Force -ErrorAction SilentlyContinue`,
+		os.Getpid(), psSingleQuote(path))
+	cmd := exec.Command("powershell", "-NoProfile", "-NonInteractive",
+		"-WindowStyle", "Hidden", "-Command", script)
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		HideWindow: true,
+		// CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP: hidden, outlives us.
+		CreationFlags: 0x08000000 | 0x00000200,
+	}
+	_ = cmd.Start()
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -100,6 +100,7 @@ Config is at `~/.config/fsend/config.json` (Linux),
 | `--send` / `--receive` | Force mode instead of auto-detecting from the argument. Mutually exclusive; handy in scripts. |
 | `--quiet` | Suppress non-error output. |
 | `--debug` | Verbose logging to stderr. Also `FSEND_DEBUG=1`. |
+| `--update` | Update fsend to the latest release by re-running the installer in place. Reports when already up to date. |
 | `--uninstall` | Remove the binary and the fsend config directory (see [`--connect`](#choosing-a-server---connect) for the per-OS path). `--yes` skips confirmation. |
 | `--help` / `-h` | Show inline help. |
 | `--version` / `-v` | Print version. |
@@ -115,9 +116,9 @@ Config is at `~/.config/fsend/config.json` (Linux),
 Flags always win when both are set.
 
 After a successful transfer, fsend checks GitHub at most once a day for a
-newer release and, if one exists, prints a one-line upgrade hint. The
-check is skipped when output is piped or `--quiet` is set, and can be
-turned off entirely with `FSEND_NO_UPDATE_CHECK=1`.
+newer release and, if one exists, prints a one-line hint to run
+`fsend --update`. The check is skipped when output is piped or `--quiet`
+is set, and can be turned off entirely with `FSEND_NO_UPDATE_CHECK=1`.
 
 ## `fsend server`
 

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -107,6 +107,10 @@ var (
 	// Distinct from E020 so the survivor knows the teardown wasn't a
 	// network drop.
 	ErrPeerCancelled = errors.New("peer cancelled the transfer")
+	// E033 — `fsend --update` could not complete: the release lookup
+	// failed or the installer exited nonzero. An environment problem,
+	// not a bug, so it skips the E099 "file an issue" catchall.
+	ErrUpdateFailed = errors.New("update failed")
 )
 
 // Entry is one row of the user-facing error catalog.
@@ -371,6 +375,12 @@ var catalog = map[error]Entry{
 		Message: "The sender cancelled the transfer.",
 		Action: "Ask the sender to run fsend again, then use the new code — the\n" +
 			"  transfer will resume in this same directory.",
+	},
+	ErrUpdateFailed: {
+		Code: "E033", Exit: 33,
+		Message: "Could not update fsend.",
+		Action: "Check your internet connection and try again, or reinstall:\n" +
+			"    https://github.com/polius/fsend#install",
 	},
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,10 +1,11 @@
 // Package update implements a best-effort "a newer fsend exists" check.
 //
-// It is deliberately passive: it never downloads or replaces anything, it
-// only tells the user a new release is out and how to get it. The result
-// of the GitHub lookup is cached for a day so normal runs do no network
-// I/O, and every failure path is silent — an update check must never
-// disturb a transfer.
+// It is deliberately passive: it never downloads or replaces anything,
+// it only reports whether a new release is out (the actual replacement
+// — `fsend --update` — lives in cmd/fsend and shells out to the
+// platform installer). The result of the GitHub lookup is cached for a
+// day so normal runs do no network I/O, and every failure path of the
+// passive check is silent — it must never disturb a transfer.
 package update
 
 import (
@@ -29,9 +30,11 @@ var apiURL = "https://api.github.com/repos/polius/fsend/releases/latest"
 const (
 	cacheFile     = "update-check.json"
 	checkInterval = 24 * time.Hour
-	httpTimeout   = 2 * time.Second
-	// installCmd is the one-liner we point users at — same as the README.
-	installCmd = "curl -fsSL https://getfsend.alzina.dev | sh"
+	// noticeTimeout keeps the passive check from ever stalling a
+	// transfer; explicitTimeout gives `fsend --update` a real chance on
+	// slow links.
+	noticeTimeout   = 2 * time.Second
+	explicitTimeout = 15 * time.Second
 )
 
 // cache is the on-disk memo of the last lookup. Latest has no leading "v".
@@ -53,13 +56,24 @@ func Notice(ctx context.Context, current string) string {
 		return ""
 	}
 	latest := latestVersion(ctx)
-	if latest == "" || !newer(latest, current) {
+	if latest == "" || !Newer(latest, current) {
 		return ""
 	}
-	// Two lines: with the install command inline the notice runs past 80
-	// columns. The caller indents the first line; match it on the second.
-	return fmt.Sprintf("A new fsend is available (%s → %s).\n  Update: %s",
-		strings.TrimPrefix(current, "v"), latest, installCmd)
+	return fmt.Sprintf("A new fsend is available (%s → %s). Update: fsend --update",
+		strings.TrimPrefix(current, "v"), latest)
+}
+
+// Latest returns the latest release version (no leading "v") from a
+// fresh lookup, bypassing the daily cache: an explicit `fsend --update`
+// deserves a current answer. ok is false when the lookup failed.
+func Latest(ctx context.Context) (string, bool) {
+	ctx, cancel := context.WithTimeout(ctx, explicitTimeout)
+	defer cancel()
+	latest, ok := fetchLatest(ctx)
+	if ok {
+		writeCache(cachePath(), cache{CheckedAt: time.Now(), Latest: latest})
+	}
+	return latest, ok
 }
 
 // latestVersion returns the latest release version (no leading "v"),
@@ -70,6 +84,8 @@ func latestVersion(ctx context.Context) string {
 	if c, ok := readCache(path); ok && time.Since(c.CheckedAt) < checkInterval {
 		return c.Latest
 	}
+	ctx, cancel := context.WithTimeout(ctx, noticeTimeout)
+	defer cancel()
 	latest, ok := fetchLatest(ctx)
 	if !ok {
 		// Network failed: stamp the attempt so we don't retry (and re-pay
@@ -86,11 +102,9 @@ func latestVersion(ctx context.Context) string {
 	return latest
 }
 
-// fetchLatest queries the GitHub API for the latest release tag.
+// fetchLatest queries the GitHub API for the latest release tag. The
+// caller bounds ctx (notice vs explicit timeouts differ).
 func fetchLatest(ctx context.Context) (string, bool) {
-	ctx, cancel := context.WithTimeout(ctx, httpTimeout)
-	defer cancel()
-
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, apiURL, nil)
 	if err != nil {
 		return "", false
@@ -155,10 +169,10 @@ func writeCache(path string, c cache) {
 	}
 }
 
-// newer reports whether semver latest is strictly greater than current.
+// Newer reports whether semver latest is strictly greater than current.
 // Pre-release and build metadata are ignored — /latest only returns
 // stable tags, and we never want to nag about a dev build's own suffix.
-func newer(latest, current string) bool {
+func Newer(latest, current string) bool {
 	lMaj, lMin, lPat, ok1 := parse(latest)
 	cMaj, cMin, cPat, ok2 := parse(current)
 	if !ok1 || !ok2 {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/polius/fsend/internal/config"
 )
@@ -26,8 +27,8 @@ func TestNewer(t *testing.T) {
 		{"0.1.0", "dev", false},
 	}
 	for _, c := range cases {
-		if got := newer(c.latest, c.current); got != c.want {
-			t.Errorf("newer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
+		if got := Newer(c.latest, c.current); got != c.want {
+			t.Errorf("Newer(%q, %q) = %v, want %v", c.latest, c.current, got, c.want)
 		}
 	}
 }
@@ -58,5 +59,33 @@ func TestNotice(t *testing.T) {
 	t.Setenv("FSEND_NO_UPDATE_CHECK", "1")
 	if msg := Notice(context.Background(), "0.1.0"); msg != "" {
 		t.Fatalf("expected no notice when opted out, got %q", msg)
+	}
+}
+
+func TestLatest(t *testing.T) {
+	config.SetPathForTesting(filepath.Join(t.TempDir(), "config.json"))
+	t.Cleanup(func() { config.SetPathForTesting("") })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"tag_name":"v2.0.0"}`))
+	}))
+	t.Cleanup(srv.Close)
+	apiURL = srv.URL
+
+	// A fresh cache with a stale answer must be bypassed.
+	writeCache(cachePath(), cache{CheckedAt: time.Now(), Latest: "1.0.0"})
+	latest, ok := Latest(context.Background())
+	if !ok || latest != "2.0.0" {
+		t.Fatalf("Latest() = (%q, %v), want (\"2.0.0\", true)", latest, ok)
+	}
+	// And the fresh answer is written back for the passive check.
+	if c, ok := readCache(cachePath()); !ok || c.Latest != "2.0.0" {
+		t.Errorf("cache after Latest() = (%+v, %v), want Latest 2.0.0", c, ok)
+	}
+
+	// Lookup failure reports ok=false, never a stale value.
+	srv.Close()
+	if latest, ok := Latest(context.Background()); ok {
+		t.Fatalf("Latest() after server close = (%q, true), want ok=false", latest)
 	}
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -189,8 +189,10 @@ verify_checksum() {
         _actual="$(shasum -a 256 "$_archive" | awk '{print $1}')"
     elif command -v sha256 >/dev/null 2>&1; then
         _actual="$(sha256 -q "$_archive")"
+    elif command -v openssl >/dev/null 2>&1; then
+        _actual="$(openssl dgst -sha256 "$_archive" | awk '{print $NF}')"
     else
-        err "no sha256 tool available (need sha256sum, shasum, or sha256)"
+        err "no sha256 tool available (need sha256sum, shasum, sha256, or openssl)"
     fi
 
     [ "$_actual" = "$_expected" ] \


### PR DESCRIPTION
Three changes that grew out of an install failure on a WD MyCloud NAS:

**1. `fix(install)`: openssl checksum fallback.** Embedded boxes often lack `sha256sum`/`shasum`/`sha256` but ship `openssl` for their TLS stack — the installer died at the verify step. Adds `openssl dgst -sha256` as a last resort.

**2. `docs(cli)`: trim `--help`.** Drops the ENVIRONMENT, SELF-HOSTING, and SHELL COMPLETIONS sections; LEARN MORE is now just the project URL.

**3. `feat(cli)`: `fsend --update`.** Re-runs the documented installer (`curl|sh`, or `install.ps1` on Windows) pinned to the running binary's directory, so download + checksum verification stay in one place. A fresh release lookup reports "already the latest version" when there's nothing to do, and the daily update notice now points at `fsend --update`. On Windows the running image is renamed aside first (a running .exe can't be overwritten), restored on failure, and reaped after exit. Failures render as the new E033 catalog entry.

Verified end-to-end on macOS: a binary stamped 1.2.0 in a temp dir self-updated to the real v1.3.0 release in place; already-latest and dev-build paths exercised too. Cross-compiles checked for windows and freebsd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)