### PR TITLE
fix(install): verify cosign signature on checksums.txt before trusting it

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -113,3 +113,23 @@ excluded for legibility). Codes are:
   not user-selectable. To require a password on top of the code, add
   `--pass` when sending.
 
+## Release integrity
+
+Release archives are published with a `checksums.txt` that is **signed in
+CI with keyless [cosign](https://docs.sigstore.dev/)** (Sigstore Fulcio +
+Rekor), bound to the release workflow's identity. The installer and
+`fsend --update` verify two independent things:
+
+- **Authenticity** — if `cosign` is installed, the signature on
+  `checksums.txt` is verified against the release workflow's identity
+  before any checksum is trusted. This catches a *tampered* release, not
+  just a corrupted download — a SHA-256 match alone only proves the
+  archive matches `checksums.txt`, and both come from the same host.
+- **Integrity** — the downloaded archive's SHA-256 is checked against the
+  (now-trusted) `checksums.txt`.
+
+cosign is optional so the one-line install keeps working on hosts without
+it; in that case only the checksum is verified and the installer says so.
+Set `FSEND_REQUIRE_SIGNATURE=1` to refuse to install unless the signature
+is verified.
+

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -38,6 +38,11 @@ Set-StrictMode -Version Latest
 $Repo   = 'polius/fsend'
 $Binary = 'fsend.exe'
 
+# Keyless-cosign identity of the release workflow (checksums.txt is signed in
+# CI; see .goreleaser.yml). These pin who is allowed to have signed it.
+$CosignIdentityRegexp = "^https://github.com/$Repo/.github/workflows/release.yml@refs/tags/v.*$"
+$CosignIssuer = 'https://token.actions.githubusercontent.com'
+
 function Info($m) { Write-Host "› $m" -ForegroundColor Cyan }
 function Ok($m)   { Write-Host "✓ $m" -ForegroundColor Green }
 
@@ -88,6 +93,36 @@ function Download($url, $out) {
     }
 }
 
+# Verify-Signature checks cosign's keyless signature on checksums.txt before
+# any checksum derived from it is trusted. The SHA-256 check alone only proves
+# the archive matches checksums.txt (both fetched over the same channel); the
+# signature proves the file came from the release workflow. cosign is optional:
+# absent, we fall back to checksum-only unless FSEND_REQUIRE_SIGNATURE=1.
+function Verify-Signature($sums, $base, $dir) {
+    if (-not (Get-Command cosign -ErrorAction SilentlyContinue)) {
+        if ($env:FSEND_REQUIRE_SIGNATURE -eq '1') {
+            Err 'FSEND_REQUIRE_SIGNATURE=1 but cosign is not installed'
+        }
+        Write-Host '! cosign not found - verifying checksum only, not the release signature.' -ForegroundColor Yellow
+        Write-Host '  install cosign for full authenticity, or set FSEND_REQUIRE_SIGNATURE=1 to require it.' -ForegroundColor Yellow
+        return
+    }
+    $sig = Join-Path $dir 'checksums.txt.sig'
+    $pem = Join-Path $dir 'checksums.txt.pem'
+    Download "$base/checksums.txt.sig" $sig
+    Download "$base/checksums.txt.pem" $pem
+    & cosign verify-blob `
+        --certificate $pem `
+        --signature $sig `
+        --certificate-identity-regexp $CosignIdentityRegexp `
+        --certificate-oidc-issuer $CosignIssuer `
+        $sums 2>$null | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        Err 'cosign signature verification failed for checksums.txt - refusing to install'
+    }
+    Ok 'signature verified'
+}
+
 # Windows PowerShell 5.1 defaults to TLS 1.0/1.1; GitHub requires 1.2+.
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
@@ -127,6 +162,9 @@ try {
     $archive = "fsend_${vnum}_windows_${arch}.zip"
     Info "downloading $archive"
     Download "https://github.com/$Repo/releases/download/$Version/$archive" (Join-Path $tmp $archive)
+
+    Info 'verifying signature'
+    Verify-Signature $checksums "https://github.com/$Repo/releases/download/$Version" $tmp
 
     Info 'verifying checksum'
     $row = Get-Content $checksums | Where-Object { $_ -match ("\s" + [regex]::Escape($archive) + "$") } | Select-Object -First 1

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -6,6 +6,11 @@ BINARY="fsend"
 FSEND_VERSION="${FSEND_VERSION:-latest}"
 PREFIX="${PREFIX:-}"
 
+# Keyless-cosign identity of the release workflow. checksums.txt is signed
+# in CI (see .goreleaser.yml); these pin who is allowed to have signed it.
+COSIGN_IDENTITY_REGEXP="^https://github.com/${REPO}/.github/workflows/release.yml@refs/tags/v.*$"
+COSIGN_ISSUER="https://token.actions.githubusercontent.com"
+
 if [ -n "$PREFIX" ]; then
     PREFIX_EXPLICIT=1
 else
@@ -177,6 +182,40 @@ extract_zip() {
 # POSIX sh has no function scope: bare assignments here would clobber the
 # caller's globals. The archive name in particular is reused for extraction
 # after this returns, so keep these parameters underscore-prefixed.
+# verify_signature checks cosign's keyless signature on checksums.txt before
+# any checksum derived from it is trusted. The SHA-256 check alone only proves
+# the archive matches checksums.txt — both fetched over the same channel — so
+# it catches corruption, not a tampered release. The signature proves the file
+# came from the release workflow.
+#
+# cosign is optional: requiring it would break the common curl|sh path on hosts
+# without it. When absent we fall back to checksum-only and say so; a present
+# cosign that reports a bad signature is always fatal. Set
+# FSEND_REQUIRE_SIGNATURE=1 to refuse to install without verification.
+verify_signature() {
+    _sums="$1"  # checksums.txt
+    _base="$2"  # release download base URL
+    _dir="$3"   # temp dir
+    if ! command -v cosign >/dev/null 2>&1; then
+        if [ "${FSEND_REQUIRE_SIGNATURE:-0}" = "1" ]; then
+            err "FSEND_REQUIRE_SIGNATURE=1 but cosign is not installed"
+        fi
+        warn "cosign not found — verifying checksum only, not the release signature."
+        warn "  install cosign for full authenticity, or set FSEND_REQUIRE_SIGNATURE=1 to require it."
+        return 0
+    fi
+    download "${_base}/checksums.txt.sig" "${_dir}/checksums.txt.sig"
+    download "${_base}/checksums.txt.pem" "${_dir}/checksums.txt.pem"
+    cosign verify-blob \
+        --certificate "${_dir}/checksums.txt.pem" \
+        --signature "${_dir}/checksums.txt.sig" \
+        --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
+        --certificate-oidc-issuer "$COSIGN_ISSUER" \
+        "$_sums" >/dev/null 2>&1 \
+        || err "cosign signature verification failed for checksums.txt — refusing to install"
+    ok "signature verified"
+}
+
 verify_checksum() {
     _archive="$1"
     _sums="$2"
@@ -299,6 +338,10 @@ main() {
         info "downloading checksums"
         download "https://github.com/${REPO}/releases/download/${version}/checksums.txt" "$tmp/checksums.txt"
     fi
+    info "verifying signature"
+    verify_signature "$tmp/checksums.txt" \
+        "https://github.com/${REPO}/releases/download/${version}" "$tmp"
+
     info "installing fsend ${version} for ${os}-${arch} into ${PREFIX}"
 
     case "$os" in


### PR DESCRIPTION
## Summary

Closes the self-update supply-chain finding. The release pipeline signs `checksums.txt` with **keyless cosign** and publishes `checksums.txt.sig` + `.pem`, but **neither installer ever verified them**. They checked only the archive against `checksums.txt` — both fetched from the same host — which proves integrity-vs-corruption, not authenticity. Anyone able to replace release assets (compromised token, or a subverted `getfsend.alzina.dev` redirect) ships a malicious archive plus a matching `checksums.txt` and the SHA-256 check passes. `fsend --update` re-runs the same installer and may `sudo` over a system binary, so the gap compounds.

## Changes
- `scripts/install.sh` + `scripts/install.ps1`: verify the cosign signature on `checksums.txt` against the release workflow's keyless identity **before** any checksum from it is trusted.
- `docs/security.md`: new "Release integrity" section documenting the authenticity + integrity split and the opt-out/enforce knobs.

## Policy
- **cosign present** → signature verified; a bad signature is **fatal**.
- **cosign absent** → falls back to checksum-only and says so (keeps the one-line `curl | sh` working everywhere).
- **`FSEND_REQUIRE_SIGNATURE=1`** → refuses to install unless the signature is verified.

## Empirical validation
The pinned identity/issuer were confirmed by decoding the **real v1.5.0 release certificate**:
- SAN identity: `https://github.com/polius/fsend/.github/workflows/release.yml@refs/tags/v1.5.0` — matched by the pinned regexp `…release.yml@refs/tags/v.*`
- OIDC issuer: `https://token.actions.githubusercontent.com`
- `checksums.txt.sig` confirmed present (HTTP 302) on v1.3.0/v1.4.0/v1.5.0 — no regression for older pinned versions.

`sh -n` and `shellcheck -S warning` clean. (No local `pwsh`/`cosign` to run the PowerShell path end-to-end; logic mirrors the existing `Download`/`Err` patterns and the sh version.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)