### PR TITLE
fix(transfer): fsync received files before commit for crash durability

### DIFF
--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -524,6 +524,13 @@ func (rf *recvFile) finalize(s *Streams, root [32]byte, opts RecvOptions) error 
 		declineTransfer(s, wire.ErrCodeFileHashMismatch, "root hash mismatch")
 		return fserrors.ErrHashMismatch
 	}
+	// Flush data to stable storage before the rename so a crash can't leave a
+	// size-correct, mtime-correct file with unpersisted (garbage) contents —
+	// which a later skip-unchanged run would then trust forever.
+	if err := rf.f.Sync(); err != nil {
+		_ = rf.f.Close()
+		return fmt.Errorf("%w: sync partial: %v", fserrors.ErrWriteFailed, err)
+	}
 	if err := rf.f.Close(); err != nil {
 		return fmt.Errorf("%w: close partial: %v", fserrors.ErrWriteFailed, err)
 	}
@@ -538,6 +545,7 @@ func (rf *recvFile) finalize(s *Streams, root [32]byte, opts RecvOptions) error 
 	if err := os.Rename(rf.partial, target); err != nil {
 		return fmt.Errorf("%w: finalize: %v", fserrors.ErrWriteFailed, err)
 	}
+	fsyncDir(filepath.Dir(target)) // make the rename itself durable
 	_ = os.Chmod(target, os.FileMode(rf.plan.entry.Mode)&os.ModePerm)
 	if rf.plan.entry.ModTimeSec > 0 {
 		t := time.Unix(rf.plan.entry.ModTimeSec, 0)
@@ -665,6 +673,13 @@ func recvStream(ctx context.Context, s *Streams, hello *wire.SenderHello, opts R
 		}
 	})
 	if f != nil {
+		// Flush data before the rename (see finalize) so a crash can't commit
+		// a correctly-named file with unpersisted contents.
+		if err == nil {
+			if serr := f.Sync(); serr != nil {
+				err = fmt.Errorf("%w: sync stream file: %v", fserrors.ErrWriteFailed, serr)
+			}
+		}
 		_ = f.Close()
 		if err != nil {
 			_ = os.Remove(target + partialSuffix)
@@ -677,6 +692,7 @@ func recvStream(ctx context.Context, s *Streams, hello *wire.SenderHello, opts R
 		if err := os.Rename(target+partialSuffix, target); err != nil {
 			return fmt.Errorf("%w: finalize: %v", fserrors.ErrWriteFailed, err)
 		}
+		fsyncDir(filepath.Dir(target)) // make the rename itself durable
 		if opts.OnFileDone != nil {
 			opts.OnFileDone(target)
 		}

--- a/internal/transfer/util.go
+++ b/internal/transfer/util.go
@@ -23,6 +23,20 @@ func hashPrefixInto(h *blake3.Hasher, f *os.File, n int64) error {
 	return err
 }
 
+// fsyncDir flushes a directory's entries to stable storage so a rename
+// into it survives a crash. Best-effort: directory fsync is a POSIX notion
+// not supported on every platform (notably Windows), so errors are ignored.
+// Durability of the file *contents* is guaranteed separately by syncing the
+// file before it is renamed into place.
+func fsyncDir(dir string) {
+	d, err := os.Open(dir)
+	if err != nil {
+		return
+	}
+	_ = d.Sync()
+	_ = d.Close()
+}
+
 // pathIsUnder reports whether child is the same as parent or lives below it
 // in the filesystem hierarchy. Both must be absolute and clean.
 func pathIsUnder(child, parent string) bool {


### PR DESCRIPTION
## Summary

Closes the durability finding from the audit. The receive paths closed and renamed a completed file **without ever calling `Sync()`** (the only `Sync` in the tree was in `config.go`). After a "successful" transfer, a crash or power loss could leave a size-correct, mtime-correct file whose data blocks were never persisted — and a later run would then classify it as identical and **skip it forever**, since the BLAKE3 verification that protected the original transfer never re-runs. A verified transfer becomes silent on-disk corruption across a crash boundary.

## Changes
- `internal/transfer/recv.go`: `f.Sync()` before close/rename in **both** commit paths — `finalize` (listing path) and `recvStream` (single-stream path). Flushing data *before* the rename is issued is the load-bearing fix: it closes the silent-corruption window even if the rename later replays from the journal.
- `internal/transfer/util.go`: new best-effort `fsyncDir` helper, called after each rename so the rename itself is durable. No-op where directory fsync is unsupported (e.g. Windows); errors ignored because file-content durability is already guaranteed by the file sync.

## Scope
Limited to data files (the corruption vector). Structural entries (empty files, dirs, symlinks) carry no data to lose and are simply re-created on resend if missing — left unchanged to keep the diff minimal.

## Verification
```
$ go build ./...                                      # OK
$ go test -race ./internal/transfer/... ./test/e2e/...  # pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)