### PR TITLE
fix: prevent STUN/QUIC demux collision dropping large transfers

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -391,7 +391,7 @@ func dialRelay(alloc *server.RelayAllocateResponse) (net.PacketConn, error) {
 // attempt resume mid-file — the sender verifies the prefix, seeks past
 // it, and streams the remainder.
 func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code string, pathInfo connpath.Info) error {
-	tr := &quic.Transport{Conn: pc}
+	tr := quicconn.NewTransport(pc)
 	defer func() { _ = tr.Close() }()
 
 	outDir, sink, err := resolveOutDir(f)

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -369,7 +369,7 @@ func senderQUICAccept(ctx context.Context, pc net.PacketConn, code string) (*qui
 		_ = pc.Close()
 		return nil, nil, nil, err
 	}
-	tr := &quic.Transport{Conn: pc}
+	tr := quicconn.NewTransport(pc)
 	ln, err := tr.Listen(tlsCfg, quicconn.QuicConfig())
 	if err != nil {
 		_ = tr.Close()

--- a/internal/quicconn/connid.go
+++ b/internal/quicconn/connid.go
@@ -1,0 +1,81 @@
+package quicconn
+
+import (
+	"crypto/rand"
+	"encoding/binary"
+	"net"
+
+	"github.com/quic-go/quic-go"
+)
+
+// stunMagicCookie is the 32-bit constant every STUN message carries at
+// byte offset 4 (RFC 5389 §6).
+//
+// pion/ice multiplexes STUN connectivity checks and application data on a
+// single socket and tells them apart with stun.IsMessage, which checks
+// *only* len>=20 && bytes[4:8]==cookie — it ignores the QUIC header bits.
+// So any QUIC datagram whose bytes 4..7 happen to equal this value is
+// misread as a stray STUN packet, and ice.Conn.Write rejects it with
+// "failed to write STUN message to ICE connection", tearing the
+// connection down mid-transfer. The per-packet odds are ~2^-32, but over
+// the tens of millions of datagrams in a multi-GB transfer that becomes a
+// real, if rare, failure.
+const stunMagicCookie = 0x2112A442
+
+// connIDLen is the length of the connection IDs we issue. A QUIC
+// short-header (1-RTT) packet is [flags:1][DCID:connIDLen][...], so packet
+// bytes 4..7 — the exact span stun.IsMessage inspects — fall wholly inside
+// the destination connection ID once connIDLen >= 7. We use 8 (vs
+// quic-go's default 4) so those four bytes live in a stable field we
+// control, letting GenerateConnectionID guarantee they never spell the
+// cookie. The four extra header bytes per packet are negligible.
+const connIDLen = 8
+
+// placesMagicCookie reports whether a packet carrying id as its
+// destination connection ID would expose the STUN magic cookie at the
+// bytes stun.IsMessage checks — packet offset 4..7, which is id[3:7].
+func placesMagicCookie(id []byte) bool {
+	return len(id) >= 7 && binary.BigEndian.Uint32(id[3:7]) == stunMagicCookie
+}
+
+// stunSafeConnIDGenerator issues random connection IDs that can never put
+// the STUN magic cookie at packet offset 4..7, so a 1-RTT data packet can
+// never be mistaken for STUN by pion's demux.
+//
+// pion's write guard fires on the *sending* side, and the packet carries
+// the *peer's* connection ID as its destination — so our generator only
+// protects writes aimed at a peer that also issues STUN-safe IDs. When
+// both peers run this code (the common case) the collision is removed in
+// both directions at the source. Against an un-upgraded peer (or on the
+// consumable-input path, which gets a single attempt), the retry
+// classifier treating the write error as transient is the load-bearing
+// fallback. See internal/retry.IsTransient.
+type stunSafeConnIDGenerator struct{}
+
+func (stunSafeConnIDGenerator) GenerateConnectionID() (quic.ConnectionID, error) {
+	var b [connIDLen]byte
+	for {
+		if _, err := rand.Read(b[:]); err != nil {
+			return quic.ConnectionID{}, err
+		}
+		// Re-roll on the ~2^-32 chance of a collision; in practice this
+		// loop never iterates a second time.
+		if !placesMagicCookie(b[:]) {
+			return quic.ConnectionIDFromBytes(b[:]), nil
+		}
+	}
+}
+
+func (stunSafeConnIDGenerator) ConnectionIDLen() int { return connIDLen }
+
+// NewTransport builds the quic.Transport used on the internet paths
+// (direct-over-ICE and relay), wiring in the STUN-safe connection-ID
+// generator. Centralized so the sender and receiver construction sites
+// can't drift. The generator only matters on the ICE path; on the relay
+// path it is simply a harmless longer connection ID.
+func NewTransport(pc net.PacketConn) *quic.Transport {
+	return &quic.Transport{
+		Conn:                  pc,
+		ConnectionIDGenerator: stunSafeConnIDGenerator{},
+	}
+}

--- a/internal/quicconn/connid_test.go
+++ b/internal/quicconn/connid_test.go
@@ -1,0 +1,74 @@
+package quicconn
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/pion/stun/v3"
+)
+
+// shortHeaderPacket builds a minimal QUIC 1-RTT (short-header) datagram
+// carrying dcid as its destination connection ID: [flags][DCID][padding].
+// stun.IsMessage only looks at len>=20 and bytes[4:8], so the padding's
+// content is irrelevant.
+func shortHeaderPacket(dcid []byte) []byte {
+	pkt := make([]byte, 1200)
+	pkt[0] = 0x40 // short header, fixed bit set; top two bits = 01
+	copy(pkt[1:], dcid)
+	return pkt
+}
+
+// TestGeneratedConnIDsNeverLookLikeSTUN is the end-to-end property test:
+// every connection ID our generator issues, when placed as the DCID of a
+// short-header packet, must be invisible to pion's stun.IsMessage. If this
+// holds, ice.Conn.Write can never reject a 1-RTT data packet as STUN.
+func TestGeneratedConnIDsNeverLookLikeSTUN(t *testing.T) {
+	var gen stunSafeConnIDGenerator
+	for i := 0; i < 200_000; i++ {
+		id, err := gen.GenerateConnectionID()
+		if err != nil {
+			t.Fatalf("GenerateConnectionID: %v", err)
+		}
+		b := id.Bytes()
+		if len(b) != connIDLen {
+			t.Fatalf("connID length = %d, want %d", len(b), connIDLen)
+		}
+		if stun.IsMessage(shortHeaderPacket(b)) {
+			t.Fatalf("generated connID %x produces a STUN-looking packet", b)
+		}
+	}
+}
+
+// TestSentinelControl guards the test itself: a connID deliberately
+// carrying the magic cookie at offset 3..6 *must* make stun.IsMessage
+// fire. Without this, the test above could pass vacuously (e.g. if the
+// packet builder were wrong) and hide a real regression.
+func TestSentinelControl(t *testing.T) {
+	bad := make([]byte, connIDLen)
+	binary.BigEndian.PutUint32(bad[3:7], stunMagicCookie)
+	if !placesMagicCookie(bad) {
+		t.Fatal("placesMagicCookie should flag a cookie at offset 3..7")
+	}
+	if !stun.IsMessage(shortHeaderPacket(bad)) {
+		t.Fatal("control packet must be seen as STUN; packet builder is wrong")
+	}
+}
+
+func TestConnectionIDLen(t *testing.T) {
+	if got := (stunSafeConnIDGenerator{}).ConnectionIDLen(); got != connIDLen {
+		t.Fatalf("ConnectionIDLen = %d, want %d", got, connIDLen)
+	}
+	if connIDLen < 7 {
+		t.Fatalf("connIDLen must be >=7 so bytes 4..7 fall inside the DCID; got %d", connIDLen)
+	}
+}
+
+func TestNewTransportWiresGenerator(t *testing.T) {
+	tr := NewTransport(nil)
+	if tr.ConnectionIDGenerator == nil {
+		t.Fatal("NewTransport must set the STUN-safe ConnectionIDGenerator")
+	}
+	if _, ok := tr.ConnectionIDGenerator.(stunSafeConnIDGenerator); !ok {
+		t.Fatalf("ConnectionIDGenerator = %T, want stunSafeConnIDGenerator", tr.ConnectionIDGenerator)
+	}
+}

--- a/internal/quicconn/transport_test.go
+++ b/internal/quicconn/transport_test.go
@@ -1,0 +1,106 @@
+package quicconn
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"io"
+	"net"
+	"testing"
+	"time"
+)
+
+// TestNewTransportRealHandshake guards the production wiring: that quic-go
+// accepts our 8-byte ConnectionIDGenerator and that a real handshake +
+// 1-RTT transfer completes through NewTransport on both ends (not
+// quicconn.Dial/ListenAddr's self-opened sockets). The STUN-safety
+// property itself is proven separately in connid_test.go.
+func TestNewTransportRealHandshake(t *testing.T) {
+	const code = "abc-defg-jkm"
+
+	// quic.Transport.Close only closes conns it opened itself; we supplied
+	// these, so we must close them or leak the fds each run.
+	senderUDP, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer senderUDP.Close()
+	recvUDP, err := net.ListenUDP("udp", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer recvUDP.Close()
+
+	senderTR := NewTransport(senderUDP)
+	defer senderTR.Close()
+	recvTR := NewTransport(recvUDP)
+	defer recvTR.Close()
+
+	tlsCfg, err := SenderTLSConfig()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ln, err := senderTR.Listen(tlsCfg, QuicConfig())
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	payload := make([]byte, 256*1024) // many 1-RTT packets
+	if _, err := rand.Read(payload); err != nil {
+		t.Fatal(err)
+	}
+
+	// read barrier: the sender must keep the QUIC connection open until the
+	// receiver has drained the payload. Closing right after Write returns
+	// (Write only buffers into quic-go) would tear the connection down
+	// mid-flush and surface as "Application error 0x0 (remote)".
+	readDone := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		qc, err := ln.Accept(ctx)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		res, err := SenderHandshake(ctx, qc, code)
+		if err != nil {
+			errCh <- err
+			return
+		}
+		if _, err := res.Streams.Data.Write(payload); err != nil {
+			errCh <- err
+			return
+		}
+		errCh <- nil
+		<-readDone
+		res.Close()
+	}()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	qc, err := recvTR.Dial(ctx, senderUDP.LocalAddr(), ReceiverTLSConfig(), QuicConfig())
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	res, err := ReceiverHandshake(ctx, qc, code)
+	if err != nil {
+		t.Fatalf("receiver handshake: %v", err)
+	}
+	defer res.Close()
+
+	got := make([]byte, len(payload))
+	_, readErr := io.ReadFull(res.Streams.Data, got)
+	close(readDone) // release the sender to close its side
+	if err := <-errCh; err != nil {
+		t.Fatalf("sender side: %v", err)
+	}
+	if readErr != nil {
+		t.Fatalf("read payload: %v", readErr)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Fatal("payload mismatch over custom-connID connection")
+	}
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -186,10 +186,20 @@ func IsTransient(err error) bool {
 	// declined, ...) are surfaced via wire-level ErrorFrames BEFORE the
 	// QUIC stream tears down, so they're already caught by the terminal
 	// sentinel check above and never reach this fallback.
+	//
+	// "failed to write STUN message to ICE connection" is pion/ice's
+	// sentinel from its STUN/data demux guard: ice.Conn.Write refuses any
+	// app packet that stun.IsMessage flags (len>=20 && bytes[4:8]==magic
+	// cookie). A QUIC datagram whose encrypted bytes 4..7 randomly equal
+	// the cookie trips it — a false positive, never a real network fault.
+	// A retry re-dials with fresh connection IDs/keys so the colliding
+	// bytes can't recur (and the STUN-safe connID generator prevents it
+	// outright); always safe to retry. See internal/quicconn/connid.go.
 	if s := err.Error(); strings.Contains(s, "idle timeout") ||
 		strings.Contains(s, "connection reset by peer") ||
 		strings.Contains(s, "use of closed network connection") ||
-		strings.Contains(s, "Application error 0x") {
+		strings.Contains(s, "Application error 0x") ||
+		strings.Contains(s, "failed to write STUN message to ICE connection") {
 		return true
 	}
 

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -156,6 +156,14 @@ func TestIsTransient_Classification(t *testing.T) {
 		{"quic_application_error_with_message_transient",
 			errors.New("Application error 0x100 (remote): peer left"), true},
 
+		// pion/ice STUN-demux false positive: a QUIC datagram's encrypted
+		// bytes 4..7 randomly matched the STUN magic cookie, so
+		// ice.Conn.Write rejected it. Never a real network fault; a re-dial
+		// with fresh connection IDs dodges it, so it must retry rather than
+		// surface as E099. This is the exact field-report string.
+		{"ice_stun_write_false_positive_transient",
+			errors.New("wire: writing chunk payload: failed to write STUN message to ICE connection"), true},
+
 		// Terminal cases — explicitly tested because a wrapping mistake
 		// here would silently turn user errors into 3-retry hangs.
 		{"hash_mismatch_terminal", fserrors.ErrHashMismatch, false},

--- a/test/e2e/internet_transfer_test.go
+++ b/test/e2e/internet_transfer_test.go
@@ -1,0 +1,36 @@
+package e2e
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestInternet_Transfer drives real transfers over the two internet paths
+// that build their quic.Transport via quicconn.NewTransport — and thus
+// exercise the STUN-safe connection-ID generator on both ends:
+//
+//   - --mode=direct: the ICE path, where the original STUN-demux collision
+//     occurred. ICE establishes over loopback host candidates here.
+//   - --mode=relay:  the server-relayed path.
+//
+// The LAN happy-path tests use quicconn.ListenAddr/Dial and never touch
+// that wiring, so without these cases the suite would not prove the
+// internet paths still transfer end-to-end after the change. Payloads are
+// random (incompressible) so the wire moves the full byte count rather
+// than a zstd-collapsed stub.
+func TestInternet_Transfer(t *testing.T) {
+	requireE2E(t)
+	for _, mode := range []string{"direct", "relay"} {
+		t.Run(mode, func(t *testing.T) {
+			src, dst := t.TempDir(), t.TempDir()
+			payload := filepath.Join(src, "payload.bin")
+			writeRandom(t, payload, 8*1024*1024)
+
+			r := h.runPair(t,
+				[]string{"--mode=" + mode, payload}, dst, []string{"--yes"}, "")
+			r.requireSuccess(t)
+
+			assertFilesEqual(t, payload, filepath.Join(dst, "payload.bin"))
+		})
+	}
+}


### PR DESCRIPTION
## The bug

On the internet path, fsend runs QUIC over a pion/ice connection. pion's `ice.Conn.Write` rejects any packet that `stun.IsMessage` flags — `len>=20 && bytes[4:8]==0x2112A442` (the STUN magic cookie) — **ignoring the QUIC header entirely**.

A 1-RTT data packet whose encrypted bytes 4..7 happen to equal the cookie is misread as a stray STUN packet and refused:

```
[E099] Unexpected error: wire: writing chunk payload: failed to write STUN message to ICE connection
```

Per packet the odds are ~2⁻³², but over the tens of millions of datagrams in a multi-GB transfer it becomes a real, if rare, failure — and it surfaced as the "file a bug" catch-all, with no retry.

## The fix (two parts)

**1. Root cause — STUN-safe connection IDs** (`internal/quicconn/connid.go`)
Issue 8-byte connection IDs that never place the cookie at packet bytes 4..7. A short-header packet is `[flags:1][DCID:8][…]`, so those bytes fall inside a stable field we control → a data packet can never look like STUN. Wired in via a single `NewTransport` helper used by both sender and receiver.

**2. Backstop — retry classifier** (`internal/retry/retry.go`)
Treat the pion write error as transient. The normal path now retries-and-resumes instead of dying; on exhaustion it renders as E020 (recoverable), not E099. This also covers the single-attempt consumable-input path and mixed-version peers.

## Why both

The generator removes the collision when both peers run this code. The classifier covers the cases the generator can't (un-upgraded peer, `--text`/stdin single attempt).

## Validation

- Unit + property tests; full suite green under `-race`.
- New integration test: real handshake + 256 KB transfer through `NewTransport`.
- **Real binary**, real transfers over both internet paths — **ICE-direct** (the path that originally failed) and **relay** — 8 MB random payload, SHA256-verified. Kept as `TestInternet_Transfer` (these paths had zero e2e transfer coverage before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)