### PR TITLE
feat(ux): name the connection path on both sides at connect time

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -849,3 +849,42 @@ func TestPrintPath_QuietSuppressed(t *testing.T) {
 		t.Errorf("--quiet should suppress, got %q", got)
 	}
 }
+
+// The path now rides inline on the connected/incoming lines, so the
+// standalone headline is --debug only — even for relay.
+func TestPrintPath_DebugOnly(t *testing.T) {
+	relay := connpath.FromRelay("relay.example.com:443")
+	if got := captureStderr(t, func() { printPath(&flags{}, relay) }); got != "" {
+		t.Errorf("non-debug should print nothing, got %q", got)
+	}
+	got := captureStderr(t, func() { printPath(&flags{debug: true}, relay) })
+	if !strings.Contains(got, "Relayed via relay.example.com:443") {
+		t.Errorf("debug headline missing:\n%s", got)
+	}
+	got = captureStderr(t, func() { printPath(&flags{debug: true}, connpath.FromICE("srflx", "host")) })
+	if !strings.Contains(got, "ICE candidate pair: srflx → host") {
+		t.Errorf("debug ICE detail missing:\n%s", got)
+	}
+}
+
+// Route transparency: the accept prompt names the path for every kind.
+func TestPromptAccept_PathChipShown(t *testing.T) {
+	cases := []struct {
+		info connpath.Info
+		want string
+	}{
+		{connpath.FromLAN(), "local network"},
+		{connpath.FromICE("srflx", "host"), "direct over the internet"},
+		{connpath.FromRelay("relay.example.com:443"), "relayed via relay.example.com:443"},
+	}
+	for _, c := range cases {
+		got := captureStderr(t, func() {
+			h := wire.SenderHello{TransferKind: wire.TransferSingleFile, DisplayName: "x", TotalBytes: 1, TotalFiles: 1}
+			ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, c.info)
+			_ = ui.promptAccept(h)
+		})
+		if !strings.Contains(got, "Incoming from") || !strings.Contains(got, c.want) {
+			t.Errorf("prompt missing path chip %q:\n%s", c.want, got)
+		}
+	}
+}

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -491,26 +491,21 @@ func hostnameOrDefault(s string) string {
 	return h
 }
 
-// printPath renders the connection-path status line. Only the relay
-// path warrants a standalone headline (⚠ Relayed via <host> — the one
-// route users should know about before bytes flow); direct paths stay
-// silent here because the summary line already carries the path tag,
-// and repeating it read as padding. --debug restores the headline for
-// every path plus the selected ICE candidate types. --quiet suppresses
-// everything.
+// printPath renders the --debug path trace: the standalone headline
+// plus the selected ICE candidate types. The user-facing path display
+// lives inline on the "Receiver connected" line (sender) and the
+// "Incoming from" line (receiver), so non-debug runs print nothing
+// extra here — a standalone headline would repeat the inline chip.
 func printPath(f *flags, info connpath.Info) {
-	if f.quiet {
+	if f.quiet || !f.debug {
 		return
 	}
-	switch {
-	case info.Kind == connpath.KindRelay:
-		fmt.Fprintln(os.Stderr, uxlog.Warn(), info.Headline())
-	case f.debug:
-		fmt.Fprintln(os.Stderr, uxlog.Check(), info.Headline())
+	glyph := uxlog.Check()
+	if info.Kind == connpath.KindRelay {
+		glyph = uxlog.Warn()
 	}
-	if f.debug {
-		if d := info.Detail(); d != "" {
-			fmt.Fprintln(os.Stderr, "    ICE candidate pair:", d)
-		}
+	fmt.Fprintln(os.Stderr, glyph, info.Headline())
+	if d := info.Detail(); d != "" {
+		fmt.Fprintln(os.Stderr, "    ICE candidate pair:", d)
 	}
 }

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -500,11 +500,7 @@ func printPath(f *flags, info connpath.Info) {
 	if f.quiet || !f.debug {
 		return
 	}
-	glyph := uxlog.Check()
-	if info.Kind == connpath.KindRelay {
-		glyph = uxlog.Warn()
-	}
-	fmt.Fprintln(os.Stderr, glyph, info.Headline())
+	fmt.Fprintln(os.Stderr, uxlog.Check(), info.Headline())
 	if d := info.Detail(); d != "" {
 		fmt.Fprintln(os.Stderr, "    ICE candidate pair:", d)
 	}

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -143,7 +143,7 @@ func (ui *receiverUI) accept(h wire.SenderHello) bool {
 // promptAccept renders the incoming-transfer block on stderr and asks
 // whether to receive:
 //
-//	Incoming from <peer>  [· via relay]
+//	Incoming from <peer>  ·  <path chip>
 //
 //	    <artifact>  ·  <size>  [🔒 password]
 //	    [⚠ already in <dir> · will overwrite if you accept]
@@ -160,9 +160,11 @@ func (ui *receiverUI) promptAccept(h wire.SenderHello) bool {
 		return f.yes
 	}
 	peer := sanitizeRemote(h.Hostname)
+	// Same route transparency as the sender's "Receiver connected (…)"
+	// line: every path gets the chip, not just the relay.
 	pathChip := ""
-	if ui.pathInfo.Kind == connpath.KindRelay {
-		pathChip = uxlog.Dim("  ·  via relay")
+	if ui.pathInfo.Kind != connpath.KindUnknown {
+		pathChip = uxlog.Dim("  ·  " + ui.pathInfo.Chip())
 	}
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintf(os.Stderr, "  Incoming from %s%s\n", peer, pathChip)

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -490,7 +490,7 @@ func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem,
 
 	cancelPair()
 	drainLoser(lanCh, serverCh, winner, lanDone, serverDone)
-	// Stop the wait spinner now so the path headline and progress bar
+	// Stop the wait spinner now so the connected line and progress bar
 	// land on a clean line. The deferred Stop above is idempotent.
 	waitSpin.Stop()
 
@@ -501,9 +501,15 @@ func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem,
 	printPath(f, pathInfo)
 	// The receiver may now sit at its accept prompt for a while; without
 	// this line the sender stares at a dead terminal wondering whether
-	// the code even arrived.
+	// the code even arrived. The path rides along so both sides see the
+	// route before any bytes flow; relay keeps the warning glyph.
 	if !f.quiet {
-		fmt.Fprintln(os.Stderr, uxlog.Check(), "Receiver connected — waiting for them to accept.")
+		glyph := uxlog.Check()
+		if pathInfo.Kind == connpath.KindRelay {
+			glyph = uxlog.Warn()
+		}
+		fmt.Fprintf(os.Stderr, "%s Receiver connected (%s) — waiting for them to accept.\n",
+			glyph, pathInfo.Chip())
 	}
 
 	if winner.lan != nil {

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -502,14 +502,12 @@ func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem,
 	// The receiver may now sit at its accept prompt for a while; without
 	// this line the sender stares at a dead terminal wondering whether
 	// the code even arrived. The path rides along so both sides see the
-	// route before any bytes flow; relay keeps the warning glyph.
+	// route before any bytes flow. ✓ even for relay: the glyph reports
+	// the connect succeeding, the chip carries the route — same neutral
+	// treatment as the receiver chip and the summary tag.
 	if !f.quiet {
-		glyph := uxlog.Check()
-		if pathInfo.Kind == connpath.KindRelay {
-			glyph = uxlog.Warn()
-		}
 		fmt.Fprintf(os.Stderr, "%s Receiver connected (%s) — waiting for them to accept.\n",
-			glyph, pathInfo.Chip())
+			uxlog.Check(), pathInfo.Chip())
 	}
 
 	if winner.lan != nil {

--- a/internal/connpath/connpath.go
+++ b/internal/connpath/connpath.go
@@ -123,12 +123,10 @@ func (i Info) Tag() string {
 	}
 }
 
-// Headline is the single line the CLI prints right after the data path
-// is established, e.g.
+// Headline is the standalone path line the CLI prints under --debug
+// right after the data path is established, e.g.
 //
-//	✓ Direct on local network
 //	✓ Direct over the internet
-//	⚠ Relayed via fsend.alzina.dev
 //
 // Identical to Tag() today — the old verbose form ("— same LAN, no NAT
 // crossed") was dropped because it read as jargon. Kept as a separate
@@ -136,6 +134,26 @@ func (i Info) Tag() string {
 // divergence.
 func (i Info) Headline() string {
 	return i.Tag()
+}
+
+// Chip returns the lowercase mid-line form shown when the connection is
+// established: "Receiver connected (local network)" on the sender,
+// "Incoming from <peer> · direct over the internet" on the receiver.
+// Tag remains the standalone capitalized form for summary lines.
+func (i Info) Chip() string {
+	switch i.Kind {
+	case KindLocal:
+		return "local network"
+	case KindDirectNAT:
+		return "direct over the internet"
+	case KindRelay:
+		if i.RelayAddr != "" {
+			return "relayed via " + i.RelayAddr
+		}
+		return "relayed"
+	default:
+		return "unknown"
+	}
 }
 
 // Detail returns the verbose ICE candidate trace for --debug output, e.g.

--- a/internal/connpath/connpath_test.go
+++ b/internal/connpath/connpath_test.go
@@ -94,6 +94,23 @@ func TestTag_CompactForms(t *testing.T) {
 	}
 }
 
+func TestChip_MidLineForms(t *testing.T) {
+	cases := []struct {
+		info Info
+		want string
+	}{
+		{Info{Kind: KindLocal}, "local network"},
+		{Info{Kind: KindDirectNAT}, "direct over the internet"},
+		{FromRelay("relay.example.com:443"), "relayed via relay.example.com:443"},
+		{Info{Kind: KindRelay}, "relayed"},
+	}
+	for _, c := range cases {
+		if got := c.info.Chip(); got != c.want {
+			t.Errorf("Chip() = %q, want %q", got, c.want)
+		}
+	}
+}
+
 func TestDetail(t *testing.T) {
 	if d := FromICE("srflx", "host").Detail(); d != "srflx → host" {
 		t.Errorf("Detail() = %q, want %q", d, "srflx → host")


### PR DESCRIPTION
Both ends now see the route before any bytes flow, instead of only in the end-of-transfer summary:

**Sender**
```
✓ Receiver connected (local network) — waiting for them to accept.
✓ Receiver connected (direct over the internet) — waiting for them to accept.
✓ Receiver connected (relayed via fsend.alzina.dev:443) — waiting for them to accept.
```

**Receiver** (the existing relay-only chip, extended to every path)
```
Incoming from MyCloudPR2100  ·  local network
Incoming from MyCloudPR2100  ·  direct over the internet
Incoming from MyCloudPR2100  ·  relayed via fsend.alzina.dev:443
```

Design notes:
- Zero new lines: the path rides inline on existing lines. The old standalone `⚠ Relayed via <host>` headline is folded into the sender's connected line, so relay now prints one line instead of two.
- Neutral `✓` for all paths, relay included: the glyph reports the event (connect succeeded), the chip carries the route. Cap awareness stays with E023, where it is actionable.
- Both sides render from a single new `connpath.Chip()`, so connect-time and summary wording cannot drift.
- `printPath` is now the `--debug` trace only (headline + ICE candidate pair).
- `--quiet` suppresses everything, as before.

Validated empirically with real transfers on all three paths (mDNS local, forced `--mode=direct` ICE, forced `--mode=relay` against fsend.alzina.dev), plus `--debug` and `--quiet` runs; payload integrity checked. Full test suite passes; new unit tests cover the chip forms, the debug-only printPath contract, and the accept-prompt chip for all three kinds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)