### PR TITLE
Regroup --help flags by role; show -h/-v shorthands

### DIFF
--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -247,7 +247,7 @@ EXAMPLES
   Use a different server:
     fsend --connect relay.mycompany.com:443
 
-COMMON FLAGS
+SENDING
   --text "<string>"      Send a literal string instead of a file
                          (the receiver prints it — nothing is saved;
                          keep it with: fsend <code> > note.txt)
@@ -255,30 +255,34 @@ COMMON FLAGS
                          Bare --pass prompts interactively — sender side
                          suggests a fresh random default (press Enter to
                          accept). Env: FSEND_PASS.
+  --exclude <glob,…>     Skip entries matching these globs in a directory
+  --name <string>        Override the hostname shown to the peer
+
+RECEIVING
+  --yes                  Auto-accept incoming transfers (no prompt)
   --out <dir>            Receive into this directory (default: current)
   --out -                Receive to stdout (single file, text, or piped
                          stream — pipe-friendly: fsend <code> --out - | …)
-  --yes                  Auto-accept incoming transfers (no prompt)
   --overwrite            Replace existing files that differ (identical files
                          are always skipped)
   --dry-run              Show what would transfer (new/identical/differs),
                          write nothing
   --checksum             Decide identical files by content hash, not
                          size+mtime (like rsync -c)
-  --quiet                Suppress all non-error output
-  --name <string>        Override the hostname shown to the peer
-  --exclude <glob,…>     Skip entries matching these globs in a directory
-  --help                 Show this help
-  --version              Show version
 
-ADVANCED FLAGS
+GENERAL
+  --quiet                Suppress all non-error output
+  --debug                Verbose logging to stderr (also: FSEND_DEBUG=1)
+  --help, -h             Show this help
+  --version, -v          Show version
+
+ADVANCED
   --connect              Show current server
   --connect <host:port>  Set the server (persisted)
   --connect <host:port>,<password>
                          Set the server + shared password
   --connect default      Revert to the compiled-in default server
   --send / --receive     Force mode (skip code/path auto-detect)
-  --debug                Verbose logging to stderr (also: FSEND_DEBUG=1)
   --update               Update fsend to the latest release
   --uninstall            Remove the fsend binary and its config dir
 

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -219,8 +219,8 @@ func TestBoldHelpHeaders(t *testing.T) {
 		t.Setenv("NO_COLOR", "")
 		t.Setenv("FORCE_COLOR", "1")
 		got := boldHelpHeaders(helpTemplate)
-		for _, header := range []string{"USAGE", "EXAMPLES", "COMMON FLAGS",
-			"ADVANCED FLAGS", "LEARN MORE"} {
+		for _, header := range []string{"USAGE", "EXAMPLES", "SENDING",
+			"RECEIVING", "GENERAL", "ADVANCED", "LEARN MORE"} {
 			if !strings.Contains(got, "\x1b[1m"+header+"\x1b[0m") {
 				t.Errorf("header %q not bolded", header)
 			}


### PR DESCRIPTION
## What

The `fsend --help` flag list was one long **COMMON FLAGS** block (12 entries) that mixed *send-only* and *receive-only* flags together — so a sender had to scan past `--out`/`--yes`/`--overwrite`/`--dry-run`/`--checksum` to find `--text`/`--pass`, and vice versa. fsend's whole model is "am I sending or receiving?", so the help now groups by that:

```
SENDING      --text  --pass  --exclude  --name
RECEIVING    --yes  --out  --overwrite  --dry-run  --checksum
GENERAL      --quiet  --debug  --help,-h  --version,-v
ADVANCED     --connect  --send/--receive  --update  --uninstall
```

- **Maps to intent** — jump straight to your mode; the send/receive mixing is gone.
- **The occasional flags** (`--dry-run`, `--checksum`) now sit in `RECEIVING` where they belong, instead of padding a "common" shortlist.
- **Matches `usage.md`** (Sending / Receiving / Shared), so help and docs reinforce each other.
- **`-h` / `-v` shorthands listed** — they already worked but weren't shown.

## Notes
- Only the root `helpTemplate` changed; `completion` and `server` have their own templates (untouched).
- Header bolding is generic (any ALL-CAPS line), so the new section names needed no logic change — just the template string and the test's header list.
- No new shorthands beyond the existing `-h`/`-v` — deliberately. Single-letter space collides here (`-c` checksum vs connect, `-d` debug vs dry-run), and fsend favors explicit, discoverable flags.

## Testing
`TestBoldHelpHeaders` updated for the new section names; full `go test ./...`, `gofmt`, and a Windows cross-compile pass. Verified the rendered `--help` output by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)