### PR TITLE
Tighten the transfer UX and make rerun-with-same-code recovery work

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 ```bash
 $ fsend report.pdf                 # home Wi-Fi
-Share this code:  abc-defg-jkm
+On the other machine, run:  fsend abc-defg-jkm
 
 $ fsend abc-defg-jkm               # café Wi-Fi, two continents away
 ✓ Saved report.pdf to ~/Downloads  ·  2.4 MB  ·  1.3s  ·  Direct over the internet

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -164,28 +164,29 @@ func classifyRelayDrop(ctx context.Context, client *signaling.Client, sessionID,
 	return runErr
 }
 
-// joinWithRetry calls Join, retrying only on ErrCodeNotFound. The
-// receiver almost always wins the race against the sender's Create
-// (LAN window is ~5s, server RTT is <200ms), but a slow human or a
-// laggy network can still produce a few hundred milliseconds where the
-// server hasn't seen the code yet. Without retries that surfaced as
-// an instant, misleading E002 — telling the user the code expired when
-// it just hasn't been registered yet.
+// joinWithRetry calls Join, retrying on ErrCodeNotFound and
+// ErrCodeAlreadyClaimed. Not-found covers the receiver winning the race
+// against the sender's Create (slow human, laggy network) — without
+// retries that surfaced as an instant, misleading E002. Already-claimed
+// covers a stale session whose receiver died mid-transfer: the sender
+// Deletes and re-Creates it when it re-enters pairing, so within the
+// budget the slot flips from claimed to joinable.
 //
-// Other errors propagate immediately: code-already-claimed,
-// server-unreachable, ctx-cancelled, etc., are not transient and the
-// caller should hear about them on the first try.
+// Other errors propagate immediately: server-unreachable,
+// ctx-cancelled, etc., are not transient and the caller should hear
+// about them on the first try.
 //
 // Every join — including a 404 — counts against the server's per-IP
 // new-session budget (that's what stops code-space probing), so the
 // schedule is deliberately sparse: ~7 joins across the budget, not a
 // tight poll. And if the server starts throttling us mid-loop after
-// every attempt said "not found", the honest answer is E002, not E017 —
-// a mistyped code must not surface as "too many attempts".
+// retryable answers, the honest error is the last retryable one (E002/
+// E003), not E017 — a mistyped code must not surface as "too many
+// attempts".
 func joinWithRetry(ctx context.Context, client *signaling.Client, code string, f *flags, existing *uxlog.Spinner) (*server.JoinSessionResponse, error) {
 	deadline := time.Now().Add(joinRetryBudget)
 	delay := 500 * time.Millisecond
-	sawNotFound := false
+	var lastRetryable error
 	var spin *uxlog.Spinner
 	// Close over the variable so a spinner started inside the loop is
 	// still Stopped on return — a plain `defer spin.Stop()` would only
@@ -196,19 +197,20 @@ func joinWithRetry(ctx context.Context, client *signaling.Client, code string, f
 		if err == nil {
 			return joined, nil
 		}
-		if sawNotFound && errors.Is(err, fserrors.ErrRateLimited) {
-			return nil, fserrors.ErrCodeNotFound
+		if lastRetryable != nil && errors.Is(err, fserrors.ErrRateLimited) {
+			return nil, lastRetryable
 		}
-		if !errors.Is(err, fserrors.ErrCodeNotFound) || time.Now().After(deadline) {
+		retryable := errors.Is(err, fserrors.ErrCodeNotFound) || errors.Is(err, fserrors.ErrCodeAlreadyClaimed)
+		if !retryable || time.Now().After(deadline) {
 			return nil, err
 		}
-		sawNotFound = true
+		lastRetryable = err
 		// Animate a single line for the duration of the wait so the
 		// user knows we're holding for the sender rather than stuck.
 		// If the caller already gave us a running spinner, leave it
 		// alone — two spinners would fight each other on stderr.
 		if spin == nil && existing == nil && !f.quiet {
-			spin = uxlog.StartSpinner("Waiting for sender to register code")
+			spin = uxlog.StartSpinner("Waiting for sender")
 		}
 		select {
 		case <-ctx.Done():

--- a/cmd/fsend/internet_test.go
+++ b/cmd/fsend/internet_test.go
@@ -256,3 +256,75 @@ func newSignalingTestServer(t *testing.T) (*server.Server, string) {
 	t.Cleanup(ts.Close)
 	return s, ts.URL
 }
+
+// A claimed code may be a stale session whose receiver died: the sender
+// Deletes and re-Creates it when it re-enters pairing. joinWithRetry
+// must ride out the "already paired" window and join the fresh session.
+func TestJoinWithRetry_RetriesWhenStaleSessionReplaced(t *testing.T) {
+	_, baseURL := newSignalingTestServer(t)
+	senderClient := signaling.New(baseURL, "test")
+	deadReceiver := signaling.New(baseURL, "test")
+	receiverClient := signaling.New(baseURL, "test")
+	code := "abc-defg-jkm"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	created, err := senderClient.Create(ctx, code)
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := deadReceiver.Join(ctx, code); err != nil {
+		t.Fatalf("first Join: %v", err)
+	}
+
+	// Second receiver starts polling against the now-paired session.
+	var wg sync.WaitGroup
+	var joinErr error
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		_, joinErr = joinWithRetry(ctx, receiverClient, code, &flags{quiet: true}, nil)
+	}()
+
+	// Sender re-enters pairing: stale session out, fresh one in.
+	time.Sleep(500 * time.Millisecond)
+	if err := senderClient.Delete(ctx, created.SessionID, created.RoleToken); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	if _, err := senderClient.Create(ctx, code); err != nil {
+		t.Fatalf("re-Create: %v", err)
+	}
+
+	wg.Wait()
+	if joinErr != nil {
+		t.Errorf("joinWithRetry should have joined the replacement session, got %v", joinErr)
+	}
+}
+
+// When the stale session is never replaced, the budget must end with
+// the honest E003 — the code really is held by another receiver.
+func TestJoinWithRetry_GivesUpOnClaimedAfterBudget(t *testing.T) {
+	_, baseURL := newSignalingTestServer(t)
+	senderClient := signaling.New(baseURL, "test")
+	firstReceiver := signaling.New(baseURL, "test")
+	code := "abc-defg-jkm"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := senderClient.Create(ctx, code); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := firstReceiver.Join(ctx, code); err != nil {
+		t.Fatalf("first Join: %v", err)
+	}
+
+	orig := joinRetryBudget
+	defer func() { joinRetryBudget = orig }()
+	joinRetryBudget = 500 * time.Millisecond
+
+	_, err := joinWithRetry(ctx, signaling.New(baseURL, "test"), code, &flags{quiet: true}, nil)
+	if !errors.Is(err, fserrors.ErrCodeAlreadyClaimed) {
+		t.Errorf("expected ErrCodeAlreadyClaimed after budget, got %v", err)
+	}
+}

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -172,7 +172,9 @@ func (ui *receiverUI) promptAccept(h wire.SenderHello) bool {
 	renderArtifact(os.Stderr, h, ui.outDir, f)
 	fmt.Fprintln(os.Stderr)
 	if f.yes {
-		fmt.Fprintln(os.Stderr, uxlog.Check(), "Accepting (--yes)")
+		// Info, not Check: nothing has succeeded yet — this only echoes
+		// that the flag skipped the prompt.
+		fmt.Fprintln(os.Stderr, uxlog.Info(), "Accepting (--yes)")
 		return true
 	}
 	question := "Save to " + saveTargetLabel(ui.outDir) + "?"
@@ -382,7 +384,7 @@ func (ui *receiverUI) headline(h *wire.SenderHello, files []string) string {
 
 // printRecvSummary renders the post-transfer success line. headline is
 // the fully-formed "Saved X to Y" / "Received" clause; the parts that
-// follow scan size → time → route. On a resumed transfer moved < total
+// follow scan size → time → rate → route. On a resumed transfer moved < total
 // and the size gains a "(X received)" clause. Suppressed under --quiet.
 func printRecvSummary(f *flags, headline string, total, moved int64, elapsed time.Duration, path connpath.Info) {
 	if f.quiet {

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -71,7 +71,7 @@ func runSend(f *flags, paths []string) error {
 	// corruption warning, which must not land on the spinner's line.
 	cfg := loadConfig(f.quiet)
 
-	// Print the artifact (code + receive command) exactly once, here,
+	// Print the artifact (the receive command) exactly once, here,
 	// before any path is attempted. Both LAN and internet paths use the
 	// same locally-generated code — LAN announces an argon2id-derived
 	// name via mDNS, and the internet path registers the code's argon2id
@@ -312,8 +312,8 @@ func shortRand() string {
 	return string(b[:])
 }
 
-// printSendArtifact renders the "code + receive command" block on stderr
-// and starts an animated "Waiting for receiver" spinner. Callers must
+// printSendArtifact renders the receive-command block on stderr and
+// starts an animated "Waiting for receiver" spinner. Callers must
 // Stop the spinner before printing anything else to stderr.
 //
 // Output rules:
@@ -330,7 +330,7 @@ func printSendArtifact(f *flags, c string, items []transfer.SourceItem, kind wir
 	fmt.Fprintln(os.Stderr)
 	switch kind {
 	case wire.TransferSingleFile:
-		fmt.Fprintf(os.Stderr, "  Sending  %s  ·  %s\n",
+		fmt.Fprintf(os.Stderr, "  Sending %s  ·  %s\n",
 			items[0].Info.RelativePath, uxlog.HumanBytes(int64(items[0].Info.Size)))
 	case wire.TransferDirectory:
 		// Archive transfers carry one SourceItem (the tar) whose Size is
@@ -341,28 +341,27 @@ func printSendArtifact(f *flags, c string, items []transfer.SourceItem, kind wir
 		for _, it := range items {
 			total += it.Info.Size
 		}
-		fmt.Fprintf(os.Stderr, "  Sending  %s  ·  %s  ·  %s\n",
+		fmt.Fprintf(os.Stderr, "  Sending %s  ·  %s  ·  %s\n",
 			label, uxlog.CountNoun(int(totalFiles), "file"), uxlog.HumanBytes(int64(total)))
 	case wire.TransferMultiFile:
-		fmt.Fprintf(os.Stderr, "  Sending  %s  ·  %s\n",
+		fmt.Fprintf(os.Stderr, "  Sending %s  ·  %s\n",
 			uxlog.CountNoun(len(items), "file"), uxlog.HumanBytes(totalBytes(items)))
 	case wire.TransferText:
-		fmt.Fprintf(os.Stderr, "  Sending  text  ·  %s\n",
+		fmt.Fprintf(os.Stderr, "  Sending text  ·  %s\n",
 			uxlog.HumanBytes(totalBytes(items)))
 	case wire.TransferStdin:
 		// Stdin is streamed: size isn't known until the producer EOFs.
 		// Print a placeholder; the progress bar carries the live byte
 		// count.
-		fmt.Fprintln(os.Stderr, "  Sending  stdin stream  ·  size unknown")
+		fmt.Fprintln(os.Stderr, "  Sending stdin stream  ·  size unknown")
 	}
-	fmt.Fprintln(os.Stderr)
-	fmt.Fprintln(os.Stderr, "  Share this code:")
-	fmt.Fprintln(os.Stderr)
-	fmt.Fprintf(os.Stderr, "      %s\n", uxlog.Code(c))
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "  On the other machine, run:")
 	fmt.Fprintln(os.Stderr)
-	fmt.Fprintf(os.Stderr, "      fsend %s\n", c)
+	// The command is the single artifact: pasted as a whole, or the
+	// highlighted code dictated out of it. A separate "Share this code"
+	// block would repeat the same code four lines apart.
+	fmt.Fprintf(os.Stderr, "      fsend %s\n", uxlog.Code(c))
 	fmt.Fprintln(os.Stderr)
 	return uxlog.StartSpinner("Waiting for receiver")
 }
@@ -403,16 +402,22 @@ func totalBytes(items []transfer.SourceItem) int64 {
 func newSenderProgress(f *flags, items []transfer.SourceItem) (closeFn func(), progressFn func(fileIndex uint32, bytesSent uint64), onResume func(fileIndex uint32, offset, total uint64), stats func() (moved, skipped int64), onStreamingEOF func(fileIndex uint32, finalBytes uint64)) {
 	prev := make(map[uint32]uint64)
 	var moved, skipped int64
-	// bar is nil under --quiet; uxlog renders nil-safe.
+	// bar is nil under --quiet and until the first byte: an eager bar
+	// would draw 0% while the receiver still sits at its accept prompt —
+	// that window belongs to the "Waiting for them to accept" spinner.
+	// Mirrors the receiver's lazy bar; uxlog renders nil-safe.
 	var bar *uxlog.Progress
-	if !f.quiet {
-		// For streaming items the up-front total is 0 (size unknown). The
-		// bar renders an indeterminate progress; SetTotal is called from
-		// onStreamingEOF once the producer EOFs.
-		bar = uxlog.New(totalBytes(items))
+	ensureBar := func() {
+		if bar == nil && !f.quiet {
+			// For streaming items the up-front total is 0 (size unknown).
+			// The bar renders an indeterminate progress; SetTotal is
+			// called from onStreamingEOF once the producer EOFs.
+			bar = uxlog.New(totalBytes(items))
+		}
 	}
-	return bar.Done,
+	return func() { bar.Done() },
 		func(fi uint32, b uint64) {
+			ensureBar()
 			d := b - prev[fi]
 			prev[fi] = b
 			bar.Add(int64(d))
@@ -426,6 +431,7 @@ func newSenderProgress(f *flags, items []transfer.SourceItem) (closeFn func(), p
 				d := int64(offset - prev[fi])
 				prev[fi] = offset
 				skipped += d
+				ensureBar()
 				bar.Add(d)
 			}
 			if !f.quiet {
@@ -451,7 +457,7 @@ func resumeNotice(offset, total uint64) string {
 // printSendSummary renders the post-transfer success line on the sender.
 // The artifact name is already shown in printSendArtifact at session
 // start, so the summary deliberately omits it — repeating reads as
-// padding. Path tag goes last so the line scans size → time → route.
+// padding. The line scans size → time → rate → route.
 //
 // Suppressed under --quiet (the bare code on stdout is the contract;
 // nothing on stderr).
@@ -464,8 +470,9 @@ func printSendSummary(f *flags, total, moved int64, elapsed time.Duration, path 
 	printUpdateNotice(f)
 }
 
-// summaryParts builds the bytes/duration/path/rate sequence that both
-// send and recv summaries share. moved is the byte count actually
+// summaryParts builds the bytes/duration/rate/path sequence that both
+// send and recv summaries share: the numbers cluster together and the
+// route reads as the closing note. moved is the byte count actually
 // transferred this run; on a resumed transfer it is below total, the
 // size gains a "(X sent)"/"(X received)" clause (verb per role), and
 // the rate is computed from moved so it reflects real throughput rather
@@ -480,12 +487,11 @@ func summaryParts(total, moved int64, verb string, elapsed time.Duration, path c
 	parts := []string{
 		size,
 		uxlog.HumanDuration(elapsed),
-		path.Tag(),
 	}
 	if r := uxlog.HumanRate(moved, elapsed); r != "" {
 		parts = append(parts, r)
 	}
-	return parts
+	return append(parts, path.Tag())
 }
 
 // displayPath renders an absolute filesystem path for display: a

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -88,7 +88,7 @@ type sendPairOutcome struct {
 // as ctx.Err() — the coordinator treats that as "loser, no-op".
 func pairOverLAN(ctx context.Context, code string) (*lanSenderPairing, error) {
 	port := landisc.PortForCode(code)
-	ln, err := quicconn.ListenAddr(":"+strconv.Itoa(port), code)
+	ln, err := listenLANWithRetry(ctx, port, code)
 	if err != nil {
 		return nil, fmt.Errorf("%w: %v", fserrors.ErrLANListenerFailed, err)
 	}
@@ -200,6 +200,26 @@ func pairOverInternet(ctx context.Context, f *flags, code string, cfg *config.Co
 			deleteSession()
 		},
 	}, nil
+}
+
+// listenLANWithRetry binds the code's deterministic LAN port, retrying
+// briefly: on a re-pair round the previous listener's socket is only
+// released once its dead QUIC connection finishes draining, so an
+// immediate re-bind can lose that race and needlessly surrender the
+// LAN path to the server.
+func listenLANWithRetry(ctx context.Context, port int, code string) (*quicconn.Listener, error) {
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		ln, err := quicconn.ListenAddr(":"+strconv.Itoa(port), code)
+		if err == nil || time.Now().After(deadline) {
+			return ln, err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
 }
 
 // waitRetryStep scales the backoff between Wait retries (n·step for the
@@ -355,9 +375,42 @@ func senderQUICAccept(ctx context.Context, pc net.PacketConn, code string) (*qui
 	return ln, res, teardown, nil
 }
 
-// runSendParallel is the top-level coordinator. It runs the two pair
-// paths concurrently, picks the first that succeeds, cancels the loser,
-// and runs the transfer on the winner.
+// runSendParallel pairs and transfers, returning to "Waiting for
+// receiver" — same code — when the receiver vanishes mid-transfer.
+// Each round re-announces mDNS and re-Creates the server session (the
+// previous round's cleanup freed the slot), so a rerun `fsend <code>`
+// rediscovers the sender and resumes from its .fsend-partial. The wait
+// is unbounded, like the initial one: Ctrl-C ends it.
+//
+// Stdin/--text transfers can't replay their reader, so they fail as
+// before instead of re-pairing.
+func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem, kind wire.TransferKind, totalFiles uint32, label, code string, cfg *config.Config, waitSpin *uxlog.Spinner) error {
+	for {
+		err := runSendOnce(ctx, f, items, kind, totalFiles, label, code, cfg, waitSpin)
+		if err == nil || ctx.Err() != nil || hasConsumableReader(items) ||
+			(!errors.Is(err, fserrors.ErrTransientFailure) && !isReceiverClose(err)) {
+			return err
+		}
+		if !f.quiet {
+			fmt.Fprintf(os.Stderr, "%s Receiver disconnected — waiting for them to reconnect.\n", uxlog.Info())
+		}
+		waitSpin = startWaitSpinner(f, "Waiting for receiver")
+	}
+}
+
+// isReceiverClose reports whether err is the receiver deliberately
+// closing its QUIC connection (Ctrl-C, clean process exit). That
+// receiver will never re-dial the current pairing, so the re-accept
+// grace would be a dead wait. Network drops and kills surface as idle
+// timeouts instead and keep the grace.
+func isReceiverClose(err error) bool {
+	var appErr *quic.ApplicationError
+	return errors.As(err, &appErr) && appErr.Remote
+}
+
+// runSendOnce runs one pair-then-transfer round. It races the two pair
+// paths, picks the first that succeeds, cancels the loser, and runs the
+// transfer on the winner.
 //
 // Failure handling is deliberately asymmetric:
 //   - LAN-only failure (e.g. port conflict): keep waiting for the server
@@ -367,7 +420,7 @@ func senderQUICAccept(ctx context.Context, pc net.PacketConn, code string) (*qui
 //     ⚠ line so the user knows only same-LAN receivers can connect now.
 //   - Both fail: return the most informative error (E001 if the server
 //     was unreachable, otherwise the LAN error).
-func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem, kind wire.TransferKind, totalFiles uint32, label, code string, cfg *config.Config, waitSpin *uxlog.Spinner) error {
+func runSendOnce(ctx context.Context, f *flags, items []transfer.SourceItem, kind wire.TransferKind, totalFiles uint32, label, code string, cfg *config.Config, waitSpin *uxlog.Spinner) error {
 	pairCtx, cancelPair := context.WithCancel(ctx)
 	defer cancelPair()
 	// Belt-and-braces: if we exit through an unusual path (panic-recover,
@@ -608,12 +661,19 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 			notice(attempt, wait, lastErr)
 		}
 	}
+	classify := retry.IsTransient
 	if hasConsumableReader(items) {
 		// A partially-consumed stdin/--text reader would resend from an
 		// arbitrary offset and still pass per-chunk hashes; fail instead.
 		opts.Attempts = 1
+	} else {
+		// A deliberate receiver close means no re-dial is coming: bail
+		// past the re-accept grace so runSendParallel re-pairs now. The
+		// raw error never reaches the user — the re-pair loop always
+		// catches it (re-pairable items only).
+		classify = func(err error) bool { return !isReceiverClose(err) && retry.IsTransient(err) }
 	}
-	err := retry.WithBackoff(ctx, opts, nil,
+	err := retry.WithBackoff(ctx, opts, classify,
 		func(attempt int) error {
 			if current == nil {
 				res, err := reaccept(ctx)

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -499,15 +499,16 @@ func runSendParallel(ctx context.Context, f *flags, items []transfer.SourceItem,
 		pathInfo = winner.server.pathInfo
 	}
 	printPath(f, pathInfo)
-	// The receiver may now sit at its accept prompt for a while; without
-	// this line the sender stares at a dead terminal wondering whether
-	// the code even arrived. The path rides along so both sides see the
-	// route before any bytes flow. ✓ even for relay: the glyph reports
-	// the connect succeeding, the chip carries the route — same neutral
-	// treatment as the receiver chip and the summary tag.
+	// Without this line the sender stares at a dead terminal wondering
+	// whether the code even arrived. The path rides along as a dim chip —
+	// same shape as the receiver's "Incoming from <peer>  ·  <chip>" — so
+	// both sides see the route before any bytes flow. ✓ even for relay:
+	// the glyph reports the connect succeeding, the chip carries the
+	// route. The accept wait itself is a spinner, started in
+	// runSenderTransferLoop.
 	if !f.quiet {
-		fmt.Fprintf(os.Stderr, "%s Receiver connected (%s) — waiting for them to accept.\n",
-			uxlog.Check(), pathInfo.Chip())
+		fmt.Fprintf(os.Stderr, "%s Receiver connected%s\n",
+			uxlog.Check(), uxlog.Dim("  ·  "+pathInfo.Chip()))
 	}
 
 	if winner.lan != nil {
@@ -576,6 +577,13 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 	closeProg, progressFn, onResume, stats, onStreamingEOF := newSenderProgress(f, items)
 	defer closeProg()
 
+	// The receiver may sit at its accept prompt for a while; the spinner
+	// owns that window. The first event off the wire — a byte, a resume
+	// notice, a retry — stops it so the progress bar (or notice line)
+	// lands on a clean row. Stop is idempotent and nil-safe (--quiet).
+	spin := startWaitSpinner(f, "Waiting for them to accept")
+	defer spin.Stop()
+
 	// Time from the first byte, not from here — the receiver may sit at
 	// its accept prompt for a while, and counting that wait makes the
 	// summary read like a glacial transfer.
@@ -584,11 +592,22 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 	progress := func(fi uint32, b uint64) {
 		if firstByte.IsZero() {
 			firstByte = time.Now()
+			spin.Stop()
 		}
 		progressFn(fi, b)
 	}
+	resume := func(fi uint32, offset, total uint64) {
+		spin.Stop()
+		onResume(fi, offset, total)
+	}
 	current := firstRes
 	opts := retry.Options{OnRetry: retryNoticeFor(f)}
+	if notice := opts.OnRetry; notice != nil {
+		opts.OnRetry = func(attempt int, wait time.Duration, lastErr error) {
+			spin.Stop()
+			notice(attempt, wait, lastErr)
+		}
+	}
 	if hasConsumableReader(items) {
 		// A partially-consumed stdin/--text reader would resend from an
 		// arbitrary offset and still pass per-chunk hashes; fail instead.
@@ -616,7 +635,7 @@ func runSenderTransferLoop(ctx context.Context, f *flags, items []transfer.Sourc
 				DisplayName:    displayName,
 				Password:       f.passArg,
 				ProgressFn:     progress,
-				OnResume:       onResume,
+				OnResume:       resume,
 				OnStreamingEOF: onStreamingEOF,
 			})
 		})

--- a/cmd/fsend/sendpair_test.go
+++ b/cmd/fsend/sendpair_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/quic-go/quic-go"
+
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/signaling"
 )
@@ -294,4 +296,28 @@ func TestDrainLoser_LoserErrored(t *testing.T) {
 		winner := sendPairOutcome{server: &internetSenderPairing{cleanup: func() {}}}
 		drainLoser(lanCh, serverCh, winner, false, true)
 	})
+}
+
+// isReceiverClose must fire only on a remote application close — the
+// receiver deliberately hanging up — and not on local closes or idle
+// timeouts, which keep the re-accept grace for a possible re-dial.
+func TestIsReceiverClose(t *testing.T) {
+	remote := &quic.ApplicationError{Remote: true}
+	local := &quic.ApplicationError{Remote: false}
+
+	if !isReceiverClose(remote) {
+		t.Error("remote application close should classify as receiver close")
+	}
+	if !isReceiverClose(fmt.Errorf("send: chunk: %w", remote)) {
+		t.Error("wrapped remote close should classify as receiver close")
+	}
+	if isReceiverClose(local) {
+		t.Error("local close must not classify as receiver close")
+	}
+	if isReceiverClose(&quic.IdleTimeoutError{}) {
+		t.Error("idle timeout must not classify as receiver close")
+	}
+	if isReceiverClose(nil) {
+		t.Error("nil must not classify as receiver close")
+	}
 }

--- a/internal/uxlog/progress_test.go
+++ b/internal/uxlog/progress_test.go
@@ -49,8 +49,8 @@ func TestProgress_AbortBeforeComplete(t *testing.T) {
 // TestProgress_StreamingSetTotal mirrors the streamed-stdin code path:
 // the bar is constructed with total=0 (size unknown), bytes flow in via
 // Add(), and at EOF the producer calls SetTotal(actual, true) so the
-// bar latches to "done" instead of "aborted". Regression guard for the
-// streaming-stdin work.
+// bar completes (and is removed) instead of aborting. Regression guard
+// for the streaming-stdin work.
 func TestProgress_StreamingSetTotal(t *testing.T) {
 	silenceStderr(t)
 	p := New(0)

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -166,23 +166,20 @@ func New(totalBytes int64) *Progress {
 	hasTotal := totalBytes > 0
 	showRate := totalBytes >= rateThreshold
 
-	// Percentage on the left. OnComplete swaps it for "done" so the bar
-	// reads as terminal once the transfer is finished — no stale ETA
-	// chip lingering at 0s.
+	// Percentage on the left. The completed bar is removed (see
+	// BarRemoveOnComplete below), so no terminal-state swap is needed.
 	prependDecs := []decor.Decorator{
 		decor.Name("  "),
 		// "%d" renders "66%", matching plain mode — the default
 		// "% d" pads a space before the sign ("66 %").
-		decor.OnComplete(decor.NewPercentage("%d", decor.WC{W: 4}), "done"),
+		decor.NewPercentage("%d", decor.WC{W: 4}),
 		decor.Name("  "),
 	}
 	if !hasTotal {
 		// Streaming transfers (stdin) — no meaningful percentage.
-		// Replace with a static dots glyph that doesn't shift width
-		// when the transfer finishes (closeFn latches the total then).
 		prependDecs = []decor.Decorator{
 			decor.Name("  "),
-			decor.OnComplete(decor.Name("... "), "done"),
+			decor.Name("... "),
 			decor.Name("  "),
 		}
 	}
@@ -243,6 +240,10 @@ func New(totalBytes int64) *Progress {
 	p.bar = p.mp.New(totalBytes,
 		style,
 		mpb.BarWidth(barWidth),
+		// Progress is transient: a completed bar erases itself and the
+		// summary line that follows is the permanent record. Aborted
+		// (partial) bars stay — see Done().
+		mpb.BarRemoveOnComplete(),
 		mpb.PrependDecorators(prependDecs...),
 		mpb.AppendDecorators(appendDecs...),
 	)
@@ -284,16 +285,14 @@ func (p *Progress) SetTotal(total int64, complete bool) {
 // Done marks the bar complete and waits for mpb to flush. Always call
 // this before the caller exits.
 //
-// Two paths so the success case still renders the OnComplete suffix
-// ("done") instead of being silently aborted:
+// Two paths:
 //
-//   - Bar already at 100% (Completed reports true): the final Add()
-//     already triggered OnComplete; just Wait for mpb to flush.
-//   - Bar below 100% (aborted mid-transfer): Abort(false) so mpb
+//   - Bar at 100%: BarRemoveOnComplete erases it; just Wait for mpb
+//     to flush so the summary line lands on a clean row.
+//   - Bar below 100% (aborted mid-transfer): Abort(false) — keep the
+//     partial bar on screen as the record of where it stopped — so mpb
 //     releases the bar and Wait returns instead of hanging forever
-//     waiting for the bar to reach its declared total. We deliberately
-//     don't SetTotal here — that would render a misleading "done" on
-//     a partial bar.
+//     waiting for the bar to reach its declared total.
 func (p *Progress) Done() {
 	if p == nil {
 		return

--- a/test/e2e/signal_test.go
+++ b/test/e2e/signal_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"testing"
 	"time"
@@ -254,4 +255,89 @@ func inodeOf(path string) (uint64, error) {
 		return 0, nil
 	}
 	return uint64(st.Ino), nil
+}
+
+// The flagship recovery path: the receiver dies mid-transfer (Ctrl-C)
+// and is re-run with the same code. The sender must re-enter pairing —
+// fresh mDNS announce, fresh server session — and the rerun must resume
+// from the .fsend-partial rather than restart.
+func TestSignal_ReceiverSIGINTRerunSameCode(t *testing.T) {
+	requireE2E(t)
+	src, dst := t.TempDir(), t.TempDir()
+	srcFile := filepath.Join(src, "big.bin")
+	writeRandom(t, srcFile, 64*1024*1024)
+
+	xdg := h.newXDG(t)
+	s := h.startSender(t, xdg, srcFile)
+	t.Cleanup(func() { _ = s.cmd.Process.Kill() })
+	code := s.waitForCode(t, 5*time.Second)
+
+	// Attempt 1 — interrupt the receiver once a meaningful prefix is on
+	// disk, so the rerun has something to resume from.
+	r1 := h.fsendCmd(xdg, "--yes", code)
+	r1.Dir = dst
+	var r1Err bytes.Buffer
+	r1.Stderr = &r1Err
+	if err := r1.Start(); err != nil {
+		t.Fatalf("start recv1: %v", err)
+	}
+	if !waitForSidecarSize(dst, 4*1024*1024, 10*time.Second) {
+		_ = r1.Process.Kill()
+		_ = r1.Wait()
+		t.Fatal("sidecar never reached 4 MiB — receiver never got going")
+	}
+	if err := r1.Process.Signal(syscall.SIGINT); err != nil {
+		t.Fatalf("signal recv1: %v", err)
+	}
+	_ = r1.Wait()
+
+	// The sender must go back to waiting rather than exit.
+	if !waitForStderr(s, "Receiver disconnected", 15*time.Second) {
+		t.Fatalf("sender never re-entered pairing\n--- sender stderr ---\n%s", s.stderr.String())
+	}
+
+	// Attempt 2 — same code, same dst: must pair again and resume.
+	r2 := h.fsendCmd(xdg, "--yes", code)
+	r2.Dir = dst
+	var r2Err bytes.Buffer
+	r2.Stderr = &r2Err
+	if err := r2.Run(); err != nil {
+		t.Fatalf("rerun receiver failed (exit %d)\n--- recv2 stderr ---\n%s\n--- sender stderr ---\n%s",
+			exitCodeOf(t, err), r2Err.String(), s.stderr.String())
+	}
+	if got := s.wait(t, 10*time.Second); got != 0 {
+		t.Fatalf("sender exit = %d\n--- sender stderr ---\n%s", got, s.stderr.String())
+	}
+	if !strings.Contains(r2Err.String(), "Resuming from") {
+		t.Errorf("rerun did not resume from the partial\n--- recv2 stderr ---\n%s", r2Err.String())
+	}
+	assertFilesEqual(t, srcFile, filepath.Join(dst, "big.bin"))
+}
+
+// waitForSidecarSize polls until a *.fsend-partial under dir reaches
+// minBytes, or the budget elapses.
+func waitForSidecarSize(dir string, minBytes int64, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		matches, _ := filepath.Glob(filepath.Join(dir, "*.fsend-partial"))
+		for _, m := range matches {
+			if st, err := os.Stat(m); err == nil && st.Size() >= minBytes {
+				return true
+			}
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
+}
+
+// waitForStderr polls a sender's stderr for substr within budget.
+func waitForStderr(s *senderProc, substr string, budget time.Duration) bool {
+	deadline := time.Now().Add(budget)
+	for time.Now().Before(deadline) {
+		if strings.Contains(s.stderr.String(), substr) {
+			return true
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return false
 }


### PR DESCRIPTION
Two changes that came out of a UX review of the send/receive screens — a rendering-only tightening pass, and a fix for a recovery gap the verification of that pass uncovered.

## 1. UX: tighter send/receive screens (`ce259a8`)

Rendering-only; no behavior changes.

- **Sender artifact**: the "Share this code:" block is gone — the receive command is the single artifact, with the code highlighted (bold cyan) inside it for dictation. The pre-transfer block drops from 10 lines to 6, and the code no longer appears twice.
- **Progress bars erase themselves on completion** (`BarRemoveOnComplete`); the ✓ summary line is the permanent record. Aborted bars still stay as the record of where a failed transfer stopped.
- **Summary order**: size · time · rate · route on both roles — metrics cluster, the route closes the line.
- **Connect line**: `✓ Receiver connected  ·  <chip>` (dim chip, mirroring the receiver's "Incoming from" line), followed by a real "Waiting for them to accept" spinner instead of the em-dash clause. The sender's bar is now created lazily on the first byte — same pattern the receiver already used — so no 0% bar renders during the accept wait.
- `ℹ Accepting (--yes)` instead of a premature green check; "Sending" loses its double space; README snippet updated to match.

Final sender screen:

```
  Sending big.bin  ·  800 MB

  On the other machine, run:

      fsend phr-ttyr-uzw

✓ Receiver connected  ·  local network
✓ Sent  ·  800 MB  ·  8.9s  ·  90.1 MB/s  ·  Direct on local network
```

## 2. Fix: rerunning `fsend <code>` after the receiver dies now works (`1816703`)

Rerunning the same code after interrupting the receiver mid-transfer used to fail — **E002** on the LAN path (mDNS de-announced at pair time, server session deleted by the losing race goroutine) or **E003** on the internet path (stale "paired" session) — while the sender sat re-accepting on sockets nobody could discover, then exited E020. This contradicted the README's resume promise. Verified pre-existing on `main` (not introduced by the UX commit).

The sender now returns to the state it was built to handle: on a transient transfer failure it tears down the dead pairing (freeing the slot and port) and **re-enters the pair race with the same code** — fresh mDNS announce, fresh server session — so a rerun rediscovers it and resumes from the `.fsend-partial`. Supporting pieces:

- A deliberate receiver close (Ctrl-C → remote QUIC application close) skips the re-accept grace and re-pairs immediately, so Ctrl-C + rerun recovers within seconds. Crashes/kills still ride the 30s idle timeout + grace first.
- The LAN re-bind retries briefly — quic-go releases the old listener's socket only after its dead connection drains, and losing that race silently surrendered the LAN path to the server.
- The receiver's join poll also retries on "already claimed" within its existing 15s budget — a stale session pending the sender's re-pair flips to joinable mid-poll. A genuinely claimed code still ends as E003.

Stdin/`--text` transfers can't replay their reader and fail exactly as before; declines and other terminal errors don't re-pair.

## Verification

- Full suite (`go test -count=1 ./...`): 19 packages pass; `-race` clean on `cmd/fsend`, `internal/uxlog`, `test/e2e`.
- New tests: `TestIsReceiverClose`, `TestJoinWithRetry_RetriesWhenStaleSessionReplaced`, `TestJoinWithRetry_GivesUpOnClaimedAfterBudget`, and e2e `TestSignal_ReceiverSIGINTRerunSameCode` (kills a real receiver mid-transfer, asserts the sender re-enters pairing and the rerun resumes byte-identically).
- Empirical pty validation of both commits with 800 MB transfers: interactive accept, decline, `--yes`, stdin streaming, resume, non-TTY plain mode (zero ANSI escapes), Ctrl-C + rerun (LAN and server paths), kill -9 + rerun, and sender Ctrl-C during the re-pair wait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)