### PR TITLE
test+fix: harden against malicious peer input (negotiation cap, fuzzing)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -61,6 +61,21 @@ jobs:
       - run: go install golang.org/x/vuln/cmd/govulncheck@latest
       - run: govulncheck ./...
 
+  # Bounded fuzzing of the parsers most exposed to a malicious peer (the wire
+  # codec and the path sanitizer). Seed corpora also run in the normal test
+  # job; this explores beyond them for a fixed budget.
+  fuzz:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache: true
+      - run: go test -run '^$' -fuzz='^FuzzReadControlRaw$' -fuzztime=30s ./internal/wire/
+      - run: go test -run '^$' -fuzz='^FuzzReadChunk$' -fuzztime=30s ./internal/wire/
+      - run: go test -run '^$' -fuzz='^FuzzSanitizeRelativePath$' -fuzztime=30s ./internal/transfer/
+
   deadcode:
     runs-on: ubuntu-latest
     steps:

--- a/internal/transfer/engine_security_test.go
+++ b/internal/transfer/engine_security_test.go
@@ -216,3 +216,38 @@ func TestVersionMismatch_SenderReportsClearly(t *testing.T) {
 	_ = ctrlB.Close()
 	_ = dataB.Close()
 }
+
+// A hostile receiver must not be able to grow the sender's decision map past
+// the number of entries it actually sent.
+func TestSenderNegotiate_RejectsExcessDecisions(t *testing.T) {
+	ctrlA, ctrlB := net.Pipe()
+	sender := &Streams{Control: ctrlA}
+	sources := []Source{
+		{Entry: wire.ListingEntry{Index: 0}},
+		{Entry: wire.ListingEntry{Index: 1}},
+	}
+
+	res := make(chan error, 1)
+	go func() {
+		_, err := senderNegotiate(sender, sources)
+		res <- err
+	}()
+	go func() { _, _ = io.Copy(io.Discard, ctrlB) }() // drain any sender writes
+
+	batch := make([]wire.Decision, 0, 100)
+	for i := uint32(0); i < 100; i++ {
+		batch = append(batch, wire.Decision{Index: i, Action: wire.DecisionSend})
+	}
+	if err := wire.WriteControl(ctrlB, wire.TypeClassifyBatch, batch); err != nil {
+		t.Fatalf("write batch: %v", err)
+	}
+
+	select {
+	case err := <-res:
+		if !errors.Is(err, fserrors.ErrProtocolError) {
+			t.Fatalf("want ErrProtocolError, got %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("senderNegotiate did not reject excess decisions")
+	}
+}

--- a/internal/transfer/fuzz_test.go
+++ b/internal/transfer/fuzz_test.go
@@ -1,0 +1,108 @@
+package transfer
+
+import (
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// FuzzSanitizeRelativePath hammers the anti-traversal gate with arbitrary
+// peer-supplied path strings. Any path it *accepts* must be safe to join under
+// a target directory: relative, no volume, no ".." segment, and provably
+// inside the root. Anything it rejects is fine. It must never panic.
+func FuzzSanitizeRelativePath(f *testing.F) {
+	for _, s := range []string{
+		"", ".", "a", "a/b/c", "a/../b", "a/b/..", "a/./b",
+		"../escape", "a/../../escape", "/abs", `\abs`,
+		`C:\windows`, `c:/windows`, `\\unc\share`, "//unc/share",
+		"föö/bär", "a\x00b", "....//", "..",
+	} {
+		f.Add(s)
+	}
+	absRoot, err := filepath.Abs("fuzzroot")
+	if err != nil {
+		f.Fatal(err)
+	}
+	f.Fuzz(func(t *testing.T, p string) {
+		out, err := SanitizeRelativePath(p)
+		if err != nil {
+			return // rejection is always acceptable
+		}
+		if filepath.IsAbs(out) {
+			t.Fatalf("accepted absolute result %q from %q", out, p)
+		}
+		if filepath.VolumeName(out) != "" {
+			t.Fatalf("accepted volume name in %q from %q", out, p)
+		}
+		for _, part := range strings.Split(out, string(filepath.Separator)) {
+			if part == ".." {
+				t.Fatalf("accepted .. segment in %q from %q", out, p)
+			}
+		}
+		// The security property: joined under a target dir, an accepted path
+		// must never resolve outside it. (Precise prefix-boundary check — not
+		// pathIsUnder, whose ".." prefix test over-matches dotted filenames
+		// like "...." that are legitimate, in-bounds names.)
+		joined := filepath.Join(absRoot, out)
+		if joined != absRoot && !strings.HasPrefix(joined, absRoot+string(filepath.Separator)) {
+			t.Fatalf("sanitized %q -> %q escapes the root (%q)", p, out, joined)
+		}
+	})
+}
+
+// TestPathIsUnder covers the escape check, including filenames that merely
+// start with two dots (a legitimate in-bounds case the old prefix test wrongly
+// flagged as traversal).
+func TestPathIsUnder(t *testing.T) {
+	root, err := filepath.Abs("root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	cases := []struct {
+		child string
+		want  bool
+	}{
+		{root, true},
+		{filepath.Join(root, "a", "b"), true},
+		{filepath.Join(root, "..data"), true},        // dotted filename, not a traversal
+		{filepath.Join(root, "..config", "x"), true}, // k8s-style nested
+		{filepath.Join(root, "...."), true},
+		{filepath.Join(root, "..", "etc"), false}, // real traversal
+		{filepath.Dir(root), false},               // parent is not under root
+	}
+	for _, tc := range cases {
+		if got := pathIsUnder(tc.child, root); got != tc.want {
+			t.Errorf("pathIsUnder(%q, %q) = %v, want %v", tc.child, root, got, tc.want)
+		}
+	}
+}
+
+// TestSymlinkEscapes pins the guard that stops a malicious sender from planting
+// a symlink that resolves outside the target dir — a classic transfer RCE
+// vector with no negative coverage before this.
+func TestSymlinkEscapes(t *testing.T) {
+	absTarget := "/etc/passwd"
+	if runtime.GOOS == "windows" {
+		absTarget = `C:\Windows\System32\drivers\etc\hosts`
+	}
+	cases := []struct {
+		name, relPath, linkTarget string
+		want                      bool
+	}{
+		{"absolute target", "link", absTarget, true},
+		{"climbs above root", "link", "../../../etc", true},
+		{"deep climb", "a/b/link", "../../../../etc", true},
+		{"in-bounds sibling", "a/b/link", "../c", false},
+		{"in-bounds same dir", "a/link", "c", false},
+		{"in-bounds nested", "link", "sub/file", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := symlinkEscapes("/target", tc.relPath, tc.linkTarget); got != tc.want {
+				t.Fatalf("symlinkEscapes(/target, %q, %q) = %v, want %v",
+					tc.relPath, tc.linkTarget, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -166,6 +166,7 @@ func senderNegotiate(s *Streams, sources []Source) (map[uint32]wire.Decision, er
 		byIndex[src.Entry.Index] = src.AbsPath
 	}
 	out := make(map[uint32]wire.Decision)
+	hashed := make(map[uint32][32]byte) // hash each file at most once per session
 	for {
 		ft, body, err := wire.ReadControlRaw(s.Control)
 		if err != nil {
@@ -183,9 +184,14 @@ func senderNegotiate(s *Streams, sources []Source) (map[uint32]wire.Decision, er
 				if !ok || p == "" {
 					continue
 				}
-				h, err := hashFileRoot(p)
-				if err != nil {
-					return nil, fmt.Errorf("%w: hash %s: %v", fserrors.ErrReadFailed, p, err)
+				// Cache so a replayed VERIFY_REQUEST can't make a hostile peer
+				// re-hash the same files indefinitely. Bounded by len(sources).
+				h, done := hashed[i]
+				if !done {
+					if h, err = hashFileRoot(p); err != nil {
+						return nil, fmt.Errorf("%w: hash %s: %v", fserrors.ErrReadFailed, p, err)
+					}
+					hashed[i] = h
 				}
 				resp = append(resp, wire.FileHash{Index: i, Hash: h})
 			}
@@ -199,6 +205,12 @@ func senderNegotiate(s *Streams, sources []Source) (map[uint32]wire.Decision, er
 			}
 			for _, d := range batch {
 				out[d.Index] = d
+			}
+			// A well-behaved receiver returns at most one decision per entry we
+			// sent. More means a malformed or hostile peer trying to grow the
+			// map unbounded — the listing path is capped, so cap this too.
+			if len(out) > len(sources) {
+				return nil, fmt.Errorf("%w: more decisions than entries sent", fserrors.ErrProtocolError)
 			}
 		case wire.TypeClassifyEnd:
 			return out, nil

--- a/internal/transfer/util.go
+++ b/internal/transfer/util.go
@@ -47,7 +47,14 @@ func pathIsUnder(child, parent string) bool {
 	if rel == "." {
 		return true
 	}
-	return !strings.HasPrefix(rel, "..") && !filepath.IsAbs(rel)
+	// A leading ".." is a real escape only when it is the ".." element itself
+	// (rel == ".." or "../…"), not a filename that merely starts with two dots
+	// — e.g. "..data", which Kubernetes secret mounts create. The old
+	// HasPrefix(rel, "..") test rejected those legitimate in-bounds names.
+	if rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return false
+	}
+	return !filepath.IsAbs(rel)
 }
 
 // symlinkEscapes reports whether placing a symlink at <targetDir>/<relPath>

--- a/internal/wire/fuzz_test.go
+++ b/internal/wire/fuzz_test.go
@@ -1,0 +1,39 @@
+package wire
+
+import (
+	"bytes"
+	"testing"
+)
+
+// FuzzReadControlRaw drives the control-frame parser with arbitrary bytes a
+// malicious peer could send. The contract: reject with an error, never panic
+// or hang. The seed corpus also runs during a normal `go test`.
+func FuzzReadControlRaw(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add([]byte{0x02})
+	var buf bytes.Buffer
+	if err := WriteControl(&buf, TypeHello, &SenderHello{ProtocolVersion: ProtocolVersion}); err == nil {
+		f.Add(buf.Bytes())
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _, _ = ReadControlRaw(bytes.NewReader(data))
+	})
+}
+
+// FuzzReadChunk drives the data-chunk parser the same way — this is the parser
+// that runs once per chunk on every byte a peer sends.
+func FuzzReadChunk(f *testing.F) {
+	f.Add([]byte(nil))
+	f.Add([]byte{0x00, 0x00, 0x00, 0x00})
+	var buf bytes.Buffer
+	seed := &Chunk{
+		Segments: []Segment{{FileIndex: 0, Length: 3, EOF: true}},
+		Payload:  []byte("abc"),
+	}
+	if err := WriteChunk(&buf, seed); err == nil {
+		f.Add(buf.Bytes())
+	}
+	f.Fuzz(func(t *testing.T, data []byte) {
+		_, _ = ReadChunk(bytes.NewReader(data))
+	})
+}


### PR DESCRIPTION
## Summary

Implements the two "harden against malicious input" items from the audit. Closes the last concrete robustness bug and earns the "tested against a hostile peer" claim. Hardlinks are deliberately left for a future PR.

## #1 — Bound the negotiation loop
`senderNegotiate` accumulated a `map[uint32]Decision` with **no cap**, so a hostile receiver could trickle distinct-index decision batches forever and grow it unbounded (the listing path is capped; this wasn't). Now:
- Capped at `len(sources)` — a receiver can't return more decisions than entries it was sent.
- Verify hashes are cached, so a replayed `VERIFY_REQUEST` can't make the sender re-hash the same files indefinitely.

Covered by `TestSenderNegotiate_RejectsExcessDecisions`.

## #2 — Fuzz the untrusted parsers (there was none)
- `FuzzReadControlRaw`, `FuzzReadChunk` — the wire codec that parses every byte a peer sends.
- `FuzzSanitizeRelativePath` — the anti-traversal gate.
- `TestSymlinkEscapes` — first negative coverage for the symlink escape guard.
- A bounded `fuzz` CI job (30s/target). Seed corpora also run in the normal test job.

Millions of execs found **no panic** in the parsers.

## Bonus: a real bug the fuzz surfaced
The sanitizer fuzz flagged that `pathIsUnder` (the defense-in-depth escape check used by `classify` and `symlinkEscapes`) used `HasPrefix(rel, "..")`, which wrongly rejected legitimate filenames that merely *start* with two dots — e.g. **`..data`, which Kubernetes secret/configmap mounts create**. Such a tree would fail to transfer. Fixed to match only the actual `..` path element; strictly security-preserving (real `../` traversals still rejected), with `TestPathIsUnder` covering both.

## Verification
```
$ go vet ./...                                   # clean
$ go test -race ./...                            # all 19 packages + e2e pass
$ go test -fuzz=FuzzSanitizeRelativePath -fuzztime=30s   # 7.1M execs, no escape
$ go test -fuzz=FuzzReadControlRaw / FuzzReadChunk        # no panic
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)