### PR TITLE
Tolerate surrounding whitespace on a share code

### DIFF
--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -451,9 +451,7 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		if len(f.posArgs) != 1 {
 			return fmt.Errorf("%w: --receive requires exactly one positional argument (the code)", fserrors.ErrUsage)
 		}
-		// Tolerate surrounding whitespace (a redirected newline, a pasted
-		// space) on the explicitly-given code.
-		return startReceive(f, strings.TrimSpace(f.posArgs[0]))
+		return startReceive(f, f.posArgs[0])
 	}
 
 	// --text is unambiguously send mode. An explicitly empty value
@@ -501,9 +499,11 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		}
 		return startReceive(f, arg)
 	}
-	// Codes copied through iMessage / WhatsApp / Slack often have the first
-	// letter auto-capitalized. If the lowercased form is a valid code and no
-	// file by the original name exists, receive; otherwise fall through to send.
+	// Codes copied through iMessage / WhatsApp / Slack often have the
+	// first letter auto-capitalized. If the lowercased form is a valid
+	// code AND there's no file with the original name, accept it as a
+	// receive — anything else (file exists, or lowercased still doesn't
+	// match the regex) falls through to send.
 	if lowered := strings.ToLower(arg); lowered != arg && code.IsCode(lowered) {
 		if _, err := os.Stat(arg); os.IsNotExist(err) {
 			return startReceive(f, lowered)

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -512,12 +512,23 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	return runSend(f, []string{arg})
 }
 
-// wrappedCode reports a share code surrounded by whitespace and returns it
-// trimmed. A clean code returns false, leaving it to the code-vs-path logic
-// below (internal whitespace is left alone, so a malformed code stays one).
+// wrappedCode reports a share code surrounded by whitespace, returning it
+// trimmed (and lowercased — a chat-app copy that grabs a trailing space often
+// also capitalizes the first letter). A clean code returns false, leaving it to
+// the code-vs-path logic below; internal whitespace is untouched, so a
+// malformed code stays one.
 func wrappedCode(arg string) (string, bool) {
 	t := strings.TrimSpace(arg)
-	return t, t != arg && code.IsCode(t)
+	if t == arg {
+		return "", false
+	}
+	if code.IsCode(t) {
+		return t, true
+	}
+	if low := strings.ToLower(t); code.IsCode(low) {
+		return low, true
+	}
+	return "", false
 }
 
 // applyEnvFallbacks fills in flags from environment variables when the

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -451,7 +451,9 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		if len(f.posArgs) != 1 {
 			return fmt.Errorf("%w: --receive requires exactly one positional argument (the code)", fserrors.ErrUsage)
 		}
-		return startReceive(f, f.posArgs[0])
+		// Tolerate surrounding whitespace (a redirected newline, a pasted
+		// space) on the explicitly-given code.
+		return startReceive(f, strings.TrimSpace(f.posArgs[0]))
 	}
 
 	// --text is unambiguously send mode. An explicitly empty value
@@ -486,6 +488,12 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 
 	// Single arg: code-vs-path auto-detect.
 	arg := f.posArgs[0]
+	// A code wrapped in whitespace (a redirected newline, a pasted space, a
+	// CRLF) is never a filename, so receive the trimmed form. --send forces
+	// send for a file genuinely named like a code.
+	if c, ok := wrappedCode(arg); ok {
+		return startReceive(f, c)
+	}
 	if code.IsCode(arg) {
 		// Code regex match. If a file with that name exists in CWD, prompt.
 		if _, err := os.Stat(arg); err == nil {
@@ -493,17 +501,23 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		}
 		return startReceive(f, arg)
 	}
-	// Codes copied through iMessage / WhatsApp / Slack often have the
-	// first letter auto-capitalized. If the lowercased form is a valid
-	// code AND there's no file with the original name, accept it as a
-	// receive — anything else (file exists, or lowercased still doesn't
-	// match the regex) falls through to send.
+	// Codes copied through iMessage / WhatsApp / Slack often have the first
+	// letter auto-capitalized. If the lowercased form is a valid code and no
+	// file by the original name exists, receive; otherwise fall through to send.
 	if lowered := strings.ToLower(arg); lowered != arg && code.IsCode(lowered) {
 		if _, err := os.Stat(arg); os.IsNotExist(err) {
 			return startReceive(f, lowered)
 		}
 	}
 	return runSend(f, []string{arg})
+}
+
+// wrappedCode reports a share code surrounded by whitespace and returns it
+// trimmed. A clean code returns false, leaving it to the code-vs-path logic
+// below (internal whitespace is left alone, so a malformed code stays one).
+func wrappedCode(arg string) (string, bool) {
+	t := strings.TrimSpace(arg)
+	return t, t != arg && code.IsCode(t)
 }
 
 // applyEnvFallbacks fills in flags from environment variables when the

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -186,6 +186,30 @@ func TestAskCodeOrPath(t *testing.T) {
 	})
 }
 
+// wrappedCode detects a share code surrounded by whitespace (redirected
+// newline, pasted space, CRLF) so it's received rather than mistaken for a
+// filename — while leaving clean codes, malformed codes, and filenames alone.
+func TestWrappedCode(t *testing.T) {
+	for _, tc := range []struct {
+		in, want string
+		ok       bool
+	}{
+		{"abc-defg-hjk", "", false},                // clean → handled by normal path
+		{"abc-defg-hjk\n", "abc-defg-hjk", true},   // redirected newline
+		{"abc-defg-hjk ", "abc-defg-hjk", true},    // trailing space
+		{" abc-defg-hjk", "abc-defg-hjk", true},    // leading space
+		{"abc-defg-hjk\r\n", "abc-defg-hjk", true}, // Windows CRLF
+		{"\nabc-defg-hjk\n", "abc-defg-hjk", true}, // surrounded
+		{"abc - defg - hjk", "", false},            // internal spaces → still malformed
+		{"report.pdf ", "", false},                 // filename with a space → not a code
+	} {
+		got, ok := wrappedCode(tc.in)
+		if ok != tc.ok || (ok && got != tc.want) {
+			t.Errorf("wrappedCode(%q) = (%q, %v), want (%q, %v)", tc.in, got, ok, tc.want, tc.ok)
+		}
+	}
+}
+
 func TestBoldHelpHeaders(t *testing.T) {
 	t.Run("colored", func(t *testing.T) {
 		// FORCE_COLOR makes ColorFor true even though test stdout is

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -200,6 +200,8 @@ func TestWrappedCode(t *testing.T) {
 		{" abc-defg-hjk", "abc-defg-hjk", true},    // leading space
 		{"abc-defg-hjk\r\n", "abc-defg-hjk", true}, // Windows CRLF
 		{"\nabc-defg-hjk\n", "abc-defg-hjk", true}, // surrounded
+		{"Abc-defg-hjk\n", "abc-defg-hjk", true},   // chat-app: capitalized + newline
+		{"ABC-DEFG-HJK ", "abc-defg-hjk", true},    // uppercase + space
 		{"abc - defg - hjk", "", false},            // internal spaces → still malformed
 		{"report.pdf ", "", false},                 // filename with a space → not a code
 	} {


### PR DESCRIPTION
## What

On the **auto-detect** path, a share code arriving wrapped in whitespace used to fall through to **send** mode and fail with a misleading error:

```
$ fsend "abc-defg-hjk "          # trailing space (paste), or \n / \r\n
[FAIL] [E025] No such file or directory: abc-defg-hjk
```

That sends the user hunting for a *file* problem when they meant to *receive*. Now the trimmed (and lowercased) form is recognized and received.

## Behavior

| Code argument | Before | After |
|---|---|---|
| `abc-defg-hjk` (clean) | receive | receive (unchanged) |
| `abc-defg-hjk\n` (redirected `--quiet > code.txt`) | `E025` ✗ | **receive** |
| `abc-defg-hjk ` / ` abc-defg-hjk` (pasted) | `E025` ✗ | **receive** |
| `abc-defg-hjk\r\n` (Windows file) | `E025` ✗ | **receive** |
| `Abc-defg-hjk\n` / `ABC-DEFG-HJK ` (chat-app: capitalized + whitespace) | `E025` ✗ | **receive** |
| `abc - defg - hjk` (internal spaces) | `E025` | `E025` (still malformed — not "repaired") |

Deliberately narrow:
- **Only surrounding whitespace** is stripped (`strings.TrimSpace`); internal whitespace leaves a malformed code malformed.
- Composes with the existing case-insensitive handling, so a chat-app copy that both capitalizes and grabs a trailing space still works.
- **Filenames are sent byte-verbatim** — a real file named `report .pdf` still sends as-is.
- **`--send` still forces send** for the rare file genuinely named like a code.
- **Scoped to the auto-detect path only.** `--receive` is unchanged: it already rejects a malformed code with a clear `E025`→`E004`, so it never had the misleading-error bug.

The `--quiet` stdout itself is unchanged (still ends in a newline, the conventional behavior; `$(…)` strips it). This makes the *input* side robust regardless of where the whitespace came from.

## Testing

`TestWrappedCode` covers every row above (whitespace and capitalized-whitespace → receive; malformed-internal and spaced-filename → not a code). Verified end-to-end with the real binary. `gofmt`, full `go test ./...`, `-race`, and a Windows cross-compile pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)