### PR TITLE
fix(server): panic recovery, graceful relay drain, honest health

### DIFF
--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -144,11 +145,47 @@ func runServer() error {
 		}
 	}
 
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 5*time.Second)
+	// Graceful shutdown: stop new relay allocations, then let in-flight HTTP
+	// (including 25s /wait long-polls) and in-flight relay transfers finish
+	// before tearing down. Both are bounded by shutdownGrace so a wedged
+	// session can't block shutdown forever; the container's stop_grace_period
+	// must exceed it (the compose file sets 35s).
+	relaySrv.Drain()
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownGrace)
 	defer shutdownCancel()
-	_ = httpSrv.Shutdown(shutdownCtx)
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() { defer wg.Done(); _ = httpSrv.Shutdown(shutdownCtx) }()
+	go func() { defer wg.Done(); drainRelay(shutdownCtx, relaySrv, logger) }()
+	wg.Wait()
 	cancel()
 	return nil
+}
+
+// shutdownGrace bounds graceful shutdown. Set above the 25s /wait long-poll so
+// in-flight polls return naturally rather than being severed; the deployment's
+// stop_grace_period must exceed it.
+const shutdownGrace = 30 * time.Second
+
+// drainRelay blocks until no relay transfer has moved bytes recently (so the
+// socket can close without cutting an in-flight transfer) or ctx expires. It
+// returns immediately when the relay is idle, so a quiet server still restarts
+// fast.
+func drainRelay(ctx context.Context, r *relay.Server, logger *slog.Logger) {
+	t := time.NewTicker(250 * time.Millisecond)
+	defer t.Stop()
+	for {
+		if n := r.ActiveAllocations(); n == 0 {
+			return
+		} else if ctx.Err() != nil {
+			logger.Warn("relay drain deadline reached; dropping active sessions", "active", n)
+			return
+		}
+		select {
+		case <-ctx.Done():
+		case <-t.C:
+		}
+	}
 }
 
 // serverRuntimeConfig is the parsed environment for `fsend server`.

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -222,3 +222,35 @@ func TestAllowSTUNResponse_RateCap(t *testing.T) {
 		t.Fatal("expected allow after window rollover")
 	}
 }
+
+func TestServer_DrainRejectsNewAllocations(t *testing.T) {
+	srv := NewServer(nil, ServerConfig{})
+	if _, err := srv.Allocate(); err != nil {
+		t.Fatalf("allocate before drain: %v", err)
+	}
+	srv.Drain()
+	if _, err := srv.Allocate(); err == nil {
+		t.Fatal("Allocate after Drain should be rejected")
+	}
+}
+
+func TestServer_HealthyByDefault(t *testing.T) {
+	if !NewServer(nil, ServerConfig{}).Healthy() {
+		t.Fatal("a fresh relay should report healthy")
+	}
+}
+
+func TestServer_ActiveAllocationsCountsLiveSessions(t *testing.T) {
+	srv := NewServer(nil, ServerConfig{})
+	if n := srv.ActiveAllocations(); n != 0 {
+		t.Fatalf("active = %d, want 0", n)
+	}
+	if _, err := srv.Allocate(); err != nil {
+		t.Fatal(err)
+	}
+	// A freshly-allocated session has lastActivity = now, so it counts as
+	// in-flight for drain purposes.
+	if n := srv.ActiveAllocations(); n != 1 {
+		t.Fatalf("active = %d, want 1", n)
+	}
+}

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -40,7 +40,20 @@ type Server struct {
 	stunMu     sync.Mutex
 	stunWindow time.Time
 	stunCount  int
+
+	// healthy is true while the read loop is forwarding; it flips false if
+	// Run exits on a real socket error (not a graceful ctx cancel) so the
+	// signaling layer's /v1/health can report the zombie instead of lying.
+	healthy atomic.Bool
+	// draining rejects new allocations during graceful shutdown so the drain
+	// can converge while in-flight sessions finish.
+	draining atomic.Bool
 }
+
+// activeWindow bounds how recently an allocation must have forwarded a
+// datagram to count as in-flight for drain purposes. Long enough to span
+// QUIC's pacing gaps, short enough that drain converges once transfers stop.
+const activeWindow = 3 * time.Second
 
 // stunResponsesPerSec caps aggregate STUN binding replies. A few dozen
 // small packets per pairing is plenty for ICE gathering, so this leaves
@@ -106,13 +119,40 @@ type allocation struct {
 // lifecycle except for Close in Stop.
 func NewServer(conn net.PacketConn, cfg ServerConfig) *Server {
 	cfg.Default()
-	return &Server{
+	s := &Server{
 		conn:      conn,
 		cfg:       cfg,
 		logger:    cfg.Logger,
 		allocs:    make(map[Token]*allocation),
 		tombstone: make(map[Token]tombstoneEntry),
 	}
+	s.healthy.Store(true) // assume up until Run proves otherwise
+	return s
+}
+
+// Healthy reports whether the relay read loop is still forwarding. It flips
+// false only when Run exits on a real socket error, so /v1/health can surface
+// a dead relay rather than reporting a healthy zombie.
+func (s *Server) Healthy() bool { return s.healthy.Load() }
+
+// Drain stops the relay from accepting new allocations so a graceful shutdown
+// can wait for existing in-flight sessions to finish before the socket closes.
+func (s *Server) Drain() { s.draining.Store(true) }
+
+// ActiveAllocations counts sessions that forwarded a datagram within
+// activeWindow — i.e. transfers currently moving bytes. Idle reservations
+// (allocated but unused) don't block a drain.
+func (s *Server) ActiveAllocations() int {
+	cutoff := time.Now().Add(-activeWindow).UnixNano()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	n := 0
+	for _, a := range s.allocs {
+		if a.lastActivity.Load() >= cutoff {
+			n++
+		}
+	}
+	return n
 }
 
 // MaxBytesPerSession exposes the configured byte ceiling so the
@@ -142,6 +182,9 @@ func (s *Server) Status(t Token) string {
 // in their datagrams. Called from the signaling layer's
 // POST /v1/relay/allocate handler.
 func (s *Server) Allocate() (Token, error) {
+	if s.draining.Load() {
+		return Token{}, errors.New("relay: server is draining")
+	}
 	var t Token
 	if _, err := rand.Read(t[:]); err != nil {
 		return Token{}, fmt.Errorf("relay: token rand: %w", err)
@@ -182,14 +225,29 @@ func (s *Server) Run(ctx context.Context) error {
 			if ctx.Err() != nil {
 				return nil
 			}
-			// Other read errors (e.g. socket closed): bail out.
+			// Other read errors (e.g. socket closed): the relay is dead.
+			// Flag it so /v1/health stops reporting a healthy zombie.
+			s.healthy.Store(false)
 			return fmt.Errorf("relay: read: %w", err)
 		}
 		// Process inline — no goroutine per datagram (would be massive
-		// overhead). Forward is one syscall.
-		s.handle(buf[:n], addr.(*net.UDPAddr))
+		// overhead). Forward is one syscall. Recover per datagram so a
+		// crafted packet that trips a panic in handle can't take the whole
+		// server down with it.
+		s.handleSafe(buf[:n], addr.(*net.UDPAddr))
 		bufPool.Put(bufPtr)
 	}
+}
+
+// handleSafe runs handle with panic recovery so one malformed datagram can
+// never crash the whole server (and every other live session with it).
+func (s *Server) handleSafe(datagram []byte, src *net.UDPAddr) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Error("relay: recovered panic handling datagram", "panic", r)
+		}
+	}()
+	s.handle(datagram, src)
 }
 
 func (s *Server) handle(datagram []byte, src *net.UDPAddr) {
@@ -319,27 +377,38 @@ func (s *Server) janitor(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case now := <-t.C:
-			cutoff := now.Add(-sessionIdleTimeout).UnixNano()
-			nowNanos := now.UnixNano()
-			s.mu.Lock()
-			for tok, a := range s.allocs {
-				if a.lastActivity.Load() < cutoff {
-					delete(s.allocs, tok)
-					s.tombstone[tok] = tombstoneEntry{
-						reason:    ReasonIdle,
-						expiresAt: now.Add(TombstoneTTL).UnixNano(),
-					}
-				}
+			s.sweep(now)
+		}
+	}
+}
+
+// sweep evicts idle allocations and expired tombstones. Wrapped in panic
+// recovery so a bug here can't silently kill the janitor goroutine and let
+// the maps grow unbounded.
+func (s *Server) sweep(now time.Time) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Error("relay: recovered panic in janitor", "panic", r)
+		}
+	}()
+	cutoff := now.Add(-sessionIdleTimeout).UnixNano()
+	nowNanos := now.UnixNano()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for tok, a := range s.allocs {
+		if a.lastActivity.Load() < cutoff {
+			delete(s.allocs, tok)
+			s.tombstone[tok] = tombstoneEntry{
+				reason:    ReasonIdle,
+				expiresAt: now.Add(TombstoneTTL).UnixNano(),
 			}
-			// Expire tombstones by per-entry age — no bulk-wipe, so a
-			// burst of evictions can't blind every subsequent status
-			// lookup.
-			for tok, entry := range s.tombstone {
-				if entry.expiresAt < nowNanos {
-					delete(s.tombstone, tok)
-				}
-			}
-			s.mu.Unlock()
+		}
+	}
+	// Expire tombstones by per-entry age — no bulk-wipe, so a burst of
+	// evictions can't blind every subsequent status lookup.
+	for tok, entry := range s.tombstone {
+		if entry.expiresAt < nowNanos {
+			delete(s.tombstone, tok)
 		}
 	}
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -332,9 +332,20 @@ func (s *Server) StartJanitor(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case now := <-t.C:
-			s.evict(now)
+			s.evictSafe(now)
 		}
 	}
+}
+
+// evictSafe runs one eviction sweep with panic recovery, so a bug in evict
+// can't silently kill the janitor and let the session maps grow unbounded.
+func (s *Server) evictSafe(now time.Time) {
+	defer func() {
+		if r := recover(); r != nil {
+			s.cfg.Logger.Error("recovered panic in session janitor", "panic", r)
+		}
+	}()
+	s.evict(now)
 }
 
 func (s *Server) evict(now time.Time) {
@@ -385,8 +396,15 @@ func (s *Server) evict(now time.Time) {
 }
 
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
-	writeJSON(w, http.StatusOK, HealthResponse{
-		Status:        "ok",
+	status, code := "ok", http.StatusOK
+	// If a relay is wired and its read loop has died, report the degradation
+	// so an orchestrator restarts the container instead of trusting a zombie
+	// that still hands out relay tokens for a relay that forwards nothing.
+	if h, ok := s.relayAllocator.(interface{ Healthy() bool }); ok && !h.Healthy() {
+		status, code = "degraded", http.StatusServiceUnavailable
+	}
+	writeJSON(w, code, HealthResponse{
+		Status:        status,
 		Version:       s.cfg.ServerVersion,
 		UptimeSeconds: int64(time.Since(s.started).Seconds()),
 	})

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -483,11 +483,36 @@ type fakeRelay struct {
 	tok      relay.Token
 	reason   string
 	maxBytes uint64
+	dead     bool
 }
 
 func (f *fakeRelay) Allocate() (relay.Token, error) { return f.tok, nil }
 func (f *fakeRelay) Status(t relay.Token) string    { return f.reason }
 func (f *fakeRelay) MaxBytesPerSession() uint64     { return f.maxBytes }
+func (f *fakeRelay) Healthy() bool                  { return !f.dead }
+
+// /v1/health must flip to 503/degraded once the relay read loop has died,
+// so an orchestrator restarts the container instead of trusting a zombie.
+func TestHealth_DegradedWhenRelayDead(t *testing.T) {
+	s := New(Config{ServerVersion: "0.0.0-test"})
+	s.WithRelay(&fakeRelay{dead: true}, 443)
+	srv := httptest.NewServer(s.Handler())
+	t.Cleanup(srv.Close)
+
+	resp, err := http.Get(srv.URL + "/v1/health")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("status = %d, want 503", resp.StatusCode)
+	}
+	var h HealthResponse
+	_ = json.NewDecoder(resp.Body).Decode(&h)
+	if h.Status != "degraded" {
+		t.Fatalf("status = %q, want degraded", h.Status)
+	}
+}
 
 // /v1/relay/status must echo back the operator-set byte ceiling so the
 // CLI can render a concrete error ("server limit 100 MB") instead of a


### PR DESCRIPTION
## Summary

Closes three server-operability gaps from the second audit that would page an on-call engineer running the pairing/relay server as infrastructure. **Code only** — the Docker-as-root hardening was intentionally dropped from this PR.

## Changes

**1. Panic recovery (`recover()` was nowhere in non-test code)**
The relay read loop, the relay janitor, and the signaling janitor ran in bare goroutines. A panic in any of them — e.g. a future nil-deref on a crafted datagram — took the **whole process** down, every healthy session with it (`net/http` only recovers per-request handlers). Each now recovers and logs:
- `relay.handleSafe` wraps per-datagram handling.
- `relay.sweep` (extracted from the janitor) recovers per tick.
- `server.evictSafe` recovers the signaling janitor per tick.

**2. Graceful relay drain on shutdown**
SIGTERM previously hard-killed in-flight relay transfers, and the HTTP shutdown timeout (5s) was *shorter* than the 25s `/wait` long-poll. Now: `relaySrv.Drain()` stops new allocations, then HTTP shutdown and a relay drain run concurrently under a single 30s budget. The drain waits for sessions that moved bytes within `activeWindow` (3s) and returns immediately when idle — so a quiet server still restarts fast.

**3. Honest health**
`/v1/health` always returned 200, even with a dead relay loop — a zombie still handing out relay tokens. The relay now tracks liveness (`healthy` flips false only on a *real* socket error, not a graceful ctx cancel), and `/v1/health` returns `503`/`"degraded"` so the Docker healthcheck (`--health-check`) restarts the container.

## Tests
- `server`: `TestHealth_DegradedWhenRelayDead` (503 + `"degraded"`).
- `relay`: drain rejects new allocations, healthy-by-default, active-allocation count.

## Verification
```
$ go vet ./...            # clean
$ go test -race ./...     # all 19 packages + e2e pass
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)