### PR TITLE
fix(transfer): bind stream I/O to context for prompt cancellation

### DIFF
--- a/internal/quicconn/quicconn.go
+++ b/internal/quicconn/quicconn.go
@@ -252,9 +252,11 @@ func ReceiverHandshake(ctx context.Context, c *quic.Conn, code string) (*AcceptR
 // shutdown contract.
 type streamCloser struct{ stream *quic.Stream }
 
-func (s *streamCloser) Read(p []byte) (int, error)  { return s.stream.Read(p) }
-func (s *streamCloser) Write(p []byte) (int, error) { return s.stream.Write(p) }
-func (s *streamCloser) Close() error                { return s.stream.Close() }
+func (s *streamCloser) Read(p []byte) (int, error)         { return s.stream.Read(p) }
+func (s *streamCloser) Write(p []byte) (int, error)        { return s.stream.Write(p) }
+func (s *streamCloser) Close() error                       { return s.stream.Close() }
+func (s *streamCloser) SetReadDeadline(t time.Time) error  { return s.stream.SetReadDeadline(t) }
+func (s *streamCloser) SetWriteDeadline(t time.Time) error { return s.stream.SetWriteDeadline(t) }
 
 // uniInCloser adapts a quic.ReceiveStream (read-only) to io.ReadWriteCloser.
 type uniInCloser struct{ s *quic.ReceiveStream }
@@ -263,16 +265,18 @@ func (u *uniInCloser) Read(p []byte) (int, error) { return u.s.Read(p) }
 func (u *uniInCloser) Write(_ []byte) (int, error) {
 	return 0, errors.New("quicconn: stream is receive-only")
 }
-func (u *uniInCloser) Close() error { u.s.CancelRead(0); return nil }
+func (u *uniInCloser) Close() error                      { u.s.CancelRead(0); return nil }
+func (u *uniInCloser) SetReadDeadline(t time.Time) error { return u.s.SetReadDeadline(t) }
 
 func wrapUniIn(s *quic.ReceiveStream) io.ReadWriteCloser { return &uniInCloser{s: s} }
 
 // uniOutCloser adapts a quic.SendStream (write-only) to io.ReadWriteCloser.
 type uniOutCloser struct{ s *quic.SendStream }
 
-func (u *uniOutCloser) Read(_ []byte) (int, error)  { return 0, io.EOF }
-func (u *uniOutCloser) Write(p []byte) (int, error) { return u.s.Write(p) }
-func (u *uniOutCloser) Close() error                { return u.s.Close() }
+func (u *uniOutCloser) Read(_ []byte) (int, error)         { return 0, io.EOF }
+func (u *uniOutCloser) Write(p []byte) (int, error)        { return u.s.Write(p) }
+func (u *uniOutCloser) Close() error                       { return u.s.Close() }
+func (u *uniOutCloser) SetWriteDeadline(t time.Time) error { return u.s.SetWriteDeadline(t) }
 
 func wrapUniOut(s *quic.SendStream) io.ReadWriteCloser { return &uniOutCloser{s: s} }
 

--- a/internal/transfer/ctxstream.go
+++ b/internal/transfer/ctxstream.go
@@ -1,0 +1,87 @@
+package transfer
+
+import (
+	"context"
+	"io"
+	"time"
+)
+
+// bindCtx makes a Streams pair promptly cancellable.
+//
+// QUIC reads/writes take no context, and the handshake deadline is cleared
+// once auth completes, so a blocked Read/Write only returns when the peer
+// responds or the connection's idle timeout (~30s) fires. Without this, a
+// Ctrl-C while the data loop is parked on a wedged peer or a stalled disk
+// isn't observed for up to that long.
+//
+// On cancel the watcher sets a past deadline on the data stream (both
+// directions) and the control read side, unblocking the parked call with a
+// deadline error; the returned ctxConn then reports it as ctx.Err() so the
+// loops surface a clean cancellation. The control *write* side is left alone
+// so the sender's best-effort cancel notification (notifyCancel) still
+// reaches the peer.
+//
+// Streams that don't expose deadlines (the io.Pipe pair used in tests) are
+// simply not interrupted — behavior there is unchanged from the per-loop
+// ctx.Err() checks. The returned stop func ends the watcher; callers defer it.
+func bindCtx(ctx context.Context, s *Streams) (*Streams, func()) {
+	done := make(chan struct{})
+	go func() {
+		select {
+		case <-ctx.Done():
+			past := time.Now()
+			setReadDeadline(s.Control, past)
+			setReadDeadline(s.Data, past)
+			setWriteDeadline(s.Data, past)
+		case <-done:
+		}
+	}()
+	wrapped := &Streams{
+		Control: &ctxConn{inner: s.Control, ctx: ctx},
+		Data:    &ctxConn{inner: s.Data, ctx: ctx},
+	}
+	return wrapped, func() { close(done) }
+}
+
+// ctxConn delegates to an underlying stream but reports ctx.Err() in place of
+// the deadline/IO error that bindCtx's watcher induces on cancellation, so a
+// cancelled transfer surfaces as context.Canceled rather than a transient
+// read/write failure that the retry layer might misclassify.
+type ctxConn struct {
+	inner io.ReadWriteCloser
+	ctx   context.Context
+}
+
+func (c *ctxConn) Read(p []byte) (int, error) {
+	n, err := c.inner.Read(p)
+	return n, c.cancelErr(err)
+}
+
+func (c *ctxConn) Write(p []byte) (int, error) {
+	n, err := c.inner.Write(p)
+	return n, c.cancelErr(err)
+}
+
+func (c *ctxConn) Close() error { return c.inner.Close() }
+
+func (c *ctxConn) cancelErr(err error) error {
+	if err != nil && c.ctx.Err() != nil {
+		return c.ctx.Err()
+	}
+	return err
+}
+
+type readDeadliner interface{ SetReadDeadline(time.Time) error }
+type writeDeadliner interface{ SetWriteDeadline(time.Time) error }
+
+func setReadDeadline(rw io.ReadWriteCloser, t time.Time) {
+	if d, ok := rw.(readDeadliner); ok {
+		_ = d.SetReadDeadline(t)
+	}
+}
+
+func setWriteDeadline(rw io.ReadWriteCloser, t time.Time) {
+	if d, ok := rw.(writeDeadliner); ok {
+		_ = d.SetWriteDeadline(t)
+	}
+}

--- a/internal/transfer/ctxstream_test.go
+++ b/internal/transfer/ctxstream_test.go
@@ -1,0 +1,80 @@
+package transfer
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"sync"
+	"testing"
+	"time"
+)
+
+// blockingStream models a QUIC stream whose Read parks until a (past)
+// deadline is set, then returns a timeout error — exactly the shape bindCtx
+// relies on to interrupt a wedged peer.
+type blockingStream struct {
+	once    sync.Once
+	unblock chan struct{}
+}
+
+func newBlockingStream() *blockingStream { return &blockingStream{unblock: make(chan struct{})} }
+
+func (b *blockingStream) Read([]byte) (int, error) {
+	<-b.unblock
+	return 0, os.ErrDeadlineExceeded
+}
+func (b *blockingStream) Write(p []byte) (int, error) { return len(p), nil }
+func (b *blockingStream) Close() error                { return nil }
+func (b *blockingStream) SetReadDeadline(time.Time) error {
+	b.once.Do(func() { close(b.unblock) })
+	return nil
+}
+func (b *blockingStream) SetWriteDeadline(time.Time) error { return nil }
+
+func TestBindCtx_UnblocksBlockedReadOnCancel(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	s := &Streams{Control: newBlockingStream(), Data: newBlockingStream()}
+	wrapped, stop := bindCtx(ctx, s)
+	defer stop()
+
+	errc := make(chan error, 1)
+	go func() {
+		_, err := wrapped.Data.Read(make([]byte, 8))
+		errc <- err
+	}()
+
+	cancel() // must interrupt the parked Read and surface ctx.Err()
+	select {
+	case err := <-errc:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("want context.Canceled, got %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read did not unblock within 2s of cancel")
+	}
+}
+
+// errStream returns a fixed error on Read so we can check ctxConn's error
+// remapping in both ctx states.
+type errStream struct{ err error }
+
+func (e errStream) Read([]byte) (int, error)    { return 0, e.err }
+func (e errStream) Write(p []byte) (int, error) { return len(p), nil }
+func (e errStream) Close() error                { return nil }
+
+func TestCtxConn_PassesThroughErrorWhenNotCancelled(t *testing.T) {
+	c := &ctxConn{inner: errStream{err: io.EOF}, ctx: context.Background()}
+	if _, err := c.Read(make([]byte, 1)); !errors.Is(err, io.EOF) {
+		t.Fatalf("want io.EOF passed through, got %v", err)
+	}
+}
+
+func TestCtxConn_RemapsErrorWhenCancelled(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	c := &ctxConn{inner: errStream{err: io.ErrUnexpectedEOF}, ctx: ctx}
+	if _, err := c.Read(make([]byte, 1)); !errors.Is(err, context.Canceled) {
+		t.Fatalf("want context.Canceled, got %v", err)
+	}
+}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -66,6 +66,11 @@ type ClassifiedEntry struct {
 
 // Recv executes the full receiver-side protocol over the supplied streams.
 func Recv(ctx context.Context, s *Streams, opts RecvOptions) error {
+	// Bind the streams to ctx so a Ctrl-C parked in a blocked QUIC read
+	// unblocks promptly instead of waiting out the idle timeout.
+	s, stop := bindCtx(ctx, s)
+	defer stop()
+
 	var hello wire.SenderHello
 	ft, err := wire.ReadControl(s.Control, &hello)
 	if err != nil {

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -52,6 +52,12 @@ func Send(ctx context.Context, s *Streams, opts SendOptions) error {
 }
 
 func send(ctx context.Context, s *Streams, opts SendOptions) error {
+	// Bind the streams to ctx so a Ctrl-C parked in a blocked QUIC write
+	// unblocks promptly instead of waiting out the idle timeout. notifyCancel
+	// (called by the outer Send with the raw, unwrapped streams) is unaffected.
+	s, stop := bindCtx(ctx, s)
+	defer stop()
+
 	hello := &wire.SenderHello{
 		ProtocolVersion: wire.ProtocolVersion,
 		Hostname:        opts.Hostname,


### PR DESCRIPTION
## Summary

Closes the highest-value robustness finding from the second audit: **Ctrl-C during a transfer could feel hung for up to ~30s.**

QUIC reads/writes take no `context`, and the handshake deadline is cleared once auth completes (`quicconn.go`). The transfer loops check `ctx.Err()` only at the *top* of each iteration, so a cancel while parked inside `WriteChunk`/`ReadChunk` against a wedged peer or a stalled disk wasn't observed until the connection's idle timeout (~30s) fired.

## Approach
New `internal/transfer/ctxstream.go`:
- **`bindCtx`** installs a watcher that, on `ctx.Done()`, sets a **past deadline** on the data stream (both directions) and the control **read** side — unblocking any parked call.
- **`ctxConn`** wraps each stream and reports the resulting deadline error as `ctx.Err()`, so a cancelled transfer surfaces as `context.Canceled` (→ exit 130, treated as terminal by the retry layer) instead of a transient I/O error.
- The control **write** side is deliberately left un-deadlined so the sender's best-effort `notifyCancel` still reaches the peer; its `io.Copy` Control drain now returns promptly instead of hanging too.
- Streams without deadline support (the `io.Pipe` pair in tests) are simply not interrupted — behavior there is unchanged.

The QUIC wrappers (`streamCloser`, `uniInCloser`, `uniOutCloser`) gain `SetReadDeadline`/`SetWriteDeadline` delegating to the underlying quic-go streams.

## Tests
New `ctxstream_test.go`:
- `TestBindCtx_UnblocksBlockedReadOnCancel` — a parked Read returns `context.Canceled` within 2s of cancel (was: never, until idle timeout).
- `TestCtxConn_PassesThroughErrorWhenNotCancelled` / `...RemapsErrorWhenCancelled` — error remapping only fires under cancellation.

## Verification
```
$ go vet ./...                        # clean
$ go test -race ./...                 # all 19 packages + e2e pass
$ go test -race -run TestSignal ./test/e2e/...   # real-QUIC cancel paths pass
```

Scoped to a *process unblocking its own ctx-cancelled I/O* (the finding). Cross-process receiver-retry latency when the *peer* vanishes is a separate concern, unchanged here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)