### PR TITLE
docs(readme): label the hero block's two machines as Sender/Receiver

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,12 @@
 </p>
 
 ```bash
-$ fsend report.pdf                 # home Wi-Fi
+# Sender — home Wi-Fi
+$ fsend report.pdf
 On the other machine, run:  fsend abc-defg-jkm
 
-$ fsend abc-defg-jkm               # café Wi-Fi, two continents away
+# Receiver — café Wi-Fi, two continents away
+$ fsend abc-defg-jkm
 ✓ Saved report.pdf to ~/Downloads  ·  2.4 MB  ·  1.3s  ·  Direct over the internet
 ```
 


### PR DESCRIPTION
Labels the README hero block's two prompts as `# Sender — home Wi-Fi` and `# Receiver — café Wi-Fi, two continents away` so the two-machine premise is explicit instead of inferred. Also drops the hand-padded trailing comments (they had to be re-aligned whenever a command's length changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)