### PR TITLE
Follow symlinks to their content when sending

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -331,6 +331,25 @@ func TestRenderError_MapsCancelledToUserCancelled(t *testing.T) {
 	}
 }
 
+// An unsendable symlink renders as a dedicated E036 with the offending path
+// inlined and the --exclude hint, and exits 36.
+func TestRenderError_UnsendableSymlink(t *testing.T) {
+	err := fmt.Errorf("%w: broken link proj/dangling → ../gone (target does not exist)", fserrors.ErrUnsendableSymlink)
+	var code int
+	got := captureStderr(t, func() { code = renderError(err, false) })
+	for _, want := range []string{
+		"[E036] Cannot send a symlink: broken link proj/dangling → ../gone (target does not exist)",
+		"Fix the link, or skip it with --exclude.",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	if code != 36 {
+		t.Errorf("exit code = %d, want 36", code)
+	}
+}
+
 // captureStderr redirects os.Stderr to a pipe for the duration of fn,
 // then returns whatever was written. Used by tests of helpers that
 // print to stderr (printPath, printCurrentServer, retryNoticeFor, ...).

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -162,6 +162,7 @@ func renderError(err error, debug bool) int {
 	}
 	if known && (errors.Is(err, fserrors.ErrUsage) ||
 		errors.Is(err, fserrors.ErrSourceNotFound) ||
+		errors.Is(err, fserrors.ErrUnsendableSymlink) ||
 		errors.Is(err, fserrors.ErrRelayCapHit) ||
 		errors.Is(err, fserrors.ErrRelayIdleTimeout) ||
 		errors.Is(err, fserrors.ErrServerStartup) ||
@@ -208,6 +209,13 @@ func renderError(err error, debug bool) int {
 		case detail == "send" || detail == "receive":
 			fmt.Fprintf(os.Stderr, "  fsend has no %q subcommand — `fsend <file>` sends, `fsend <code>` receives.\n", detail)
 		}
+		if entry.Action != "" {
+			fmt.Fprintf(os.Stderr, "  %s\n", entry.Action)
+		}
+	case detail != "" && errors.Is(err, fserrors.ErrUnsendableSymlink):
+		// Inline the offending link into the message — "[E036] Cannot send a
+		// symlink: broken link foo → ../gone (target does not exist)".
+		fmt.Fprintf(os.Stderr, "%s [%s] %s: %s\n", glyph, entry.Code, entry.Message, detail)
 		if entry.Action != "" {
 			fmt.Fprintf(os.Stderr, "  %s\n", entry.Action)
 		}

--- a/cmd/fsend/preview.go
+++ b/cmd/fsend/preview.go
@@ -19,13 +19,17 @@ const previewRows = 10
 //   - note is a status annotation ("up to date", "differs", "resume"); ""
 //     omits it. "differs" is the one that warrants attention, so it's the
 //     only one rendered in colour rather than dimmed.
-//   - link is a symlink target; non-empty marks the row a symlink, which has
-//     no byte size to show.
+//   - link is a *preserved* symlink target (from an older sender); non-empty
+//     renders "name → target" with "→" in the size column (no byte size).
+//   - from is a *followed* symlink's origin (a sender-side annotation); the row
+//     has a real size and renders "name (→ target)". link and from are mutually
+//     exclusive.
 type previewItem struct {
 	name string
 	size uint64
 	note string
 	link string
+	from string
 }
 
 // renderPreview writes a size-sorted, truncated file list to w, indented to
@@ -56,8 +60,11 @@ func renderPreview(w io.Writer, items []previewItem, indent int) {
 	}
 	for _, it := range items[:shown] {
 		name := it.name
-		if it.link != "" {
+		switch {
+		case it.link != "": // preserved symlink: "name → target", "→" size cell
 			name += " → " + it.link
+		case it.from != "": // followed symlink: real size + "name (→ target)"
+			name += " (→ " + it.from + ")"
 		}
 		line := fmt.Sprintf("%s%*s   %s", pad, sizeWidth, sizeCell(it), name)
 		if it.note != "" {

--- a/cmd/fsend/preview_test.go
+++ b/cmd/fsend/preview_test.go
@@ -75,16 +75,40 @@ func TestSenderPreview_DropsDirectories(t *testing.T) {
 	sources := []transfer.Source{
 		{Entry: wire.ListingEntry{RelativePath: "proj", Type: wire.EntryDir}},
 		{Entry: wire.ListingEntry{RelativePath: "proj/a.bin", Size: 10, Type: wire.EntryFile}},
-		{Entry: wire.ListingEntry{RelativePath: "proj/link", Type: wire.EntrySymlink}},
+		// A followed symlink travels as a regular file with LinkTarget set.
+		{Entry: wire.ListingEntry{RelativePath: "proj/latest", Size: 10, Type: wire.EntryFile}, LinkTarget: "a.bin"},
 	}
 	items := senderPreview(sources)
 	if len(items) != 2 {
 		t.Fatalf("want 2 non-dir items, got %d: %+v", len(items), items)
 	}
-	for _, it := range items {
-		if it.name == "proj" {
+	var latest *previewItem
+	for i := range items {
+		if items[i].name == "proj" {
 			t.Errorf("directory should be dropped: %+v", items)
 		}
+		if items[i].name == "proj/latest" {
+			latest = &items[i]
+		}
+	}
+	if latest == nil || latest.from != "a.bin" {
+		t.Errorf("followed symlink should carry its origin in `from`: %+v", latest)
+	}
+}
+
+// A followed symlink renders with a real size and a "(→ target)" annotation —
+// distinct from a preserved symlink's "→ name → target".
+func TestRenderPreview_FollowedSymlinkRow(t *testing.T) {
+	got := render([]previewItem{
+		{name: "big.bin", size: 1000},
+		{name: "latest", size: 1000, from: "big.bin"},
+	})
+	if !strings.Contains(got, "latest (→ big.bin)") {
+		t.Errorf("followed symlink should render 'name (→ target)':\n%s", got)
+	}
+	// It has a real byte size, not the "→" size cell used for preserved links.
+	if strings.Contains(got, "→   latest") {
+		t.Errorf("followed symlink must show a byte size, not the '→' cell:\n%s", got)
 	}
 }
 

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -240,11 +240,14 @@ func senderPreview(sources []transfer.Source) []previewItem {
 		if s.Entry.Type == wire.EntryDir {
 			continue
 		}
-		it := previewItem{name: s.Entry.RelativePath, size: s.Entry.Size}
-		if s.Entry.Type == wire.EntrySymlink {
-			it.link = s.Entry.SymlinkTarget
-		}
-		items = append(items, it)
+		// Followed symlinks travel as regular files; annotate the row with the
+		// origin link so the user sees it was a symlink — and so a size that
+		// repeats (link + its target both in the set) reads as intentional.
+		items = append(items, previewItem{
+			name: s.Entry.RelativePath,
+			size: s.Entry.Size,
+			from: s.LinkTarget,
+		})
 	}
 	return items
 }

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -119,6 +119,11 @@ var (
 	// privileged install dir needing sudo). A non-zero exit so scripts can
 	// tell a failed uninstall from a clean one.
 	ErrUninstallFailed = errors.New("uninstall failed")
+	// E036 — a symlink in the send set can't be followed to real content:
+	// its target is missing, unreadable, or the link cycles. fsend sends the
+	// pointed-to content, so an unresolvable link is a hard stop (with the
+	// path, so the user can fix or --exclude it).
+	ErrUnsendableSymlink = errors.New("unsendable symlink")
 )
 
 // Entry is one row of the user-facing error catalog.
@@ -401,6 +406,11 @@ var catalog = map[error]Entry{
 		Message: "fsend was not fully uninstalled.",
 		Action: "Remove the binary by hand (the path is printed above), " +
 			"possibly with sudo.",
+	},
+	ErrUnsendableSymlink: {
+		Code: "E036", Exit: 36,
+		Message: "Cannot send a symlink",
+		Action:  "Fix the link, or skip it with --exclude.",
 	},
 }
 

--- a/internal/transfer/walk.go
+++ b/internal/transfer/walk.go
@@ -1,7 +1,9 @@
 package transfer
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -16,11 +18,18 @@ import (
 type Source struct {
 	Entry   wire.ListingEntry
 	AbsPath string // sender-local absolute path; "" for synthetic/stream
+	// LinkTarget is the original symlink target when this entry came from a
+	// followed symlink. Sender-side only (never sent on the wire — the entry
+	// travels as a plain file); used to annotate the preview as "name (→ target)".
+	LinkTarget string
 }
 
-// Walk expands CLI arguments into an ordered Source list — files, directories
-// (recursively), and symlinks — using stat only. No file contents are read;
-// the BLAKE3 root is computed inline at send time.
+// Walk expands CLI arguments into an ordered Source list — files and
+// directories (recursively). Symlinks are followed to their target content:
+// fsend is a send tool, so the recipient receives the pointed-to file/dir, not
+// a dangling link. A symlink whose target is missing, unreadable, or cyclic is
+// a hard error (ErrUnsendableSymlink). No file contents are read here; the
+// BLAKE3 root is computed inline at send time.
 //
 // RelativePath is rooted at each argument's base name, so `~/proj/foo` lands
 // as `foo/...`. Duplicate roots and case-only collisions (the receiver may be
@@ -63,7 +72,7 @@ func Walk(paths []string, excludes []string) ([]Source, error) {
 				if err != nil {
 					return nil, fmt.Errorf("walk: lstat %s: %w", cAbs, err)
 				}
-				if err := addEntry(&out, seen, cAbs, c.Name(), cst, m); err != nil {
+				if err := addEntry(&out, seen, nil, cAbs, c.Name(), cst, m); err != nil {
 					return nil, err
 				}
 			}
@@ -74,7 +83,7 @@ func Walk(paths []string, excludes []string) ([]Source, error) {
 			return nil, fmt.Errorf("%w: %s and %s would both arrive as %q — rename one before sending", fserrors.ErrUsage, prev, raw, root)
 		}
 		roots[strings.ToLower(root)] = raw
-		if err := addEntry(&out, seen, abs, root, st, m); err != nil {
+		if err := addEntry(&out, seen, nil, abs, root, st, m); err != nil {
 			return nil, err
 		}
 	}
@@ -86,8 +95,11 @@ func Walk(paths []string, excludes []string) ([]Source, error) {
 }
 
 // addEntry appends one filesystem entry and recurses into directories. rel is
-// the forward-slash path as seen inside the transfer.
-func addEntry(out *[]Source, seen map[string]string, abs, rel string, st os.FileInfo, m excludeMatcher) error {
+// the forward-slash path as seen inside the transfer. stack holds the FileInfo
+// of every directory currently on the recursion path, so a followed symlink
+// that points back into an ancestor is caught as a cycle instead of recursing
+// forever.
+func addEntry(out *[]Source, seen map[string]string, stack []os.FileInfo, abs, rel string, st os.FileInfo, m excludeMatcher) error {
 	if m.match(rel) {
 		return nil
 	}
@@ -95,6 +107,20 @@ func addEntry(out *[]Source, seen map[string]string, abs, rel string, st os.File
 		return fmt.Errorf("%w: %s and %s collide on a case-insensitive filesystem — rename one", fserrors.ErrUsage, prev, rel)
 	}
 	seen[strings.ToLower(rel)] = rel
+
+	// Follow symlinks to their target. os.Stat resolves the whole chain (and
+	// reports ELOOP for a self-referential one); a missing or unreadable
+	// target is a hard stop. linkTarget is kept for the preview annotation.
+	linkTarget := ""
+	if st.Mode()&os.ModeSymlink != 0 {
+		target, _ := os.Readlink(abs)
+		linkTarget = target
+		resolved, err := os.Stat(abs)
+		if err != nil {
+			return symlinkError(rel, target, err)
+		}
+		st = resolved
+	}
 
 	mode := st.Mode()
 	e := wire.ListingEntry{
@@ -104,17 +130,17 @@ func addEntry(out *[]Source, seen map[string]string, abs, rel string, st os.File
 	}
 
 	switch {
-	case mode&os.ModeSymlink != 0:
-		target, err := os.Readlink(abs)
-		if err != nil {
-			return fmt.Errorf("walk: readlink %s: %w", abs, err)
+	case mode.IsDir():
+		// Cycle guard: only meaningful when we got here through a symlink (a
+		// real directory tree can't contain itself). Compare this directory's
+		// identity against every ancestor on the stack.
+		if linkTarget != "" {
+			for _, anc := range stack {
+				if os.SameFile(st, anc) {
+					return fmt.Errorf("%w: %s → %s loops back into the transfer", fserrors.ErrUnsendableSymlink, rel, linkTarget)
+				}
+			}
 		}
-		e.Type = wire.EntrySymlink
-		e.SymlinkTarget = target
-		*out = append(*out, Source{Entry: e, AbsPath: abs})
-		return nil
-
-	case st.IsDir():
 		e.Type = wire.EntryDir
 		*out = append(*out, Source{Entry: e, AbsPath: abs})
 		children, err := os.ReadDir(abs)
@@ -122,6 +148,7 @@ func addEntry(out *[]Source, seen map[string]string, abs, rel string, st os.File
 			return fmt.Errorf("walk: readdir %s: %w", abs, err)
 		}
 		sort.Slice(children, func(i, j int) bool { return children[i].Name() < children[j].Name() })
+		stack = append(stack, st)
 		for _, c := range children {
 			cAbs := filepath.Join(abs, c.Name())
 			cRel := rel + "/" + c.Name()
@@ -129,22 +156,41 @@ func addEntry(out *[]Source, seen map[string]string, abs, rel string, st os.File
 			if err != nil {
 				return fmt.Errorf("walk: lstat %s: %w", cAbs, err)
 			}
-			if err := addEntry(out, seen, cAbs, cRel, cst, m); err != nil {
+			if err := addEntry(out, seen, stack, cAbs, cRel, cst, m); err != nil {
 				return err
 			}
 		}
 		return nil
 
-	default:
-		// Skip non-regular files (fifo/device/socket): reading one blocks
-		// or can't be copied. Mirrors the receiver's handling.
-		if !mode.IsRegular() {
-			return nil
-		}
+	case mode.IsRegular():
 		e.Type = wire.EntryFile
 		e.Size = uint64(st.Size())
-		*out = append(*out, Source{Entry: e, AbsPath: abs})
+		*out = append(*out, Source{Entry: e, AbsPath: abs, LinkTarget: linkTarget})
 		return nil
+
+	default:
+		// fifo/device/socket can't be copied. A plain one is skipped silently
+		// (as before); one a symlink explicitly resolves to is surfaced rather
+		// than silently dropping a target the user pointed at.
+		if linkTarget != "" {
+			return fmt.Errorf("%w: %s → %s is not a regular file", fserrors.ErrUnsendableSymlink, rel, linkTarget)
+		}
+		return nil
+	}
+}
+
+// symlinkError classifies a failure to resolve a symlink's target into a
+// user-facing ErrUnsendableSymlink with the offending path and cause.
+func symlinkError(rel, target string, err error) error {
+	switch {
+	case errors.Is(err, fs.ErrNotExist):
+		return fmt.Errorf("%w: broken link %s → %s (target does not exist)", fserrors.ErrUnsendableSymlink, rel, target)
+	case errors.Is(err, fs.ErrPermission):
+		return fmt.Errorf("%w: cannot read target of %s → %s (permission denied)", fserrors.ErrUnsendableSymlink, rel, target)
+	default:
+		// Includes ELOOP from a self-referential chain (a → b → a); the OS
+		// message ("too many levels of symbolic links") makes the cause clear.
+		return fmt.Errorf("%w: cannot resolve %s → %s: %v", fserrors.ErrUnsendableSymlink, rel, target, err)
 	}
 }
 

--- a/internal/transfer/walk.go
+++ b/internal/transfer/walk.go
@@ -18,9 +18,11 @@ import (
 type Source struct {
 	Entry   wire.ListingEntry
 	AbsPath string // sender-local absolute path; "" for synthetic/stream
-	// LinkTarget is the original symlink target when this entry came from a
-	// followed symlink. Sender-side only (never sent on the wire — the entry
-	// travels as a plain file); used to annotate the preview as "name (→ target)".
+	// LinkTarget is where this entry actually lives when it came from a followed
+	// symlink — a direct link's own target, or the resolved source path for a
+	// file reached through a symlinked directory. Sender-side only (never sent
+	// on the wire — the entry travels as a plain file); annotates the preview as
+	// "name (→ target)".
 	LinkTarget string
 }
 
@@ -72,7 +74,7 @@ func Walk(paths []string, excludes []string) ([]Source, error) {
 				if err != nil {
 					return nil, fmt.Errorf("walk: lstat %s: %w", cAbs, err)
 				}
-				if err := addEntry(&out, seen, nil, cAbs, c.Name(), cst, m); err != nil {
+				if err := addEntry(&out, seen, nil, "", cAbs, c.Name(), cst, m); err != nil {
 					return nil, err
 				}
 			}
@@ -83,7 +85,7 @@ func Walk(paths []string, excludes []string) ([]Source, error) {
 			return nil, fmt.Errorf("%w: %s and %s would both arrive as %q — rename one before sending", fserrors.ErrUsage, prev, raw, root)
 		}
 		roots[strings.ToLower(root)] = raw
-		if err := addEntry(&out, seen, nil, abs, root, st, m); err != nil {
+		if err := addEntry(&out, seen, nil, "", abs, root, st, m); err != nil {
 			return nil, err
 		}
 	}
@@ -98,8 +100,10 @@ func Walk(paths []string, excludes []string) ([]Source, error) {
 // the forward-slash path as seen inside the transfer. stack holds the FileInfo
 // of every directory currently on the recursion path, so a followed symlink
 // that points back into an ancestor is caught as a cycle instead of recursing
-// forever.
-func addEntry(out *[]Source, seen map[string]string, stack []os.FileInfo, abs, rel string, st os.FileInfo, m excludeMatcher) error {
+// forever. srcPrefix is the real-source path of the parent directory when we're
+// inside a followed symlink (empty in the user's real tree); it lets every
+// symlink-derived file carry its true origin for the preview annotation.
+func addEntry(out *[]Source, seen map[string]string, stack []os.FileInfo, srcPrefix, abs, rel string, st os.FileInfo, m excludeMatcher) error {
 	if m.match(rel) {
 		return nil
 	}
@@ -110,7 +114,7 @@ func addEntry(out *[]Source, seen map[string]string, stack []os.FileInfo, abs, r
 
 	// Follow symlinks to their target. os.Stat resolves the whole chain (and
 	// reports ELOOP for a self-referential one); a missing or unreadable
-	// target is a hard stop. linkTarget is kept for the preview annotation.
+	// target is a hard stop. linkTarget is the raw target of a direct symlink.
 	linkTarget := ""
 	if st.Mode()&os.ModeSymlink != 0 {
 		target, _ := os.Readlink(abs)
@@ -120,6 +124,20 @@ func addEntry(out *[]Source, seen map[string]string, stack []os.FileInfo, abs, r
 			return symlinkError(rel, target, err)
 		}
 		st = resolved
+	}
+
+	// src is where this entry actually lives, for the preview annotation: a
+	// direct symlink's own target, or — for a file reached through a followed
+	// symlinked directory — the parent's source path plus this base name. "" for
+	// a genuine entry in the user's tree (no annotation). It also becomes the
+	// srcPrefix passed to children, composing through nested symlinks.
+	src := linkTarget
+	if src == "" && srcPrefix != "" {
+		base := rel
+		if i := strings.LastIndex(rel, "/"); i >= 0 {
+			base = rel[i+1:]
+		}
+		src = srcPrefix + "/" + base
 	}
 
 	mode := st.Mode()
@@ -156,7 +174,7 @@ func addEntry(out *[]Source, seen map[string]string, stack []os.FileInfo, abs, r
 			if err != nil {
 				return fmt.Errorf("walk: lstat %s: %w", cAbs, err)
 			}
-			if err := addEntry(out, seen, stack, cAbs, cRel, cst, m); err != nil {
+			if err := addEntry(out, seen, stack, src, cAbs, cRel, cst, m); err != nil {
 				return err
 			}
 		}
@@ -165,7 +183,7 @@ func addEntry(out *[]Source, seen map[string]string, stack []os.FileInfo, abs, r
 	case mode.IsRegular():
 		e.Type = wire.EntryFile
 		e.Size = uint64(st.Size())
-		*out = append(*out, Source{Entry: e, AbsPath: abs, LinkTarget: linkTarget})
+		*out = append(*out, Source{Entry: e, AbsPath: abs, LinkTarget: src})
 		return nil
 
 	default:

--- a/internal/transfer/walk_test.go
+++ b/internal/transfer/walk_test.go
@@ -1,0 +1,157 @@
+package transfer
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/wire"
+)
+
+// mkSymlink creates a symlink, skipping the test when the platform won't allow
+// it (Windows without developer mode), so the suite stays green on the matrix.
+func mkSymlink(t *testing.T, target, link string) {
+	t.Helper()
+	if err := os.Symlink(target, link); err != nil {
+		t.Skipf("symlinks unsupported here: %v", err)
+	}
+}
+
+func bySrcRel(srcs []Source) map[string]Source {
+	m := make(map[string]Source, len(srcs))
+	for _, s := range srcs {
+		m[s.Entry.RelativePath] = s
+	}
+	return m
+}
+
+// A symlink to a sibling file is followed: it travels as a regular file with
+// the target's content/size, LinkTarget records the origin, and no symlink
+// entry is emitted. The target is still sent under its own name (no dedup).
+func TestWalk_FollowsSymlinkToFile(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "file1.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mkSymlink(t, "file1.txt", filepath.Join(dir, "file2"))
+
+	srcs, err := Walk([]string{dir}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := filepath.Base(dir)
+	by := bySrcRel(srcs)
+
+	f2, ok := by[base+"/file2"]
+	if !ok {
+		t.Fatalf("file2 missing from walk: %+v", srcs)
+	}
+	if f2.Entry.Type != wire.EntryFile {
+		t.Errorf("file2 type = %v, want EntryFile", f2.Entry.Type)
+	}
+	if f2.Entry.Size != 5 {
+		t.Errorf("file2 size = %d, want 5 (target content)", f2.Entry.Size)
+	}
+	if f2.LinkTarget != "file1.txt" {
+		t.Errorf("file2 LinkTarget = %q, want %q", f2.LinkTarget, "file1.txt")
+	}
+	if _, ok := by[base+"/file1.txt"]; !ok {
+		t.Errorf("target file1.txt should still be sent under its own name (no dedup)")
+	}
+	for _, s := range srcs {
+		if s.Entry.Type == wire.EntrySymlink {
+			t.Errorf("walk must not emit symlink entries: %+v", s.Entry)
+		}
+	}
+}
+
+// A symlink to a directory is followed and its contents recursed under the
+// link's name.
+func TestWalk_FollowsSymlinkToDir(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "real"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "real", "inner.txt"), []byte("xyz"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mkSymlink(t, "real", filepath.Join(dir, "alias"))
+
+	srcs, err := Walk([]string{dir}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	base := filepath.Base(dir)
+	by := bySrcRel(srcs)
+	if d, ok := by[base+"/alias"]; !ok || d.Entry.Type != wire.EntryDir {
+		t.Errorf("alias should be a directory entry: %+v", d)
+	}
+	if f, ok := by[base+"/alias/inner.txt"]; !ok || f.Entry.Size != 3 {
+		t.Errorf("alias/inner.txt should be sent with the target's content: %+v", f)
+	}
+}
+
+// A symlink pointing outside the send set is followed (no inside/outside
+// guardrail) — its content is sent.
+func TestWalk_FollowsSymlinkOutsideSet(t *testing.T) {
+	ext := t.TempDir()
+	if err := os.WriteFile(filepath.Join(ext, "secret"), []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	dir := t.TempDir()
+	mkSymlink(t, filepath.Join(ext, "secret"), filepath.Join(dir, "ptr"))
+
+	srcs, err := Walk([]string{dir}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	by := bySrcRel(srcs)
+	ptr, ok := by[filepath.Base(dir)+"/ptr"]
+	if !ok || ptr.Entry.Type != wire.EntryFile || ptr.Entry.Size != 10 {
+		t.Errorf("external symlink should be followed to its 10-byte content: %+v", ptr)
+	}
+}
+
+func TestWalk_BrokenSymlinkErrors(t *testing.T) {
+	dir := t.TempDir()
+	mkSymlink(t, "does-not-exist", filepath.Join(dir, "dangling"))
+
+	_, err := Walk([]string{dir}, nil)
+	if !errors.Is(err, fserrors.ErrUnsendableSymlink) {
+		t.Fatalf("want ErrUnsendableSymlink, got %v", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "dangling") || !strings.Contains(got, "does-not-exist") {
+		t.Errorf("error should name the link and target: %q", got)
+	}
+}
+
+// A symlink that points back into an ancestor directory must be reported as a
+// cycle rather than recursing forever.
+func TestWalk_CycleErrors(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "sub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mkSymlink(t, dir, filepath.Join(dir, "sub", "up")) // up -> the root we're walking
+
+	_, err := Walk([]string{dir}, nil)
+	if !errors.Is(err, fserrors.ErrUnsendableSymlink) {
+		t.Fatalf("want ErrUnsendableSymlink (cycle), got %v", err)
+	}
+}
+
+// --exclude lets the user send a folder despite an otherwise-fatal broken link.
+func TestWalk_ExcludeSkipsBrokenSymlink(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "keep.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mkSymlink(t, "gone", filepath.Join(dir, "dangling"))
+
+	if _, err := Walk([]string{dir}, []string{"dangling"}); err != nil {
+		t.Fatalf("excluding the broken link should allow the send: %v", err)
+	}
+}

--- a/internal/transfer/walk_test.go
+++ b/internal/transfer/walk_test.go
@@ -89,8 +89,14 @@ func TestWalk_FollowsSymlinkToDir(t *testing.T) {
 	if d, ok := by[base+"/alias"]; !ok || d.Entry.Type != wire.EntryDir {
 		t.Errorf("alias should be a directory entry: %+v", d)
 	}
-	if f, ok := by[base+"/alias/inner.txt"]; !ok || f.Entry.Size != 3 {
-		t.Errorf("alias/inner.txt should be sent with the target's content: %+v", f)
+	f, ok := by[base+"/alias/inner.txt"]
+	if !ok || f.Entry.Size != 3 {
+		t.Fatalf("alias/inner.txt should be sent with the target's content: %+v", f)
+	}
+	// A file reached through a followed dir-symlink carries its real source so
+	// the preview can annotate it "(→ real/inner.txt)".
+	if f.LinkTarget != "real/inner.txt" {
+		t.Errorf("alias/inner.txt LinkTarget = %q, want %q", f.LinkTarget, "real/inner.txt")
 	}
 }
 


### PR DESCRIPTION
## What

fsend is a *send* tool, so the recipient should receive the file/directory a symlink points to — not a dangling link that resolves to nothing on their machine. The walk now **follows symlinks** and records the target as a regular file/dir; the receiver gets real content.

**Before** (symlink preserved → recipient gets a broken link):
```
  Sending proj/  ·  5 files  ·  1.3 MB
             →   latest → big.bin
```
**After** (symlink followed → recipient gets the file):
```
  Sending proj/  ·  3 files  ·  102.4 KB
      51.2 KB   big.bin
      51.2 KB   latest (→ big.bin)
          2 B   note.txt
```

## Behavior

- **Follows everything**, including links pointing *outside* the shared folder. No inside/outside guardrail — you send what you point at, and the pre-transfer preview shows every resolved file (with its target) before you confirm. Matches magic-wormhole's model; croc preserves links instead — this is a deliberate product choice.
- **No dedup.** A link to a file already in the set is sent again under the link's name. The preview annotates it `name (→ target)` with the real size, so the repeated size reads as intentional, not a bug. The annotation is **sender-side**; the receiver just gets a normal file.
- **Hardlinks** need no special handling — they already walk as regular files.
- **Backward compatible:** sender-side only. Older receivers still understand the `EntrySymlink` wire type, and a new receiver still renders a preserved link from an old sender.

## The only guardrail: unresolvable links are a hard error

A symlink that can't be followed to real content stops the send (at walk time, *before* a code is generated), with the offending path and an `--exclude` hint:

```
[E036] Cannot send a symlink: broken link proj/dangling → ../gone (target does not exist)
  Fix the link, or skip it with --exclude.
```

Three causes, all `E036`:
- **Cycle** — a link that loops back into an ancestor (`a → b → a`, or a link to a parent dir) would recurse forever. Detected by comparing each followed directory's identity (`os.SameFile`) against the recursion stack; self-referential chains surface as `ELOOP` from `os.Stat`.
- **Broken** — target doesn't exist.
- **Unreadable** — target exists but permission denied.

## Testing

New `walk_test.go` covers: follow-to-file, follow-to-dir, follow-outside-set, broken → error, cycle → error, and `--exclude` rescuing a broken link. Plus preview tests for the `(→ target)` rendering and a render-format test for E036. Validated end-to-end as **real LAN transfers**: internal/external/dir symlinks all arrive as regular files with matching content (verified by `cmp`); broken and cyclic links fail with E036 and exit 36 before any code is generated. `gofmt`, full `go test ./...`, `-race`, and a Windows cross-compile all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)