### PR TITLE
docs: scripting, middle-machine chaining, and symlink behavior

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -235,6 +235,7 @@ own code phrase, while fsend always picks it for you.
 |---|---|---|---|
 | Send files | ✓ | ✓ | ✓ |
 | Send folders | ✓ | ✓ (`--zip` to compress) | ✓ (zipped, deflated) |
+| Symlinks | **Followed to content** (broken/cyclic links → error) | Preserved as links | Followed to content (cyclic dirs silently skipped) |
 | Multiple files in one transfer | **✓** | **✓** | ✗ (one file/dir per code) |
 | Send from stdin | **✓ (binary)** | **✓** | ✗ (`--text -` only) |
 | Stream payload to stdout | **✓ `--out -`** | **✓ `--stdout`** | ✗ (text prints; files saved) |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -108,6 +108,16 @@ malformed or malicious listing). Nothing was written outside the target.
 If you trust the sender, ask them to re-send; otherwise this is fsend
 protecting you.
 
+### Sending stopped on a symlink (`E036`, sender side)
+
+fsend follows symlinks to send their target's content, so a link it can't
+resolve halts the send before any code is generated. The message names the
+offending link — fix it, or skip it with `--exclude`:
+
+- **Broken** (the target doesn't exist) or **unreadable** (permissions).
+- **Cyclic** — a link that loops back into the folder (`a → b → a`, or a
+  link to a parent directory), which would otherwise recurse forever.
+
 ## Performance
 
 ### The transfer is slower than expected

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -140,6 +140,67 @@ code." It's a fresh send with a new code:
 If the source file changed in the meantime, the partial is discarded and
 the file transfers from scratch — so you never resume onto stale data.
 
+## Scripting
+
+To drive fsend from a script you need the share code without the
+interactive display. `--quiet` does exactly that: on send it prints
+**only the bare code** to stdout (`abc-defg-jkm\n`) and routes everything
+else — progress, prompts, summaries — to stderr. The sender then blocks
+until a receiver connects, so capture the code from its stdout:
+
+```sh
+fsend file1.txt --quiet > code.txt    # writes the code, then waits for a receiver
+```
+
+On the receiving side, pair `--quiet` with `--yes` so the accept prompt
+never blocks, and pass any password via `FSEND_PASS`:
+
+```sh
+FSEND_PASS=swordfish fsend "$(cat code.txt)" --yes --quiet --out ~/incoming
+```
+
+## Chaining through a middle machine
+
+Sometimes the sender and the receiver can't reach each other, but a third
+machine can reach both — a jump box bridging two networks, or a laptop
+with one foot on each. Since `--out -` streams a received payload to
+stdout and a piped `fsend` sends whatever arrives on stdin, you can splice
+two transfers together on that middle machine and relay the data straight
+through it:
+
+```sh
+# Machine A (has the file) — prints code A:
+fsend file.bin
+
+# Machine B (can reach both A and C) — receives A and re-sends it; prints code B:
+fsend <codeA> --out - --yes | fsend
+
+# Machine C (the destination):
+fsend <codeB> --out - > file.bin
+```
+
+The bytes stream `A → B → C` through an ordinary pipe; machine B never
+writes them to disk. Each hop is paired and encrypted on its own.
+
+Good to know:
+
+- **One file or stream at a time.** The pipe carries raw bytes with no
+  names or folder structure. To relay a directory, wrap it in `tar` so it
+  rebuilds on the far side:
+  ```sh
+  # Machine A
+  tar c ./mydir | fsend
+  # Machine B (unchanged — relays the stream straight through)
+  fsend <codeA> --out - --yes | fsend
+  # Machine C
+  fsend <codeB> --out - | tar x
+  ```
+- **The filename doesn't travel.** Machine C receives an anonymous stream,
+  so redirect it to the name you want (`> file.bin` above). Drop `--out -`
+  and it's saved under an auto-generated name instead.
+- **The middle machine sees the data.** Machine B decrypts each hop to
+  re-send it, so only chain through a machine you trust.
+
 ## Choosing a server (`--connect`)
 
 The default pairing server is `fsend.alzina.dev` — best-effort, free,
@@ -162,7 +223,7 @@ Config is at `~/.config/fsend/config.json` (Linux),
 | Flag | Purpose |
 |---|---|
 | `--send` / `--receive` | Force mode instead of auto-detecting from the argument. Mutually exclusive; handy in scripts. |
-| `--quiet` | Suppress non-error output. |
+| `--quiet` | Suppress non-error output. On send, prints **just the share code** to stdout (see [Scripting](#scripting)). On receive, requires `--yes` (there's no prompt to answer otherwise). |
 | `--debug` | Verbose logging to stderr. Also `FSEND_DEBUG=1`. |
 | `--update` | Update fsend to the latest release by re-running the installer in place. Reports when already up to date. |
 | `--uninstall` | Remove the binary and **recursively delete** the fsend config directory (see [`--connect`](#choosing-a-server---connect) for the per-OS path). `--yes` skips confirmation. |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -78,6 +78,24 @@ fsend --text "the wifi password is hunter2"
 fsend ./secret.tar.gz --pass         # prompts with a random default
 ```
 
+### Symlinks
+
+fsend **follows** symlinks: it sends what the link points to, so the
+receiver gets a real file — not a link that dangles on their machine. A
+folder containing
+
+```text
+report.pdf
+latest -> report.pdf      # a symlink
+```
+
+arrives with `latest` as a **real copy** of `report.pdf` (both files land —
+the link's bytes are sent too). This works even when the target is outside
+the folder you're sending.
+
+A symlink whose target is missing or cyclic stops the send with `E036` —
+fix it, or skip it with `--exclude`.
+
 ## Receiving
 
 ```text

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -142,64 +142,39 @@ the file transfers from scratch — so you never resume onto stale data.
 
 ## Scripting
 
-To drive fsend from a script you need the share code without the
-interactive display. `--quiet` does exactly that: on send it prints
-**only the bare code** to stdout (`abc-defg-jkm\n`) and routes everything
-else — progress, prompts, summaries — to stderr. The sender then blocks
-until a receiver connects, so capture the code from its stdout:
+`--quiet` makes fsend scriptable: on send it prints **only the share code**
+to stdout (progress, prompts, and summaries go to stderr), then blocks
+until a receiver connects. Capture the code from stdout:
 
 ```sh
-fsend file1.txt --quiet > code.txt    # writes the code, then waits for a receiver
+fsend file1.txt --quiet > code.txt    # prints the code, then waits
 ```
 
-On the receiving side, pair `--quiet` with `--yes` so the accept prompt
-never blocks, and pass any password via `FSEND_PASS`:
+On receive, pair `--quiet` with `--yes` (nothing else can answer the
+prompt) and pass any password via `FSEND_PASS`:
 
 ```sh
-FSEND_PASS=swordfish fsend "$(cat code.txt)" --yes --quiet --out ~/incoming
+FSEND_PASS=swordfish fsend "$(cat code.txt)" --quiet --yes --out ~/incoming
 ```
 
 ## Chaining through a middle machine
 
-Sometimes the sender and the receiver can't reach each other, but a third
-machine can reach both — a jump box bridging two networks, or a laptop
-with one foot on each. Since `--out -` streams a received payload to
-stdout and a piped `fsend` sends whatever arrives on stdin, you can splice
-two transfers together on that middle machine and relay the data straight
-through it:
+If the sender and receiver can't reach each other but a third machine can
+reach both, splice two transfers on it: `--out -` streams a received
+payload to stdout, and a piped `fsend` sends stdin. The bytes flow
+`A → B → C` through the pipe — B never writes them to disk, and each hop
+is separately paired and encrypted:
 
 ```sh
-# Machine A (has the file) — prints code A:
-fsend file.bin
-
-# Machine B (can reach both A and C) — receives A and re-sends it; prints code B:
-fsend <codeA> --out - --yes | fsend
-
-# Machine C (the destination):
-fsend <codeB> --out - > file.bin
+fsend file.bin                          # A: prints code A
+fsend <codeA> --out - --yes | fsend     # B: relays A's stream; prints code B
+fsend <codeB> --out - > file.bin        # C: saves it
 ```
 
-The bytes stream `A → B → C` through an ordinary pipe; machine B never
-writes them to disk. Each hop is paired and encrypted on its own.
-
-Good to know:
-
-- **One file or stream at a time.** The pipe carries raw bytes with no
-  names or folder structure. To relay a directory, wrap it in `tar` so it
-  rebuilds on the far side:
-  ```sh
-  # Machine A
-  tar c ./mydir | fsend
-  # Machine B (unchanged — relays the stream straight through)
-  fsend <codeA> --out - --yes | fsend
-  # Machine C
-  fsend <codeB> --out - | tar x
-  ```
-- **The filename doesn't travel.** Machine C receives an anonymous stream,
-  so redirect it to the name you want (`> file.bin` above). Drop `--out -`
-  and it's saved under an auto-generated name instead.
-- **The middle machine sees the data.** Machine B decrypts each hop to
-  re-send it, so only chain through a machine you trust.
+The pipe carries one raw stream — no names or folders — so redirect to the
+name you want on C, and for a directory wrap it in `tar` (`tar c ./dir | fsend`
+on A, `fsend <code> --out - | tar x` on C). Because B decrypts each hop to
+re-send it, only chain through a machine you trust.
 
 ## Choosing a server (`--connect`)
 
@@ -223,7 +198,7 @@ Config is at `~/.config/fsend/config.json` (Linux),
 | Flag | Purpose |
 |---|---|
 | `--send` / `--receive` | Force mode instead of auto-detecting from the argument. Mutually exclusive; handy in scripts. |
-| `--quiet` | Suppress non-error output. On send, prints **just the share code** to stdout (see [Scripting](#scripting)). On receive, requires `--yes` (there's no prompt to answer otherwise). |
+| `--quiet` | Suppress non-error output. On send, prints **just the share code** to stdout (see [Scripting](#scripting)); on receive, requires `--yes`. |
 | `--debug` | Verbose logging to stderr. Also `FSEND_DEBUG=1`. |
 | `--update` | Update fsend to the latest release by re-running the installer in place. Reports when already up to date. |
 | `--uninstall` | Remove the binary and **recursively delete** the fsend config directory (see [`--connect`](#choosing-a-server---connect) for the per-OS path). `--yes` skips confirmation. |


### PR DESCRIPTION
Documentation-only. Three additions to the user-facing docs, each in its natural home.

## Scripting (`usage.md`)
How to drive fsend from a script: `--quiet` prints **only** the share code to stdout (everything else to stderr), then blocks until a receiver connects; capture it, and pair `--quiet` with `--yes` / `FSEND_PASS` on the receiving side. The `--quiet` flag-table row is clarified to match.

## Chaining through a middle machine (`usage.md`)
When the sender and receiver can't reach each other but a third machine can reach both: `--out -` streams a received payload to stdout and a piped `fsend` sends stdin, so two transfers splice on the middle box (`A → B → C`) without B writing to disk. Notes the one-stream limit (`tar` for directories), the dropped filename, and that B sees the decrypted data.

## Symlink behavior (`usage.md`, `troubleshooting.md`, `comparison.md`)
Documents the followed-symlink behavior shipped in #82:
- **`usage.md`** — a Sending subsection with a worked example: a link arrives as a real copy of its target (not a dangling link), and a broken/cyclic link stops the send with `E036`.
- **`troubleshooting.md`** — an `E036` entry covering the broken / unreadable / cyclic cases and the `--exclude` fix.
- **`comparison.md`** — a Symlinks row in the Features table: fsend follows (broken/cyclic → error), croc preserves links, magic-wormhole follows (cyclic dirs silently skipped). Grounded in the croc, magic-wormhole, and zipstream-ng source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)