### PR TITLE
Pre-transfer file preview with reconciled sizes

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -663,6 +663,17 @@ func filesHello() wire.SenderHello {
 	return wire.SenderHello{Mode: wire.ModeFiles, DisplayName: "proj/"}
 }
 
+// oneFileSummary is a realistic single-file classification for prompt tests
+// that only care about chips/wording, not the file list (one file shows no
+// preview rows). Carries OfferedBytes/Files so the headline renders sanely.
+func oneFileSummary() transfer.ClassifySummary {
+	const size = 1024
+	return transfer.ClassifySummary{
+		Total: 1, NewItems: 1, BytesToRecv: size, OfferedBytes: size,
+		Files: []transfer.SummaryEntry{{RelativePath: "file.bin", Size: size, Status: "new", Type: wire.EntryFile}},
+	}
+}
+
 func TestPromptAccept_QuietRequiresYes(t *testing.T) {
 	h := filesHello()
 	sum := transfer.ClassifySummary{Total: 1, NewItems: 1, BytesToRecv: 1}
@@ -684,7 +695,7 @@ func TestPromptAccept_YesAccepts(t *testing.T) {
 	} {
 		got := captureStderr(t, func() {
 			ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
-			if !ui.promptAccept(h, transfer.ClassifySummary{Total: 1, NewItems: 1}) {
+			if !ui.promptAccept(h, oneFileSummary()) {
 				t.Errorf("--yes must accept hello %+v", h)
 			}
 		})
@@ -694,15 +705,30 @@ func TestPromptAccept_YesAccepts(t *testing.T) {
 	}
 }
 
-func TestPromptAccept_ShowsBreakdown(t *testing.T) {
+// The headline reconciles the offered total (agrees with the sender) with
+// what will actually transfer ("X of Y") and surfaces the conflict count,
+// which must survive even when the differing files are too small to appear in
+// the size-ranked preview rows.
+func TestPromptAccept_HeadlineReconcilesOfferedAndNet(t *testing.T) {
 	got := captureStderr(t, func() {
 		ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
-		_ = ui.promptAccept(filesHello(), transfer.ClassifySummary{Total: 10, NewItems: 3, Identical: 6, Differing: 1})
+		_ = ui.promptAccept(filesHello(), transfer.ClassifySummary{
+			Total: 10, NewItems: 3, Identical: 6, Differing: 1,
+			OfferedBytes: 1_200_000_000, BytesToRecv: 307_000_000, DifferingBytes: 5,
+			Files: []transfer.SummaryEntry{
+				{RelativePath: "a.bin", Size: 900_000_000, Status: "new", Type: wire.EntryFile},
+				{RelativePath: "b.bin", Size: 307_000_000, Status: "new", Type: wire.EntryFile},
+			},
+		})
 	})
-	for _, want := range []string{"3 new", "6 up to date", "1 differ"} {
+	for _, want := range []string{"307 MB of 1.2 GB", "1 differ"} {
 		if !strings.Contains(got, want) {
-			t.Errorf("breakdown missing %q:\n%s", want, got)
+			t.Errorf("headline missing %q:\n%s", want, got)
 		}
+	}
+	// The old stacked breakdown line must be gone.
+	if strings.Contains(got, "3 new") || strings.Contains(got, "6 up to date") {
+		t.Errorf("stacked breakdown line should be removed:\n%s", got)
 	}
 }
 
@@ -728,7 +754,7 @@ func TestPromptAccept_PasswordChipRendered(t *testing.T) {
 	got := captureStderr(t, func() {
 		h := wire.SenderHello{Mode: wire.ModeFiles, DisplayName: "proj/", HasPassword: true}
 		ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
-		_ = ui.promptAccept(h, transfer.ClassifySummary{Total: 1, NewItems: 1})
+		_ = ui.promptAccept(h, oneFileSummary())
 	})
 	if !strings.Contains(got, "password required") {
 		t.Errorf("expected password chip, got:\n%s", got)
@@ -779,7 +805,7 @@ func TestPromptAccept_PathChipShown(t *testing.T) {
 	for _, c := range cases {
 		got := captureStderr(t, func() {
 			ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, c.info)
-			_ = ui.promptAccept(filesHello(), transfer.ClassifySummary{Total: 1, NewItems: 1})
+			_ = ui.promptAccept(filesHello(), oneFileSummary())
 		})
 		if !strings.Contains(got, "Incoming from") || !strings.Contains(got, c.want) {
 			t.Errorf("prompt missing path chip %q:\n%s", c.want, got)

--- a/cmd/fsend/preview.go
+++ b/cmd/fsend/preview.go
@@ -63,14 +63,14 @@ func renderPreview(w io.Writer, items []previewItem, indent int) {
 		if it.note != "" {
 			line += "   " + noteText(it.note)
 		}
-		fmt.Fprintln(w, line)
+		_, _ = fmt.Fprintln(w, line)
 	}
 	if more := len(items) - shown; more > 0 {
 		var rest uint64
 		for _, it := range items[shown:] {
 			rest += it.size
 		}
-		fmt.Fprintf(w, "%s%s\n", pad,
+		_, _ = fmt.Fprintf(w, "%s%s\n", pad,
 			uxlog.Dim(fmt.Sprintf("… and %d more (%s)", more, uxlog.HumanBytes(int64(rest)))))
 	}
 }

--- a/cmd/fsend/preview.go
+++ b/cmd/fsend/preview.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/polius/fsend/internal/uxlog"
+)
+
+// previewRows is how many files the pre-transfer preview lists before
+// collapsing the rest into a "… and N more" line. The rows shown are the
+// largest, so they're the ones that dominate the transfer.
+const previewRows = 10
+
+// previewItem is one row of the pre-transfer file list.
+//
+//   - note is a status annotation ("up to date", "differs", "resume"); ""
+//     omits it. "differs" is the one that warrants attention, so it's the
+//     only one rendered in colour rather than dimmed.
+//   - link is a symlink target; non-empty marks the row a symlink, which has
+//     no byte size to show.
+type previewItem struct {
+	name string
+	size uint64
+	note string
+	link string
+}
+
+// renderPreview writes a size-sorted, truncated file list to w, indented to
+// sit under the artifact summary line. Names must already be sanitized for
+// display. Single-item lists print nothing — the summary line already names
+// the file. The wrapping directory shared by every row is stripped (it's in
+// the headline), and sizes are right-aligned so the list reads as a manifest.
+func renderPreview(w io.Writer, items []previewItem, indent int) {
+	if len(items) <= 1 {
+		return
+	}
+	stripCommonDir(items)
+	// Largest first; ties broken by name so the output is deterministic.
+	sort.SliceStable(items, func(i, j int) bool {
+		if items[i].size != items[j].size {
+			return items[i].size > items[j].size
+		}
+		return items[i].name < items[j].name
+	})
+
+	pad := strings.Repeat(" ", indent)
+	shown := min(len(items), previewRows)
+	sizeWidth := 0
+	for _, it := range items[:shown] {
+		if n := len(sizeCell(it)); n > sizeWidth {
+			sizeWidth = n
+		}
+	}
+	for _, it := range items[:shown] {
+		name := it.name
+		if it.link != "" {
+			name += " → " + it.link
+		}
+		line := fmt.Sprintf("%s%*s   %s", pad, sizeWidth, sizeCell(it), name)
+		if it.note != "" {
+			line += "   " + noteText(it.note)
+		}
+		fmt.Fprintln(w, line)
+	}
+	if more := len(items) - shown; more > 0 {
+		var rest uint64
+		for _, it := range items[shown:] {
+			rest += it.size
+		}
+		fmt.Fprintf(w, "%s%s\n", pad,
+			uxlog.Dim(fmt.Sprintf("… and %d more (%s)", more, uxlog.HumanBytes(int64(rest)))))
+	}
+}
+
+// sizeCell renders the size column for one row: a byte count, or "→" for a
+// symlink (which is a pointer, not a zero-byte file).
+func sizeCell(it previewItem) string {
+	if it.link != "" {
+		return "→"
+	}
+	return uxlog.HumanBytes(int64(it.size))
+}
+
+// noteText colours a status tag: "differs" needs a decision, so it's
+// highlighted; the rest are reassuring background, so they're dimmed.
+func noteText(note string) string {
+	if note == "differs" {
+		return uxlog.Alert(note)
+	}
+	return uxlog.Dim(note)
+}
+
+// stripCommonDir removes the longest leading directory prefix shared by every
+// row (e.g. the wrapping "proj/" already shown in the headline), leaving the
+// part that distinguishes each row. A no-op when the rows don't share a root
+// (multi-path or contents sends). Only whole path segments are stripped, and
+// never a basename.
+func stripCommonDir(items []previewItem) {
+	if len(items) < 2 {
+		return
+	}
+	segs := strings.Split(items[0].name, "/")
+	if len(segs) < 2 {
+		return // first row has no directory component
+	}
+	prefix := segs[:len(segs)-1] // candidate: item0's directories
+	for _, it := range items[1:] {
+		s := strings.Split(it.name, "/")
+		n := 0
+		for n < len(prefix) && n < len(s)-1 && prefix[n] == s[n] {
+			n++
+		}
+		prefix = prefix[:n]
+		if len(prefix) == 0 {
+			return
+		}
+	}
+	cut := len(strings.Join(prefix, "/")) + 1 // include the trailing slash
+	for i := range items {
+		if len(items[i].name) > cut {
+			items[i].name = items[i].name[cut:]
+		}
+	}
+}

--- a/cmd/fsend/preview_test.go
+++ b/cmd/fsend/preview_test.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/polius/fsend/internal/transfer"
+	"github.com/polius/fsend/internal/wire"
+)
+
+// render captures renderPreview into a string for assertion.
+func render(items []previewItem) string {
+	var b bytes.Buffer
+	renderPreview(&b, items, 6)
+	return b.String()
+}
+
+func TestRenderPreview_SingleItemPrintsNothing(t *testing.T) {
+	if got := render([]previewItem{{name: "solo.bin", size: 100}}); got != "" {
+		t.Errorf("single item should print nothing, got %q", got)
+	}
+	if got := render(nil); got != "" {
+		t.Errorf("empty should print nothing, got %q", got)
+	}
+}
+
+func TestRenderPreview_LargestFirst(t *testing.T) {
+	got := render([]previewItem{
+		{name: "small.txt", size: 5},
+		{name: "big.bin", size: 4_000_000_000},
+		{name: "mid.bin", size: 1_000_000},
+	})
+	lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("want 3 rows, got %d:\n%s", len(lines), got)
+	}
+	if !strings.Contains(lines[0], "big.bin") ||
+		!strings.Contains(lines[1], "mid.bin") ||
+		!strings.Contains(lines[2], "small.txt") {
+		t.Errorf("rows not sorted largest-first:\n%s", got)
+	}
+}
+
+func TestRenderPreview_TruncatesWithHonestRemainder(t *testing.T) {
+	// 12 files of 10 bytes each → 10 shown + "… and 2 more (20 B)".
+	var items []previewItem
+	for i := 0; i < 12; i++ {
+		items = append(items, previewItem{name: "f", size: 10})
+	}
+	got := render(items)
+	if n := strings.Count(got, "\n"); n != previewRows+1 {
+		t.Errorf("want %d rows + remainder, got %d lines:\n%s", previewRows, n, got)
+	}
+	if !strings.Contains(got, "… and 2 more (20 B)") {
+		t.Errorf("remainder line missing or wrong total:\n%s", got)
+	}
+}
+
+func TestRenderPreview_NoteRendered(t *testing.T) {
+	got := render([]previewItem{
+		{name: "a.bin", size: 200, note: "up to date"},
+		{name: "b.bin", size: 100, note: "differs"},
+	})
+	if !strings.Contains(got, "a.bin") || !strings.Contains(got, "up to date") {
+		t.Errorf("note not rendered:\n%s", got)
+	}
+	if !strings.Contains(got, "differs") {
+		t.Errorf("differs note missing:\n%s", got)
+	}
+}
+
+func TestSenderPreview_DropsDirectories(t *testing.T) {
+	sources := []transfer.Source{
+		{Entry: wire.ListingEntry{RelativePath: "proj", Type: wire.EntryDir}},
+		{Entry: wire.ListingEntry{RelativePath: "proj/a.bin", Size: 10, Type: wire.EntryFile}},
+		{Entry: wire.ListingEntry{RelativePath: "proj/link", Type: wire.EntrySymlink}},
+	}
+	items := senderPreview(sources)
+	if len(items) != 2 {
+		t.Fatalf("want 2 non-dir items, got %d: %+v", len(items), items)
+	}
+	for _, it := range items {
+		if it.name == "proj" {
+			t.Errorf("directory should be dropped: %+v", items)
+		}
+	}
+}
+
+func TestReceiverPreview_StatusMapping(t *testing.T) {
+	items := receiverPreview([]transfer.SummaryEntry{
+		{RelativePath: "new.bin", Size: 10, Status: "new"},
+		{RelativePath: "same.bin", Size: 20, Status: "identical"},
+		{RelativePath: "diff.bin", Size: 30, Status: "differs"},
+		{RelativePath: "part.bin", Size: 40, Status: "resume"},
+	})
+	want := map[string]string{"new.bin": "", "same.bin": "up to date", "diff.bin": "differs", "part.bin": "resume"}
+	for _, it := range items {
+		if want[it.name] != it.note {
+			t.Errorf("%s: want note %q, got %q", it.name, want[it.name], it.note)
+		}
+	}
+}
+
+func TestReceiverPreview_Symlink(t *testing.T) {
+	items := receiverPreview([]transfer.SummaryEntry{
+		{RelativePath: "link", Status: "new", Type: wire.EntrySymlink, SymlinkTarget: "target.bin"},
+	})
+	if items[0].link != "target.bin" {
+		t.Errorf("symlink target not carried: %+v", items[0])
+	}
+}
+
+func TestRenderPreview_StripsCommonDir(t *testing.T) {
+	got := render([]previewItem{
+		{name: "proj/sub/a.bin", size: 30},
+		{name: "proj/b.bin", size: 20},
+		{name: "proj/c.bin", size: 10},
+	})
+	if strings.Contains(got, "proj/") {
+		t.Errorf("common 'proj/' prefix should be stripped:\n%s", got)
+	}
+	for _, want := range []string{"sub/a.bin", "b.bin", "c.bin"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("row %q missing after strip:\n%s", want, got)
+		}
+	}
+}
+
+// No common root (multi-path send) → nothing stripped.
+func TestRenderPreview_NoCommonDirNoOp(t *testing.T) {
+	got := render([]previewItem{
+		{name: "alpha/a.bin", size: 20},
+		{name: "beta/b.bin", size: 10},
+	})
+	if !strings.Contains(got, "alpha/a.bin") || !strings.Contains(got, "beta/b.bin") {
+		t.Errorf("unrelated roots must be preserved:\n%s", got)
+	}
+}
+
+func TestRenderPreview_SymlinkRow(t *testing.T) {
+	got := render([]previewItem{
+		{name: "big.bin", size: 1000},
+		{name: "latest", link: "big.bin"},
+	})
+	if !strings.Contains(got, "latest → big.bin") {
+		t.Errorf("symlink should render as 'name → target':\n%s", got)
+	}
+	if strings.Contains(got, "0 B   latest") {
+		t.Errorf("symlink must not render a byte size:\n%s", got)
+	}
+}
+
+// Under --overwrite the differing files transfer too, so the bar must be
+// sized for them upfront (BytesToRecv + DifferingBytes); without it the bar
+// reads past 100%. The default (no overwrite) keeps them out of the total.
+func TestAccept_BarSizing(t *testing.T) {
+	sum := transfer.ClassifySummary{
+		Total: 2, NewItems: 1, Differing: 1,
+		BytesToRecv: 100, OfferedBytes: 1000, DifferingBytes: 900,
+	}
+	overwrite := newReceiverUI(context.Background(), &flags{yes: true, overwrite: true}, "/tmp", false, mustLANInfo())
+	_ = overwrite.accept(filesHello(), sum)
+	if overwrite.bytesHint != 1000 {
+		t.Errorf("--overwrite bytesHint = %d, want 1000 (net + differing)", overwrite.bytesHint)
+	}
+	keep := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
+	_ = keep.accept(filesHello(), sum)
+	if keep.bytesHint != 100 {
+		t.Errorf("default bytesHint = %d, want 100 (net only; differing kept)", keep.bytesHint)
+	}
+}
+
+// For a contents/multi-path send the peer's display name is itself the count
+// ("2 files"); the headline must not repeat it as "2 files · 2 files".
+func TestPromptAccept_HeadlineNoDuplicateCount(t *testing.T) {
+	h := wire.SenderHello{Mode: wire.ModeFiles, DisplayName: "2 files"}
+	sum := transfer.ClassifySummary{
+		Total: 2, NewItems: 2, BytesToRecv: 100, OfferedBytes: 100,
+		Files: []transfer.SummaryEntry{
+			{RelativePath: "a.bin", Size: 60, Status: "new", Type: wire.EntryFile},
+			{RelativePath: "b.bin", Size: 40, Status: "new", Type: wire.EntryFile},
+		},
+	}
+	got := captureStderr(t, func() {
+		ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
+		_ = ui.promptAccept(h, sum)
+	})
+	if strings.Contains(got, "2 files  ·  2 files") {
+		t.Errorf("headline duplicates the count:\n%s", got)
+	}
+	if !strings.Contains(got, "2 files  ·  100 B") {
+		t.Errorf("expected collapsed 'count · size' headline:\n%s", got)
+	}
+}
+
+func TestReceiverSizeClause(t *testing.T) {
+	cases := []struct {
+		name string
+		s    transfer.ClassifySummary
+		want string
+	}{
+		{"all new", transfer.ClassifySummary{OfferedBytes: 1_200_000_000, BytesToRecv: 1_200_000_000}, "1.2 GB"},
+		{"some skipped", transfer.ClassifySummary{OfferedBytes: 1_200_000_000, BytesToRecv: 307_000_000}, "307 MB of 1.2 GB"},
+		{"all up to date", transfer.ClassifySummary{OfferedBytes: 1_200_000_000, BytesToRecv: 0, Identical: 3}, "already up to date"},
+		{"single differ", transfer.ClassifySummary{OfferedBytes: 4_200_000_000, BytesToRecv: 0, Differing: 1}, "4.2 GB"},
+		// net and offered round to the same human string → show one number,
+		// not "1.2 GB of 1.2 GB".
+		{"negligible skip", transfer.ClassifySummary{OfferedBytes: 1_200_000_000, BytesToRecv: 1_199_600_000}, "1.2 GB"},
+	}
+	for _, c := range cases {
+		if got := receiverSizeClause(c.s); got != c.want {
+			t.Errorf("%s: receiverSizeClause = %q, want %q", c.name, got, c.want)
+		}
+	}
+}
+
+// Peer-supplied names must be sanitized like every other untrusted string we
+// print — a bidi override must not survive into the preview.
+func TestReceiverPreview_SanitizesNames(t *testing.T) {
+	items := receiverPreview([]transfer.SummaryEntry{
+		{RelativePath: "evil‮name.bin", Size: 10, Status: "new"},
+	})
+	if strings.ContainsRune(items[0].name, '‮') {
+		t.Errorf("bidi override survived sanitization: %q", items[0].name)
+	}
+}
+
+// The sender artifact block lists the files largest-first under the headline.
+func TestPrintSendArtifact_ListsFiles(t *testing.T) {
+	plan := &sendPlan{
+		mode: wire.ModeFiles, displayName: "proj/", label: "proj/",
+		totalFiles: 2, totalBytes: 30,
+		sources: []transfer.Source{
+			{Entry: wire.ListingEntry{RelativePath: "proj/small.txt", Size: 10, Type: wire.EntryFile}},
+			{Entry: wire.ListingEntry{RelativePath: "proj/big.bin", Size: 20, Type: wire.EntryFile}},
+		},
+	}
+	got := captureStderr(t, func() {
+		sp := printSendArtifact(&flags{}, "abc-defg-hij", plan)
+		if sp != nil {
+			sp.Stop()
+		}
+	})
+	// The wrapping "proj/" is stripped (it's in the headline); rows show the
+	// distinguishing path.
+	if strings.Contains(got, "proj/big.bin") {
+		t.Errorf("common 'proj/' prefix should be stripped from rows:\n%s", got)
+	}
+	if !strings.Contains(got, "big.bin") || !strings.Contains(got, "small.txt") {
+		t.Errorf("artifact missing file rows:\n%s", got)
+	}
+	if strings.Index(got, "big.bin") > strings.Index(got, "small.txt") {
+		t.Errorf("files not largest-first in artifact:\n%s", got)
+	}
+}
+
+// The accept prompt lists the incoming files with their per-file status.
+func TestPromptAccept_ListsFiles(t *testing.T) {
+	sum := transfer.ClassifySummary{
+		Total: 2, NewItems: 1, Differing: 1,
+		BytesToRecv: 10, OfferedBytes: 30, DifferingBytes: 20,
+		Files: []transfer.SummaryEntry{
+			{RelativePath: "a.bin", Size: 10, Status: "new", Type: wire.EntryFile},
+			{RelativePath: "b.bin", Size: 20, Status: "differs", Type: wire.EntryFile},
+		},
+	}
+	got := captureStderr(t, func() {
+		ui := newReceiverUI(context.Background(), &flags{yes: true}, "/tmp", false, mustLANInfo())
+		_ = ui.promptAccept(filesHello(), sum)
+	})
+	if !strings.Contains(got, "a.bin") || !strings.Contains(got, "b.bin") {
+		t.Errorf("accept prompt missing file rows:\n%s", got)
+	}
+	if !strings.Contains(got, "differs") {
+		t.Errorf("accept prompt missing per-file status:\n%s", got)
+	}
+	// Headline: file count (not items), "X of Y", and the differ count.
+	for _, want := range []string{"2 files", "10 B of 30 B", "1 differ"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("headline missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/cmd/fsend/preview_test.go
+++ b/cmd/fsend/preview_test.go
@@ -220,9 +220,9 @@ func TestReceiverSizeClause(t *testing.T) {
 // print — a bidi override must not survive into the preview.
 func TestReceiverPreview_SanitizesNames(t *testing.T) {
 	items := receiverPreview([]transfer.SummaryEntry{
-		{RelativePath: "evil‮name.bin", Size: 10, Status: "new"},
+		{RelativePath: "evil\u202ename.bin", Size: 10, Status: "new"},
 	})
-	if strings.ContainsRune(items[0].name, '‮') {
+	if strings.ContainsRune(items[0].name, '\u202e') {
 		t.Errorf("bidi override survived sanitization: %q", items[0].name)
 	}
 }

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -198,22 +198,74 @@ func renderArtifact(w io.Writer, h wire.SenderHello, summary transfer.ClassifySu
 	if name == "" {
 		name = "files"
 	}
-	_, _ = fmt.Fprintf(w, "      %s  ·  %s  ·  %s%s\n",
-		name, uxlog.CountNoun(summary.Total, "item"), uxlog.HumanBytes(int64(summary.BytesToRecv)), pwChip)
-
-	var parts []string
-	if summary.NewItems > 0 {
-		parts = append(parts, fmt.Sprintf("%d new", summary.NewItems))
+	// File count (not summary.Total) so it matches the sender and the rows
+	// below — Total includes directories, which neither shows. For a contents
+	// or multi-path send the peer's display name *is* the count (e.g.
+	// "2 files"), so don't print it twice.
+	fileCount := uxlog.CountNoun(len(summary.Files), "file")
+	lead := fileCount
+	if name != fileCount {
+		lead = name + "  ·  " + fileCount
 	}
-	if summary.Identical > 0 {
-		parts = append(parts, fmt.Sprintf("%d up to date", summary.Identical))
-	}
+	diff := ""
 	if summary.Differing > 0 {
-		parts = append(parts, fmt.Sprintf("%d differ", summary.Differing))
+		diff = fmt.Sprintf("  ·  %d differ", summary.Differing)
 	}
-	if len(parts) > 0 {
-		_, _ = fmt.Fprintln(w, "      "+uxlog.Dim(strings.Join(parts, "  ·  ")))
+	_, _ = fmt.Fprintf(w, "      %s  ·  %s%s%s\n",
+		lead, receiverSizeClause(summary), diff, pwChip)
+	renderPreview(w, receiverPreview(summary.Files), 8)
+}
+
+// receiverSizeClause renders the headline's size figure. The offered total
+// always agrees with the sender (both derive it from the same listing); when
+// the receiver will skip part of it, the clause reads "X of Y" so it also
+// agrees with the progress bar, which fills to X. When nothing transfers and
+// nothing conflicts it says so outright rather than printing a bare "0 B".
+func receiverSizeClause(s transfer.ClassifySummary) string {
+	offered := uxlog.HumanBytes(int64(s.OfferedBytes))
+	if s.BytesToRecv == 0 {
+		// Nothing auto-downloads. Distinguish "you already have it all" from
+		// "everything here conflicts" (the latter keeps the offered size, and
+		// the · N differ clause explains it).
+		if s.Differing == 0 && s.Identical > 0 {
+			return "already up to date"
+		}
+		return offered
 	}
+	net := uxlog.HumanBytes(int64(s.BytesToRecv))
+	if net == offered {
+		return offered // any skipping is negligible at display resolution
+	}
+	return net + " of " + offered
+}
+
+// receiverPreview projects the classified files into preview rows. Names and
+// symlink targets are peer-supplied, so each is sanitized like every other
+// untrusted string we print. The status annotates only the consent-relevant
+// or partial rows; fresh files — the common case — stay unmarked.
+func receiverPreview(files []transfer.SummaryEntry) []previewItem {
+	items := make([]previewItem, 0, len(files))
+	for _, f := range files {
+		note := ""
+		switch f.Status {
+		case "identical":
+			note = "up to date"
+		case "differs":
+			note = "differs"
+		case "resume":
+			note = "resume"
+		}
+		it := previewItem{
+			name: sanitizeForDisplay(f.RelativePath, 128),
+			size: f.Size,
+			note: note,
+		}
+		if f.Type == wire.EntrySymlink {
+			it.link = sanitizeForDisplay(f.SymlinkTarget, 128)
+		}
+		items = append(items, it)
+	}
+	return items
 }
 
 // saveTargetLabel renders the receive destination for the accept prompt.

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -41,6 +41,7 @@ type receiverUI struct {
 	bar         *uxlog.Progress
 	firstByte   time.Time
 	bytesHint   int64
+	diffBytes   int64 // bytes that move only if overwrite is approved
 
 	closeOnce sync.Once
 }
@@ -111,6 +112,12 @@ func (ui *receiverUI) accept(h wire.SenderHello, summary transfer.ClassifySummar
 	cp := h
 	ui.hello = &cp
 	ui.bytesHint = int64(summary.BytesToRecv)
+	ui.diffBytes = int64(summary.DifferingBytes)
+	// --overwrite pulls the differing files too, so size the bar for them
+	// upfront. The prompt path instead bumps the hint in confirmOverwrite.
+	if ui.f.overwrite {
+		ui.bytesHint += ui.diffBytes
+	}
 	ui.mu.Unlock()
 	return ui.promptAccept(h, summary)
 }
@@ -184,6 +191,12 @@ func (ui *receiverUI) confirmOverwrite(conflicts []transfer.Conflict) bool {
 		}
 		switch line {
 		case "y", "yes":
+			// These files weren't in the bar's initial total (they only move
+			// on consent); add them now, before the bar is created on first
+			// byte, so it doesn't read past 100%.
+			ui.mu.Lock()
+			ui.bytesHint += ui.diffBytes
+			ui.mu.Unlock()
 			return true
 		case "l", "list":
 			for _, c := range conflicts {

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -221,6 +221,7 @@ func printSendArtifact(f *flags, c string, plan *sendPlan) *uxlog.Spinner {
 		}
 		fmt.Fprintf(os.Stderr, "  Sending %s%s  ·  %s\n",
 			name, uxlog.CountNoun(plan.totalFiles, "file"), uxlog.HumanBytes(int64(plan.totalBytes)))
+		renderPreview(os.Stderr, senderPreview(plan.sources), 6)
 	}
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintln(os.Stderr, "  On the other machine, run:")
@@ -230,12 +231,41 @@ func printSendArtifact(f *flags, c string, plan *sendPlan) *uxlog.Spinner {
 	return uxlog.StartSpinner("Waiting for receiver")
 }
 
+// senderPreview projects the walked sources into preview rows, dropping
+// directory entries so the count matches the "N files" headline. Names are
+// the user's own local paths, so no display sanitization is needed.
+func senderPreview(sources []transfer.Source) []previewItem {
+	items := make([]previewItem, 0, len(sources))
+	for _, s := range sources {
+		if s.Entry.Type == wire.EntryDir {
+			continue
+		}
+		it := previewItem{name: s.Entry.RelativePath, size: s.Entry.Size}
+		if s.Entry.Type == wire.EntrySymlink {
+			it.link = s.Entry.SymlinkTarget
+		}
+		items = append(items, it)
+	}
+	return items
+}
+
+// senderStats reports a finished send's tallies. skippedFiles counts entries
+// the receiver already had (declined via DecisionSkip) — the signal that
+// distinguishes an "already up to date" no-op from a real transfer. The
+// summary's size is the offered total (plan.totalBytes); moved is what
+// actually crossed the wire, so a partial send reads "Y (X sent)".
+type senderStats struct {
+	moved        int64 // bytes pushed on the wire this run
+	skippedFiles int   // whole files (non-dir) the receiver declined as identical
+}
+
 // newSenderProgress builds the progress callbacks driving a single overall
-// bar. Returns close, progress, onResume, a stats getter (moved/skipped), and
-// onStreamingEOF (latches the bar total once a stream EOFs).
-func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn func(uint32, uint64), onResume func(uint32, uint64, uint64), stats func() (int64, int64), onStreamingEOF func(uint32, uint64)) {
+// bar. Returns close, progress, onResume, onSkip, a stats getter, and
+// onStreamingEOF (latches the bar total once a stream EOFs). All callbacks
+// run on the single send-loop goroutine, so the counters need no locking.
+func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn func(uint32, uint64), onResume func(uint32, uint64, uint64), onSkip func(uint32), stats func() senderStats, onStreamingEOF func(uint32, uint64)) {
 	prev := make(map[uint32]uint64)
-	var moved, skipped int64
+	var s senderStats
 	var bar *uxlog.Progress
 	ensureBar := func() {
 		if bar == nil && !f.quiet {
@@ -248,13 +278,15 @@ func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn fun
 			d := b - prev[fi]
 			prev[fi] = b
 			bar.Add(int64(d))
-			moved += int64(d)
+			s.moved += int64(d)
 		},
 		func(fi uint32, offset, total uint64) {
 			if offset > prev[fi] {
+				// Reflect the resumed prefix in the bar so it shows true
+				// progress; the summary's total comes from the offered size,
+				// so no separate byte counter is needed here.
 				d := int64(offset - prev[fi])
 				prev[fi] = offset
-				skipped += d
 				ensureBar()
 				bar.Add(d)
 			}
@@ -262,7 +294,8 @@ func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn fun
 				uxlog.Println(fmt.Sprintf("  %s %s", uxlog.Info(), resumeNotice(offset, total)))
 			}
 		},
-		func() (int64, int64) { return moved, skipped },
+		func(uint32) { s.skippedFiles++ },
+		func() senderStats { return s },
 		func(_ uint32, finalBytes uint64) { bar.SetTotal(int64(finalBytes), true) }
 }
 
@@ -275,12 +308,22 @@ func resumeNotice(offset, total uint64) string {
 	return s
 }
 
-// printSendSummary renders the post-transfer success line.
-func printSendSummary(f *flags, total, moved int64, elapsed time.Duration, path connpath.Info) {
+// printSendSummary renders the post-transfer success line. skippedFiles is the
+// count of (non-dir) entries the receiver declined; 0 omits the clause.
+func printSendSummary(f *flags, total, moved int64, skippedFiles int, elapsed time.Duration, path connpath.Info) {
 	if f.quiet {
 		return
 	}
 	parts := summaryParts(total, moved, "sent", elapsed, path)
+	// The receiver may have declined files it already had. The sender can't
+	// tell an identical file from one the receiver kept a different version of
+	// (both arrive as DecisionSkip — see wire.DecisionAction), so it reports
+	// the neutral, always-true "skipped" count. That still reconciles with the
+	// receiver's precise "N up to date · M kept" breakdown by sum, and it's
+	// what explains a partial — or zero — "(X sent)" against the offered total.
+	if skippedFiles > 0 {
+		parts = append(parts, uxlog.CountNoun(skippedFiles, "file")+" skipped")
+	}
 	fmt.Fprintf(os.Stderr, "%s Sent  ·  %s\n", uxlog.Check(), strings.Join(parts, "  ·  "))
 	printUpdateNotice(f)
 }

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -650,13 +650,13 @@ func runSenderTransferOverInternet(ctx context.Context, f *flags, plan *sendPlan
 // both paths in this helper keeps the two transfer entry points purely
 // declarative.
 func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathInfo connpath.Info, firstRes *quicconn.AcceptResult, reaccept func(context.Context) (*quicconn.AcceptResult, error)) error {
-	closeProg, progressFn, onResume, stats, onStreamingEOF := newSenderProgress(f, plan)
+	closeProg, progressFn, onResume, onSkip, stats, onStreamingEOF := newSenderProgress(f, plan)
 	defer closeProg()
 
 	// The receiver may sit at its accept prompt for a while; the spinner
 	// owns that window. The first event off the wire — a byte, a resume
-	// notice, a retry — stops it so the progress bar (or notice line)
-	// lands on a clean row. Stop is idempotent and nil-safe (--quiet).
+	// notice, a skip, a retry — stops it so the progress bar (or notice
+	// line) lands on a clean row. Stop is idempotent and nil-safe (--quiet).
 	spin := startWaitSpinner(f, "Waiting for them to accept")
 	defer spin.Stop()
 
@@ -675,6 +675,12 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 	resume := func(fi uint32, offset, total uint64) {
 		spin.Stop()
 		onResume(fi, offset, total)
+	}
+	// An all-skipped transfer (receiver had everything) emits no bytes, so
+	// the skip is the only event that stops the accept spinner.
+	skip := func(fi uint32) {
+		spin.Stop()
+		onSkip(fi)
 	}
 	current := firstRes
 	opts := retry.Options{OnRetry: retryNoticeFor(f)}
@@ -720,20 +726,12 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 				Password:       f.passArg,
 				ProgressFn:     progress,
 				OnResume:       resume,
+				OnSkip:         skip,
 				OnStreamingEOF: onStreamingEOF,
 			})
 		})
 	if err != nil {
 		return err
-	}
-	// moved counts the bytes this run pushed on the wire; skipped is the
-	// resumed prefix the receiver already had. The summary shows the
-	// full size but bases the rate on moved alone. printSendSummary
-	// no-ops under --quiet, so the outer guard isn't needed.
-	moved, skipped := stats()
-	total := moved + skipped
-	if total == 0 {
-		total, moved = int64(plan.totalBytes), int64(plan.totalBytes)
 	}
 	// Flush the bar first so its terminal frame lands above the summary
 	// (the deferred call is then a no-op).
@@ -742,7 +740,13 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 	if !firstByte.IsZero() {
 		elapsed = time.Since(firstByte)
 	}
-	printSendSummary(f, total, moved, elapsed, pathInfo)
+	// The summary shows the offered total (agreeing with the pre-transfer
+	// headline) with moved as the "(X sent)" clause, so any partial send —
+	// down to a full skip ("0 B sent") — reconciles instead of silently
+	// dropping to the sent bytes. The skipped-file count explains the gap and
+	// reconciles with the receiver's breakdown. printSend* no-op under --quiet.
+	s := stats()
+	printSendSummary(f, int64(plan.totalBytes), s.moved, s.skippedFiles, elapsed, pathInfo)
 	return nil
 }
 

--- a/internal/transfer/classify.go
+++ b/internal/transfer/classify.go
@@ -45,6 +45,26 @@ type classifySummary struct {
 	Identical   int
 	Differing   int // dispDiffers + dispConflict
 	BytesToRecv uint64
+	// OfferedBytes is the size of the whole payload (every entry), matching
+	// the sender's total. The headline shows this so both sides agree on one
+	// number; BytesToRecv is what the progress bar fills to.
+	OfferedBytes uint64
+	// DifferingBytes is the size of the differing/conflicting entries — bytes
+	// that move only if the user consents to overwrite. The CLI adds these to
+	// the bar total on consent so it doesn't read past 100%.
+	DifferingBytes uint64
+	Files          []SummaryEntry // per-file rows for the pre-transfer preview
+}
+
+// SummaryEntry is one regular file (or symlink) the receiver is offered, with
+// the per-entry status the preview annotates rows with. Status uses the same
+// vocabulary as ClassifiedEntry.Category, plus "resume" for a partial on disk.
+type SummaryEntry struct {
+	RelativePath  string
+	Size          uint64
+	Status        string // "new" | "identical" | "differs" | "resume"
+	Type          wire.EntryType
+	SymlinkTarget string // EntrySymlink only
 }
 
 // Conflict describes one entry that disagrees with what's on disk, for the
@@ -203,6 +223,7 @@ func resumeCandidate(path string, total uint64) (uint64, [ImohashSize]byte, bool
 func summarize(plans []entryPlan) classifySummary {
 	s := classifySummary{Total: len(plans)}
 	for _, p := range plans {
+		s.OfferedBytes += p.entry.Size
 		switch p.disp {
 		case dispNew:
 			s.NewItems++
@@ -216,9 +237,36 @@ func summarize(plans []entryPlan) classifySummary {
 			}
 		case dispDiffers, dispConflict:
 			s.Differing++
+			s.DifferingBytes += p.entry.Size
+		}
+		// Directories aren't files the user thinks about; mirror CountFiles
+		// so the preview's row count matches the headline's file count.
+		if p.entry.Type != wire.EntryDir {
+			s.Files = append(s.Files, SummaryEntry{
+				RelativePath:  p.entry.RelativePath,
+				Size:          p.entry.Size,
+				Status:        dispStatus(p.disp),
+				Type:          p.entry.Type,
+				SymlinkTarget: p.entry.SymlinkTarget,
+			})
 		}
 	}
 	return s
+}
+
+// dispStatus maps a disposition to the preview's status vocabulary. Verify
+// (same-size, undecided) is treated as incoming until the content hash rules.
+func dispStatus(d disposition) string {
+	switch d {
+	case dispIdentical:
+		return "identical"
+	case dispDiffers, dispConflict:
+		return "differs"
+	case dispResume:
+		return "resume"
+	default:
+		return "new"
+	}
 }
 
 // conflicts extracts the consent-needing entries for the overwrite prompt.

--- a/internal/transfer/classify_test.go
+++ b/internal/transfer/classify_test.go
@@ -1,0 +1,55 @@
+package transfer
+
+import (
+	"testing"
+
+	"github.com/polius/fsend/internal/wire"
+)
+
+// summarize must surface a per-file row for every non-directory entry, with
+// the status the preview annotates rows with, while still tallying the counts
+// the breakdown line uses.
+func TestSummarize_PopulatesFiles(t *testing.T) {
+	plans := []entryPlan{
+		{entry: wire.ListingEntry{RelativePath: "dir", Type: wire.EntryDir}, disp: dispNew},
+		{entry: wire.ListingEntry{RelativePath: "new.bin", Size: 100, Type: wire.EntryFile}, disp: dispNew},
+		{entry: wire.ListingEntry{RelativePath: "same.bin", Size: 200, Type: wire.EntryFile}, disp: dispIdentical},
+		{entry: wire.ListingEntry{RelativePath: "diff.bin", Size: 300, Type: wire.EntryFile}, disp: dispDiffers},
+		{entry: wire.ListingEntry{RelativePath: "part.bin", Size: 400, Type: wire.EntryFile}, disp: dispResume, resumeOffset: 150},
+		{entry: wire.ListingEntry{RelativePath: "link", Type: wire.EntrySymlink, SymlinkTarget: "new.bin"}, disp: dispNew},
+	}
+	s := summarize(plans)
+
+	// Directory excluded; everything else (incl. symlink) kept, in order.
+	want := []SummaryEntry{
+		{RelativePath: "new.bin", Size: 100, Status: "new", Type: wire.EntryFile},
+		{RelativePath: "same.bin", Size: 200, Status: "identical", Type: wire.EntryFile},
+		{RelativePath: "diff.bin", Size: 300, Status: "differs", Type: wire.EntryFile},
+		{RelativePath: "part.bin", Size: 400, Status: "resume", Type: wire.EntryFile},
+		{RelativePath: "link", Size: 0, Status: "new", Type: wire.EntrySymlink, SymlinkTarget: "new.bin"},
+	}
+	if len(s.Files) != len(want) {
+		t.Fatalf("want %d file rows (dir dropped), got %d: %+v", len(want), len(s.Files), s.Files)
+	}
+	for i, w := range want {
+		if s.Files[i] != w {
+			t.Errorf("Files[%d] = %+v, want %+v", i, s.Files[i], w)
+		}
+	}
+	// Counts reconcile, and the byte tallies separate offered (everything)
+	// from what actually moves.
+	// NewItems counts new + resume + the dir + the symlink (all dispNew/resume).
+	if s.Total != 6 || s.NewItems != 4 || s.Identical != 1 || s.Differing != 1 {
+		t.Errorf("counts drifted: %+v", s)
+	}
+	if s.OfferedBytes != 1000 { // 100+200+300+400 (+0 dir +0 link)
+		t.Errorf("OfferedBytes = %d, want 1000", s.OfferedBytes)
+	}
+	if s.DifferingBytes != 300 {
+		t.Errorf("DifferingBytes = %d, want 300", s.DifferingBytes)
+	}
+	// BytesToRecv = new (100) + resume remaining (400-150=250) = 350.
+	if s.BytesToRecv != 350 {
+		t.Errorf("BytesToRecv = %d, want 350", s.BytesToRecv)
+	}
+}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -216,7 +216,15 @@ func recvFilesToSink(ctx context.Context, s *Streams, hello *wire.SenderHello, e
 		declineTransfer(s, wire.ErrCodeDeclined, "multi-file transfer to stdout")
 		return fmt.Errorf("%w: cannot stream a multi-file transfer to stdout; receive it with --out <dir>", fserrors.ErrUsage)
 	}
-	summary := ClassifySummary{Total: 1, NewItems: 1, BytesToRecv: entries[0].Size}
+	summary := ClassifySummary{
+		Total: 1, NewItems: 1,
+		BytesToRecv:  entries[0].Size,
+		OfferedBytes: entries[0].Size,
+		Files: []SummaryEntry{{
+			RelativePath: entries[0].RelativePath, Size: entries[0].Size,
+			Status: "new", Type: entries[0].Type,
+		}},
+	}
 	if opts.Accept != nil && !opts.Accept(*hello, summary) {
 		declineTransfer(s, wire.ErrCodeDeclined, "receiver declined")
 		return fserrors.ErrReceiverDeclined

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -122,7 +122,9 @@ func sendFiles(ctx context.Context, s *Streams, opts SendOptions) error {
 		src := &opts.Sources[i]
 		d, ok := decisions[src.Entry.Index]
 		if !ok || d.Action == wire.DecisionSkip {
-			if ok && opts.OnSkip != nil {
+			// Mirror the receiver (recv.go): directories aren't user-facing
+			// "files", so a skipped dir mustn't inflate the unchanged count.
+			if ok && opts.OnSkip != nil && src.Entry.Type != wire.EntryDir {
 				opts.OnSkip(src.Entry.Index)
 			}
 			continue

--- a/internal/uxlog/format.go
+++ b/internal/uxlog/format.go
@@ -108,6 +108,17 @@ func Dim(s string) string {
 	return colorDim + s + colorReset
 }
 
+// Alert wraps s in yellow (the same family as the warning glyph) so an
+// attention-worthy inline tag — e.g. a "differs" status — stands out instead
+// of receding. Plain text when colour is off. The counterpart to Dim, which
+// de-emphasises reassuring tags like "up to date".
+func Alert(s string) string {
+	if !colorEnabled() {
+		return s
+	}
+	return colorYellow + s + colorReset
+}
+
 // Bold wraps s in the ANSI bold escape, unconditionally. Unlike Dim and
 // Code it carries no colour gate of its own: it decorates --help, which
 // cobra writes to stdout, so the caller must gate on stdout's state via


### PR DESCRIPTION
## What

Show what's in a transfer **before** it starts, on both the sender and the receiver, and make the headline size mean the same thing on both ends.

**Sender** — lists the files under the `Sending` line:
```
  Sending proj/  ·  5 files  ·  1.3 MB
      921.6 KB   big.bin
      307.2 KB   mid.bin
       51.2 KB   sub/small.bin
          11 B   note.txt
             →   latest → big.bin
```

**Receiver** — the same list on the accept prompt, each row tagged with its status (`differs` highlighted, `up to date`/`resume` dimmed, fresh files unmarked):
```
      proj/  ·  5 files  ·  358.4 KB of 1.3 MB
        921.6 KB   big.bin   up to date
        307.2 KB   mid.bin
             …
```

Largest-first, truncated past 10 rows with an honest `… and N more (X)`. Peer-supplied names/targets are sanitized; the common wrapping directory is stripped (it's already in the headline).

## The headline size now reconciles

Previously the sender showed the offered total while the receiver showed only the bytes-to-receive — two different numbers that looked like a bug. Now the headline always shows the **offered total** (both sides agree), and when the receiver will skip part of it, reads **`X of Y`** so it also matches the progress bar. Nothing to transfer reads `already up to date`; a conflict count rides on the headline (`· N differ`) so it survives list truncation. The receiver's file count excludes directories, matching the sender and the rows.

## Pre-existing summary bugs this surfaced

- **Sender summary** keeps the offered total with a `(X sent)` clause, so a partial — or full-skip — send reconciles instead of silently dropping to the sent bytes (it used to claim `Sent · 1.2 GB` for a no-op). It reports a neutral `N skipped` count, because the sender can't distinguish an identical file from a kept conflict (both arrive as `DecisionSkip`); the count still reconciles with the receiver's `up to date / kept` breakdown by sum.
- **Skipped directories** no longer inflate the sender's count (was "7 unchanged" vs the receiver's "5").
- **`--overwrite`** (flag or interactive) now adds the differing files to the progress-bar total so it can't read past 100%.

## Testing

Unit tests for the renderer (sort/truncate/symlink/prefix-strip), the size-clause rule, bar sizing, count de-duplication, and `summarize`. Validated end-to-end as **real LAN transfers** across 15 scenarios: fresh, partial-overlap, all-up-to-date, mixed-differ, truncation, single file, symlinks, color/`NO_COLOR`, `--overwrite`, sink, contents/multi-path, text, and quiet — sender and receiver numbers reconcile in every case. `gofmt` clean, full `go test ./...` passes, `-race` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)