### PR TITLE
fix: robustness cluster from the production audit

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,6 +24,7 @@ linters:
         - G304
         - G305
         - G402
+        - G404 # weak RNG: math/rand/v2 is used only for retry jitter, not for any secret
         - G602
   exclusions:
     rules:

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -99,22 +99,41 @@ func pairOverLAN(ctx context.Context, code string) (*lanSenderPairing, error) {
 	var stopMDNSOnce sync.Once
 	stopMDNS := func() { stopMDNSOnce.Do(func() { _ = mdnsConn.Close() }) }
 
-	res, err := ln.Accept(ctx)
-	if err != nil {
-		stopMDNS()
-		_ = ln.Close()
-		return nil, err
-	}
-	stopMDNS()
-
-	return &lanSenderPairing{
-		listener: ln,
-		firstRes: res,
-		cleanup: func() {
+	// Keep accepting until the real receiver completes the handshake or the
+	// pairing window closes. A malicious LAN host can reach the deterministic
+	// port and complete TLS but fail SPAKE2 (it lacks the code); surrendering
+	// the LAN fast path to the first such impostor would be a trivial,
+	// repeatable denial of the same-LAN shortcut. Only ctx cancellation (the
+	// internet path won, or pairing gave up) ends the loop — the transfer
+	// still succeeds via the internet path meanwhile.
+	for {
+		res, err := ln.Accept(ctx)
+		if err == nil {
+			stopMDNS()
+			return &lanSenderPairing{
+				listener: ln,
+				firstRes: res,
+				cleanup: func() {
+					stopMDNS()
+					_ = ln.Close()
+				},
+			}, nil
+		}
+		if ctx.Err() != nil {
 			stopMDNS()
 			_ = ln.Close()
-		},
-	}, nil
+			return nil, err
+		}
+		// An impostor's failed handshake, not our window closing: keep
+		// listening, throttled so an instantly-erroring listener can't spin.
+		select {
+		case <-time.After(lanAcceptRetryDelay):
+		case <-ctx.Done():
+			stopMDNS()
+			_ = ln.Close()
+			return nil, ctx.Err()
+		}
+	}
 }
 
 // waitMaxConsecFails is how many consecutive Wait failures the sender
@@ -128,6 +147,11 @@ const waitMaxConsecFails = 6
 // receiver is gone — without the bound the sender spins "Waiting for
 // receiver" forever.
 const firstAcceptTimeout = 60 * time.Second
+
+// lanAcceptRetryDelay throttles re-Accept after a failed LAN handshake so a
+// wedged listener (instant errors) can't spin the CPU. Small enough that a
+// real receiver arriving right after an impostor barely waits.
+const lanAcceptRetryDelay = 100 * time.Millisecond
 
 // errPairedGone marks failures after a receiver claimed the code. The
 // LAN race can't recover from these — a receiver that joined via the

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 
 	"github.com/polius/fsend/internal/config"
+	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/uxlog"
 )
 
@@ -53,7 +54,7 @@ func runUninstall(f *flags) error {
 		if err := removeBinary(binPath); err != nil {
 			fmt.Fprintf(os.Stderr, "%s Could not remove binary at %s: %v\n", uxlog.Warn(), binPath, err)
 			fmt.Fprintf(os.Stderr, "    Delete it manually to finish: %s\n", binPath)
-			return nil
+			return fserrors.ErrUninstallFailed
 		}
 		fmt.Fprintf(os.Stderr, "%s Removed binary: %s\n", uxlog.Check(), binPath)
 		fmt.Fprintln(os.Stderr, "  fsend uninstalled.")
@@ -63,7 +64,7 @@ func runUninstall(f *flags) error {
 	if err := os.Remove(binPath); err != nil {
 		fmt.Fprintf(os.Stderr, "%s Could not remove binary at %s: %v\n", uxlog.Warn(), binPath, err)
 		fmt.Fprintln(os.Stderr, "    Remove it manually, possibly with sudo.")
-		return nil
+		return fserrors.ErrUninstallFailed
 	}
 	fmt.Fprintf(os.Stderr, "%s Removed binary: %s\n", uxlog.Check(), binPath)
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -184,7 +184,7 @@ guarantee is where they separate.
 | | **fsend** | **croc** | **magic-wormhole** |
 |---|---|---|---|
 | End-to-end encrypted | ✓ | ✓ | ✓ |
-| PAKE protocol | **SPAKE2 (RFC 9382, IETF-standardized)** | `schollz/pake` v3 (Boneh–Shoup textbook PAKE2) | SPAKE2 (`python-spake2`, symmetric mode) |
+| PAKE protocol | SPAKE2 (`gospake2`, symmetric / python-spake2 construction) | `schollz/pake` v3 (Boneh–Shoup textbook PAKE2) | SPAKE2 (`python-spake2`, symmetric mode) |
 | Defense-in-depth layers | **Two independent** — TLS 1.3 (QUIC) **+** SPAKE2 channel-bound to the TLS handshake (RFC 5705) | One — AEAD keyed from PAKE | One — secretbox keyed from SPAKE2 |
 | AEAD cipher | TLS 1.3 ciphers (AES-GCM / ChaCha20-Poly1305) | AES-256-GCM | NaCl secretbox (XSalsa20-Poly1305) |
 | Key derivation | TLS 1.3 KDF + SPAKE2 + RFC 5705 exporter binding | PBKDF2-SHA256, 100 iterations (over the PAKE key) | HKDF-SHA256 from the SPAKE2 key |

--- a/docs/security.md
+++ b/docs/security.md
@@ -11,8 +11,8 @@ peer-authentication layer:
 
 1. **TLS 1.3 over QUIC** carries all file bytes — standard transport
    security, terminated at the two peers (not at the server).
-2. **SPAKE2 (RFC 9382)**, run from the share code and bound to the TLS
-   handshake via the RFC 5705 channel-binding exporter, proves the
+2. **SPAKE2** (a balanced PAKE), run from the share code and bound to the
+   TLS handshake via the RFC 5705 channel-binding exporter, proves the
    other end of that TLS connection is the peer holding the code.
 
 A network eavesdropper is stopped by TLS. An active MITM that

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -63,7 +63,7 @@ sending, then confirms. Pass `--yes` to skip.
 | `--out -` | Stream the payload to stdout instead of saving a file (single file, text, or piped stream — not directories). Retries are disabled: emitted bytes can't be rewound. |
 | `--overwrite` | Replace existing files whose contents **differ**. Byte-identical files are always skipped silently regardless. Differing files without this flag are kept (your local edits are protected) and the receiver exits `E013`. |
 | `--dry-run` | Show what would transfer — `new` / `identical` / `differs` per path on stdout — and write nothing. |
-| `--checksum` | Decide whether a file is already present by comparing its **contents** (a BLAKE3 hash), not its size + modification time — like rsync's `-c`. Slower (reads the files that already exist), but unaffected by mismatched timestamps. |
+| `--checksum` | Decide whether a file is already present by comparing its **contents** (a BLAKE3 hash), not its size + modification time — like rsync's `-c`. Slower (reads the files that already exist), but unaffected by mismatched timestamps. By default a local file with the same size **and** mtime is assumed identical and skipped without reading it; use `--checksum` when a file may have changed in place without its size or timestamp changing. |
 | `--pass <password>` | Supply the sender's password non-interactively. Also `FSEND_PASS`. |
 
 ```sh

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -122,7 +122,11 @@ func Load() (*Config, error) {
 		if errors.Is(err, fs.ErrNotExist) {
 			return &Config{}, nil
 		}
-		return &Config{}, nil // can't read for any reason → use defaults silently
+		// Readable-but-denied (e.g. a chmod-000 or root-owned config)
+		// must not fall back to the public default *silently* — that
+		// would drop a user's custom server with no hint. Surface it as
+		// the same warn-and-default path corruption uses.
+		return &Config{}, fserrors.ErrConfigCorrupted
 	}
 	var c Config
 	if err := json.Unmarshal(data, &c); err != nil {

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -115,6 +115,10 @@ var (
 	// breaking fsend release changed the format). Resolved only by updating
 	// the older side; distinct from E015 so the message can say so.
 	ErrIncompatibleVersion = errors.New("incompatible fsend version")
+	// E035 — `fsend --uninstall` could not remove the binary (typically a
+	// privileged install dir needing sudo). A non-zero exit so scripts can
+	// tell a failed uninstall from a clean one.
+	ErrUninstallFailed = errors.New("uninstall failed")
 )
 
 // Entry is one row of the user-facing error catalog.
@@ -391,6 +395,12 @@ var catalog = map[error]Entry{
 		Message: "The other device is running an incompatible version of fsend.",
 		Action: "Update both sides to the latest version, then try again:\n" +
 			"    fsend --update",
+	},
+	ErrUninstallFailed: {
+		Code: "E035", Exit: 35,
+		Message: "fsend was not fully uninstalled.",
+		Action: "Remove the binary by hand (the path is printed above), " +
+			"possibly with sudo.",
 	},
 }
 

--- a/internal/pake/pake.go
+++ b/internal/pake/pake.go
@@ -1,4 +1,5 @@
-// Package pake wraps a symmetric SPAKE2 (RFC 9382) handshake.
+// Package pake wraps a symmetric SPAKE2 handshake (the Abdalla–Pointcheval
+// construction, as in python-spake2 — not the RFC 9382 wire encoding).
 //
 // Both peers feed the same short code in; after exchanging one message
 // each, both derive the same 32-byte key. The code itself never crosses

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -202,3 +202,23 @@ func TestServer_STUNBinding(t *testing.T) {
 	_ = serverConn.Close()
 	<-srvErr
 }
+
+func TestAllowSTUNResponse_RateCap(t *testing.T) {
+	s := &Server{}
+	base := time.Unix(1700000000, 0)
+
+	// The whole per-second budget is allowed.
+	for i := 0; i < stunResponsesPerSec; i++ {
+		if !s.allowSTUNResponse(base) {
+			t.Fatalf("response %d denied within budget", i)
+		}
+	}
+	// One more in the same window is denied.
+	if s.allowSTUNResponse(base) {
+		t.Fatal("expected denial after budget exhausted")
+	}
+	// A new one-second window resets the budget.
+	if !s.allowSTUNResponse(base.Add(time.Second)) {
+		t.Fatal("expected allow after window rollover")
+	}
+}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -32,7 +32,21 @@ type Server struct {
 	mu        sync.RWMutex
 	allocs    map[Token]*allocation
 	tombstone map[Token]tombstoneEntry // recently evicted tokens + reason; janitor expires by age
+
+	// STUN responses are a small (~2x) amplifier off a spoofable source.
+	// A global fixed-window cap bounds the reflector's aggregate output;
+	// it is deliberately NOT per-source, because the source IP is forgeable
+	// and a per-source map would itself be an unbounded-memory vector.
+	stunMu     sync.Mutex
+	stunWindow time.Time
+	stunCount  int
 }
+
+// stunResponsesPerSec caps aggregate STUN binding replies. A few dozen
+// small packets per pairing is plenty for ICE gathering, so this leaves
+// real clients ample headroom while keeping the reflector's contribution
+// to any amplification attack negligible (~40 KB/s of responses).
+const stunResponsesPerSec = 1000
 
 // tombstoneEntry records why an allocation was evicted, with the
 // monotonic-ish unix-nanos timestamp the janitor uses to expire it.
@@ -250,6 +264,9 @@ func (s *Server) handleSTUN(datagram []byte, src *net.UDPAddr) {
 	if !stun.IsMessage(datagram) {
 		return
 	}
+	if !s.allowSTUNResponse(time.Now()) {
+		return // aggregate cap hit; drop silently (ICE clients retry/fall back)
+	}
 	req := &stun.Message{Raw: datagram}
 	if err := req.Decode(); err != nil || req.Type != stun.BindingRequest {
 		return
@@ -263,6 +280,24 @@ func (s *Server) handleSTUN(datagram []byte, src *net.UDPAddr) {
 	if _, err := s.conn.WriteTo(resp.Raw, src); err != nil {
 		s.logger.Debug("relay: stun write failed", "err", err)
 	}
+}
+
+// allowSTUNResponse reports whether a STUN reply may be sent, enforcing a
+// global fixed-window rate cap. Cheap (one mutex, two fields) and holds no
+// per-source state, so it can't be turned into a memory-exhaustion vector
+// by source spoofing.
+func (s *Server) allowSTUNResponse(now time.Time) bool {
+	s.stunMu.Lock()
+	defer s.stunMu.Unlock()
+	if now.Sub(s.stunWindow) >= time.Second {
+		s.stunWindow = now
+		s.stunCount = 0
+	}
+	if s.stunCount >= stunResponsesPerSec {
+		return false
+	}
+	s.stunCount++
+	return true
 }
 
 func (s *Server) evict(t Token, reason string) {

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -3,9 +3,10 @@
 // without surfacing them to the user.
 //
 // Scope is deliberately narrow: a `WithBackoff` function plus a
-// well-tested classifier for what counts as transient. Anything more
-// (jitter, circuit breakers, persistence) belongs in a dedicated lib —
-// fsend doesn't need it.
+// well-tested classifier for what counts as transient. It adds equal
+// jitter to each sleep so a fleet of clients recovering from the same
+// outage don't retry in lockstep against a shared relay; anything beyond
+// that (circuit breakers, persistence) belongs in a dedicated lib.
 package retry
 
 import (
@@ -13,6 +14,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"math/rand/v2"
 	"net"
 	"strings"
 	"time"
@@ -90,17 +92,20 @@ func WithBackoff(ctx context.Context, opts Options, isTransient func(error) bool
 		if attempt == opts.Attempts {
 			return fmt.Errorf("%w: %v", fserrors.ErrTransientFailure, err)
 		}
+		sleep := jitter(wait)
 		if opts.OnRetry != nil {
-			opts.OnRetry(attempt+1, wait, err)
+			opts.OnRetry(attempt+1, sleep, err)
 		}
 		// Sleep, but honor ctx cancellation.
-		t := time.NewTimer(wait)
+		t := time.NewTimer(sleep)
 		select {
 		case <-t.C:
 		case <-ctx.Done():
 			t.Stop()
 			return ctx.Err()
 		}
+		// Grow the *nominal* schedule (1s, 3s, 9s…); jitter is re-applied
+		// to each sleep above, not compounded into the next interval.
 		wait *= 3
 		if wait > opts.Max {
 			wait = opts.Max
@@ -108,6 +113,17 @@ func WithBackoff(ctx context.Context, opts Options, isTransient func(error) bool
 	}
 	// Unreachable: the loop always returns inside the body.
 	return nil
+}
+
+// jitter applies equal jitter to a backoff interval: keep half, randomize
+// the other half, giving a sleep in [d/2, d]. Spreads a fleet's retries so
+// they don't all reconnect at the same instant after a shared outage.
+func jitter(d time.Duration) time.Duration {
+	if d <= 0 {
+		return d
+	}
+	half := d / 2
+	return half + time.Duration(rand.Int64N(int64(half)+1))
 }
 
 // IsTransient is the default classifier. An error is transient when


### PR DESCRIPTION
## Summary

Bundles the lower-severity audit findings into one reviewable PR (the must-fix items are separate: #65 toolchain, #66 fsync, #67 cosign).

## Changes

| Area | Finding | Fix |
|---|---|---|
| `internal/relay/server.go` | STUN responder was an unauthenticated ~2× amplifier with no throttle | Global fixed-window cap (1000/s) on binding replies. **Deliberately global, not per-source** — the source IP is spoofable, so a per-source map would itself be an unbounded-memory vector. + unit test |
| `cmd/fsend/sendpair.go` | `pairOverLAN` Accepted once → a LAN impostor that failed SPAKE2 killed the same-LAN fast path | Loop until the real receiver pairs or `pairCtx` ends, throttled (100 ms) so a wedged listener can't spin. Transfer still completes via the internet path meanwhile |
| `cmd/fsend/uninstall.go` + `fserrors` | `--uninstall` returned exit 0 when the binary couldn't be removed | New `ErrUninstallFailed` (E035) → non-zero exit, so scripts can tell a failed uninstall from a clean one |
| `internal/config/config.go` | `Load()` silently swallowed permission errors → custom server dropped to the public default with no hint | Route non-NotExist read errors into the existing warn-and-default path |
| `internal/retry/retry.go` | No jitter → fleet retries in lockstep against a shared relay | Equal jitter (`[d/2, d]`) per sleep; nominal schedule still grows 1s/3s/9s |
| `docs/*`, `pake.go` | "SPAKE2 (RFC 9382)" claim is inaccurate | **Verified against the gospake2 source**: it's the Abdalla–Pointcheval / python-spake2 construction (sha256 transcript), not the RFC 9382 wire encoding. Corrected in `security.md`, `comparison.md`, `pake.go`. Also noted in `usage.md` that the default skip trusts size+mtime without reading contents |

## Deliberately deferred (flagged for follow-up, not included)
- **Symlink escape check is lexical only** (`util.go`): hardening to `EvalSymlinks` / `openat2(RESOLVE_BENEATH)` is a riskier change to the write path that I couldn't validate without a multi-host/netns harness. Common cases are already closed by `SanitizeRelativePath`.
- **landisc goroutine leak on pion-mdns wedge**: needs an upstream pion fix or a redesign of the watchdog; the current code already downgrades the prior *hang* to a bounded leak.

These two warrant their own focused PRs with proper test harnesses rather than being rushed in here.

## Verification
```
$ go vet ./...                 # clean
$ go test -race ./...          # all 19 packages + e2e pass
$ go test ./internal/relay/... # incl. new TestAllowSTUNResponse_RateCap
```
`sh -n` / `shellcheck` n/a (no shell changes here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)