### PR TITLE
fix: bump Go toolchain to 1.26.4, add govulncheck CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -47,6 +47,20 @@ jobs:
           version: latest
           args: --timeout=5m
 
+  # Catch known CVEs in the standard library and dependencies. "1.26"
+  # floats to the latest patch, so this also fails if go.mod pins a
+  # toolchain that has fallen behind a security release.
+  govulncheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: true
+      - run: go install golang.org/x/vuln/cmd/govulncheck@latest
+      - run: govulncheck ./...
+
   deadcode:
     runs-on: ubuntu-latest
     steps:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/polius/fsend
 
-go 1.26.0
+go 1.26.4
 
 require (
 	github.com/adrg/xdg v0.5.3


### PR DESCRIPTION
## Summary

Closes the stale-toolchain finding from the audit. `govulncheck` reported **12 reachable standard-library vulnerabilities** against the `go 1.26.0` baseline in `go.mod`; bumping the directive to **1.26.4** clears all of them.

## Changes
- `go.mod`: `go 1.26.0` → `go 1.26.4`.
- `checks.yml`: new `govulncheck` job (`go-version: "1.26"` floats to the latest patch, so it also fails if the pinned toolchain ever falls behind a security release).

## Notable CVEs cleared
- **GO-2026-4870** — unauthenticated TLS 1.3 KeyUpdate record → persistent connection retention / DoS in `crypto/tls` (directly relevant: TLS-over-QUIC + public relay).
- **GO-2026-4600** — panic in `crypto/x509` on malformed certs, reachable from `quicconn.ReceiverHandshake`.
- **GO-2026-4866** — case-sensitivity name-constraint auth bypass in `crypto/x509`.
- Plus 9 others in `net/url`, `net/http2`, `net/textproto`, `os`, `net`.

## Verification
```
$ go build ./...        # OK (fetches go1.26.4)
$ go vet ./...          # clean
$ go test -short ./...  # all 19 packages pass
$ govulncheck ./...     # No vulnerabilities found   (was: 12)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)