### PR TITLE
ci: use execution-count fuzz budgets to kill deadline flake

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -64,6 +64,11 @@ jobs:
   # Bounded fuzzing of the parsers most exposed to a malicious peer (the wire
   # codec and the path sanitizer). Seed corpora also run in the normal test
   # job; this explores beyond them for a fixed budget.
+  #
+  # Budgets are execution counts (Nx), not wall-clock: a duration -fuzztime
+  # races the coordinator's deadline against in-flight workers on a loaded
+  # runner, surfacing a spurious "context deadline exceeded" failure. Counts
+  # are sized to roughly a 30s explore on a slow runner.
   fuzz:
     runs-on: ubuntu-latest
     steps:
@@ -72,9 +77,9 @@ jobs:
         with:
           go-version: "1.26"
           cache: true
-      - run: go test -run '^$' -fuzz='^FuzzReadControlRaw$' -fuzztime=30s ./internal/wire/
-      - run: go test -run '^$' -fuzz='^FuzzReadChunk$' -fuzztime=30s ./internal/wire/
-      - run: go test -run '^$' -fuzz='^FuzzSanitizeRelativePath$' -fuzztime=30s ./internal/transfer/
+      - run: go test -run '^$' -fuzz='^FuzzReadControlRaw$' -fuzztime=2000000x ./internal/wire/
+      - run: go test -run '^$' -fuzz='^FuzzReadChunk$' -fuzztime=200000x ./internal/wire/
+      - run: go test -run '^$' -fuzz='^FuzzSanitizeRelativePath$' -fuzztime=1000000x ./internal/transfer/
 
   deadcode:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

The `fuzz` job failed on `main` ([run 27966087733](https://github.com/polius/fsend/actions/runs/27966087733/job/82760155832)) with:

```
--- FAIL: FuzzSanitizeRelativePath (30.84s)
    context deadline exceeded
```

This is **not** a crashing or hanging input — `SanitizeRelativePath` is purely linear in input length, no failing-input corpus file was written, and the test passes locally on every run (6.7M execs in 30s vs CI's 1.4M on a heavily loaded shared runner).

It's the well-known Go fuzzing flake: with a **duration**-based `-fuzztime`, the coordinator's deadline races in-flight workers. On a slow/loaded runner a worker is still mid-execution when the deadline fires, and its cancelled context surfaces as a spurious `context deadline exceeded` failure instead of a clean stop.

## Fix

Switch all three fuzz steps from wall-clock to **execution-count** budgets (`Nx`). A count has no time-based cancellation to race, so the flake can't occur. Counts are sized to roughly the prior ~30s explore on a slow runner (per-target, since throughput varies ~40× between `FuzzReadChunk` and the others).

All three pass locally with the new budgets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)