### PR TITLE
Replace --dry-run with --preview (send) and --manifest (receive)

### DIFF
--- a/cmd/fsend/preview_test.go
+++ b/cmd/fsend/preview_test.go
@@ -3,9 +3,13 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/transfer"
 	"github.com/polius/fsend/internal/wire"
 )
@@ -98,6 +102,64 @@ func TestSenderPreview_DropsDirectories(t *testing.T) {
 
 // --preview emits CSV: header, directories dropped, and a path containing a
 // comma is quoted (encoding/csv).
+// --preview's contract: list what would be sent to stdout and return —
+// never reaching code.Generate or the network. runSend stops right after
+// the local walk, so calling it offline must succeed and emit the CSV.
+func TestRunSend_PreviewWritesCSVWithoutPairing(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "a.bin"), []byte("0123456789"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	var err error
+	out := captureStdout(t, func() {
+		err = runSend(&flags{preview: true}, []string{dir})
+	})
+	if err != nil {
+		t.Fatalf("runSend --preview: %v", err)
+	}
+	// Header plus the one file (the wrapping dir is structural, omitted).
+	if !strings.HasPrefix(out, "path,size\n") {
+		t.Errorf("missing CSV header:\n%s", out)
+	}
+	base := filepath.Base(dir)
+	if !strings.Contains(out, base+"/a.bin,10\n") {
+		t.Errorf("missing file row:\n%s", out)
+	}
+}
+
+// onManifest is the cmd-side writer behind --manifest: it must lay down a
+// header + one row per file (quoting commas), and surface a write failure as
+// manifestErr rather than crash the transfer.
+func TestOnManifest_WritesCSV(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "m.csv")
+	ui := &receiverUI{f: &flags{manifest: path}}
+	ui.onManifest([]transfer.ManifestEntry{
+		{RelativePath: "new.bin", Size: 10, Status: "new"},
+		{RelativePath: "with,comma.txt", Size: 3, Status: "identical"},
+	})
+	if ui.manifestErr != nil {
+		t.Fatalf("manifestErr = %v", ui.manifestErr)
+	}
+	got, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := "path,size,status\nnew.bin,10,new\n\"with,comma.txt\",3,identical\n"
+	if string(got) != want {
+		t.Errorf("manifest =\n%q\nwant\n%q", got, want)
+	}
+}
+
+func TestOnManifest_WriteError(t *testing.T) {
+	// Parent directory doesn't exist → os.Create fails.
+	path := filepath.Join(t.TempDir(), "no-such-dir", "m.csv")
+	ui := &receiverUI{f: &flags{manifest: path}}
+	ui.onManifest([]transfer.ManifestEntry{{RelativePath: "a", Size: 1, Status: "new"}})
+	if !errors.Is(ui.manifestErr, fserrors.ErrWriteFailed) {
+		t.Errorf("manifestErr = %v, want wrapping ErrWriteFailed", ui.manifestErr)
+	}
+}
+
 func TestWriteSendPreview(t *testing.T) {
 	var b bytes.Buffer
 	srcs := []transfer.Source{

--- a/cmd/fsend/preview_test.go
+++ b/cmd/fsend/preview_test.go
@@ -96,6 +96,24 @@ func TestSenderPreview_DropsDirectories(t *testing.T) {
 	}
 }
 
+// --preview emits CSV: header, directories dropped, and a path containing a
+// comma is quoted (encoding/csv).
+func TestWriteSendPreview(t *testing.T) {
+	var b bytes.Buffer
+	srcs := []transfer.Source{
+		{Entry: wire.ListingEntry{RelativePath: "proj", Type: wire.EntryDir}},
+		{Entry: wire.ListingEntry{RelativePath: "proj/a.bin", Size: 10, Type: wire.EntryFile}},
+		{Entry: wire.ListingEntry{RelativePath: "proj/with,comma.txt", Size: 3, Type: wire.EntryFile}},
+	}
+	if err := writeSendPreview(&b, srcs); err != nil {
+		t.Fatal(err)
+	}
+	want := "path,size\nproj/a.bin,10\n\"proj/with,comma.txt\",3\n"
+	if got := b.String(); got != want {
+		t.Errorf("CSV =\n%q\nwant\n%q", got, want)
+	}
+}
+
 // A followed symlink renders with a real size and a "(→ target)" annotation —
 // distinct from a preserved symlink's "→ name → target".
 func TestRenderPreview_FollowedSymlinkRow(t *testing.T) {

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -39,6 +39,10 @@ func runReceive(f *flags, c string) error {
 	if f.outDir == "-" && f.overwrite {
 		return fmt.Errorf("%w: --overwrite has no effect with --out -", fserrors.ErrUsage)
 	}
+	// --manifest records files written to disk; there are none with --out -.
+	if f.outDir == "-" && f.manifest != "" {
+		return fmt.Errorf("%w: --manifest has no effect with --out -", fserrors.ErrUsage)
+	}
 	// Validate --out before any network work: a missing directory would
 	// otherwise only fail at write time, after the sender's one-shot code
 	// has been consumed.

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/csv"
 	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -42,6 +44,7 @@ type receiverUI struct {
 	firstByte   time.Time
 	bytesHint   int64
 	diffBytes   int64 // bytes that move only if overwrite is approved
+	manifestErr error // a --manifest write failure, surfaced after the transfer
 
 	closeOnce sync.Once
 }
@@ -83,7 +86,6 @@ func (ui *receiverUI) recvOptions(hostname string) transfer.RecvOptions {
 		ClientVersion:  version.Version,
 		TargetDir:      ui.outDir,
 		Overwrite:      ui.f.overwrite,
-		DryRun:         ui.f.dryRun,
 		Checksum:       ui.f.checksum,
 		Accept:         ui.accept,
 		Password:       ui.f.passArg,
@@ -93,10 +95,12 @@ func (ui *receiverUI) recvOptions(hostname string) transfer.RecvOptions {
 		OnSkip:         ui.onSkip,
 		OnFileDone:     ui.onFileDone,
 		OnConflictKept: ui.onConflictKept,
-		OnClassified:   ui.onClassified,
 	}
 	if ui.sink {
 		o.Sink = os.Stdout
+	}
+	if ui.f.manifest != "" {
+		o.OnManifest = ui.onManifest
 	}
 	// Under --quiet or --yes the confirm stays nil: the engine then keeps
 	// differing files (skip) instead of blocking on a prompt nobody answers.
@@ -249,10 +253,24 @@ func (ui *receiverUI) onConflictKept(string) {
 	ui.mu.Unlock()
 }
 
-// onClassified prints the dry-run categorization to stdout (greppable).
-func (ui *receiverUI) onClassified(entries []transfer.ClassifiedEntry) {
+// onManifest writes the post-transfer record (path,size,status) as CSV to the
+// --manifest path. Fired only after a successful receive, so the file isn't
+// left describing a transfer that failed.
+func (ui *receiverUI) onManifest(entries []transfer.ManifestEntry) {
+	f, err := os.Create(ui.f.manifest)
+	if err != nil {
+		ui.manifestErr = fmt.Errorf("%w: --manifest %s: %v", fserrors.ErrWriteFailed, ui.f.manifest, err)
+		return
+	}
+	defer func() { _ = f.Close() }()
+	cw := csv.NewWriter(f)
+	_ = cw.Write([]string{"path", "size", "status"})
 	for _, e := range entries {
-		_, _ = fmt.Fprintf(os.Stdout, "%-9s %s\n", e.Category, e.RelativePath)
+		_ = cw.Write([]string{e.RelativePath, strconv.FormatUint(e.Size, 10), e.Status})
+	}
+	cw.Flush()
+	if err := cw.Error(); err != nil {
+		ui.manifestErr = fmt.Errorf("%w: --manifest %s: %v", fserrors.ErrWriteFailed, ui.f.manifest, err)
 	}
 }
 
@@ -294,14 +312,11 @@ func (ui *receiverUI) close() {
 	})
 }
 
-// finishReceive runs the post-transfer epilogue. A dry run printed its plan
-// already, so it just returns. When differing files were kept (no consent),
-// it returns E013 so scripts get a non-zero exit, after showing the summary.
+// finishReceive runs the post-transfer epilogue. When differing files were
+// kept (no consent) it returns E013 so scripts get a non-zero exit, after
+// showing the summary; a --manifest write failure surfaces the same way.
 func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 	ui.close()
-	if f.dryRun {
-		return nil
-	}
 
 	ui.mu.Lock()
 	h := ui.hello
@@ -325,6 +340,12 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 	}
 	total, moved := ui.bytes()
 	printRecvSummary(f, ui.headline(h, files), total, moved, kept, skippedSame, elapsed, ui.pathInfo)
+	// manifestErr is set by onManifest, which runs on this goroutine before we
+	// return, so no lock is needed. The transfer succeeded; the failure is only
+	// that --manifest couldn't be written.
+	if ui.manifestErr != nil {
+		return ui.manifestErr
+	}
 	if kept > 0 {
 		return fserrors.ErrTargetExists
 	}

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -250,17 +250,17 @@ EXAMPLES
     fsend --connect relay.mycompany.com:443
 
 SENDING
-  --text "<string>"      Send a literal string instead of a file
-                         (the receiver prints it — nothing is saved;
-                         keep it with: fsend <code> > note.txt)
   --pass <password>      Require the receiver to enter a password.
                          Bare --pass prompts interactively — sender side
                          suggests a fresh random default (press Enter to
                          accept). Env: FSEND_PASS.
   --exclude <glob,…>     Skip entries matching these globs in a directory
-  --name <string>        Override the hostname shown to the peer
+  --text "<string>"      Send a literal string instead of a file
+                         (the receiver prints it — nothing is saved;
+                         keep it with: fsend <code> > note.txt)
   --preview              List what would be sent (CSV: path,size) and exit —
                          no code, no transfer (pipe-friendly: --preview > out.csv)
+  --name <string>        Override the hostname shown to the peer
 
 RECEIVING
   --yes                  Auto-accept incoming transfers (no prompt)

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -267,6 +267,8 @@ RECEIVING
   --out <dir>            Receive into this directory (default: current)
   --out -                Receive to stdout (single file, text, or piped
                          stream — pipe-friendly: fsend <code> --out - | …)
+  --pass <value>         Supply the sender's password up front, skipping the
+                         prompt (bare --pass prompts). Env: FSEND_PASS
   --overwrite            Replace existing files that differ (identical files
                          are always skipped)
   --checksum             Decide identical files by content hash, not

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -28,13 +28,14 @@ type flags struct {
 	passArg  string // shared with receive-side: sender requires, receiver supplies
 	hostname string
 	excludes []string // glob patterns; applied when bundling a directory archive
+	preview  bool     // list what would be sent (CSV), then exit — no transfer
 
 	// Receive-side
 	yes       bool
 	outDir    string
 	overwrite bool
-	dryRun    bool
 	checksum  bool
+	manifest  string // write a CSV record of the received files to this path
 
 	// Server selection — connectArgsRaw is the raw slice cobra hands
 	// back; "no flag" vs "empty flag" is distinguished via Flags().Changed.
@@ -115,8 +116,9 @@ Examples:
 	c.Flags().BoolVar(&f.yes, "yes", false, "auto-accept incoming transfers")
 	c.Flags().StringVar(&f.outDir, "out", "", "receive into this directory")
 	c.Flags().BoolVar(&f.overwrite, "overwrite", false, "overwrite existing files that differ on receive")
-	c.Flags().BoolVar(&f.dryRun, "dry-run", false, "show what would transfer (new/identical/differs), write nothing")
 	c.Flags().BoolVar(&f.checksum, "checksum", false, "decide identical files by content hash, not size+mtime (like rsync -c)")
+	c.Flags().BoolVar(&f.preview, "preview", false, "list what would be sent (CSV: path,size) and exit; no transfer")
+	c.Flags().StringVar(&f.manifest, "manifest", "", "write a CSV record (path,size,status) of the received files to this path")
 	c.Flags().BoolVar(&f.quiet, "quiet", false, "suppress non-error output")
 	c.Flags().StringVar(&f.hostname, "name", "", "override the hostname shown to the peer")
 	c.Flags().StringSliceVar(&f.excludes, "exclude", nil,
@@ -257,6 +259,8 @@ SENDING
                          accept). Env: FSEND_PASS.
   --exclude <glob,…>     Skip entries matching these globs in a directory
   --name <string>        Override the hostname shown to the peer
+  --preview              List what would be sent (CSV: path,size) and exit —
+                         no code, no transfer (pipe-friendly: --preview > out.csv)
 
 RECEIVING
   --yes                  Auto-accept incoming transfers (no prompt)
@@ -265,10 +269,10 @@ RECEIVING
                          stream — pipe-friendly: fsend <code> --out - | …)
   --overwrite            Replace existing files that differ (identical files
                          are always skipped)
-  --dry-run              Show what would transfer (new/identical/differs),
-                         write nothing
   --checksum             Decide identical files by content hash, not
                          size+mtime (like rsync -c)
+  --manifest <file>      Write a CSV record (path,size,status) of the
+                         received files to <file>
 
 GENERAL
   --quiet                Suppress all non-error output
@@ -559,6 +563,9 @@ func applyEnvFallbacks(f *flags, cmd *cobra.Command) {
 func startReceive(f *flags, c string) error {
 	if len(f.excludes) > 0 {
 		return errExcludeMisuse()
+	}
+	if f.preview {
+		return fmt.Errorf("%w: --preview is a send-side flag and has no effect when receiving", fserrors.ErrUsage)
 	}
 	return runReceive(f, c)
 }

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -118,6 +118,24 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 			[]string{"--update", "--uninstall"},
 			"--update and --uninstall are mutually exclusive",
 		},
+		{
+			// --preview is send-side; rejected when the arg is a code.
+			"preview_on_receive",
+			[]string{"--preview", "abc-defg-jkm"},
+			"--preview is a send-side flag",
+		},
+		{
+			// --manifest is receive-side; rejected when sending.
+			"manifest_on_send",
+			[]string{"--manifest=m.csv", "file.txt"},
+			"--manifest is a receive-side flag",
+		},
+		{
+			// --manifest records files on disk; --out - writes none.
+			"manifest_with_stdout",
+			[]string{"--manifest=m.csv", "--out", "-", "abc-defg-jkm"},
+			"--manifest has no effect with --out -",
+		},
 	}
 	for _, c := range cases {
 		c := c

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/rand"
+	"encoding/csv"
 	"errors"
 	"fmt"
 	"io"
@@ -10,6 +11,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -50,7 +52,7 @@ func runSend(f *flags, paths []string) error {
 	for _, rf := range []struct {
 		name string
 		set  bool
-	}{{"--out", f.outDir != ""}, {"--yes", f.yes}, {"--overwrite", f.overwrite}, {"--dry-run", f.dryRun}, {"--checksum", f.checksum}} {
+	}{{"--out", f.outDir != ""}, {"--yes", f.yes}, {"--overwrite", f.overwrite}, {"--checksum", f.checksum}, {"--manifest", f.manifest != ""}} {
 		if rf.set {
 			return fmt.Errorf("%w: %s is a receive-side flag and has no effect when sending", fserrors.ErrUsage, rf.name)
 		}
@@ -66,6 +68,14 @@ func runSend(f *flags, paths []string) error {
 	plan, err := collectPlan(f, paths)
 	if err != nil {
 		return err
+	}
+
+	// --preview lists what would be sent and stops — no code, no pairing.
+	if f.preview {
+		if plan.mode != wire.ModeFiles {
+			return fmt.Errorf("%w: --preview only applies to file or folder sends", fserrors.ErrUsage)
+		}
+		return writeSendPreview(os.Stdout, plan.sources)
 	}
 
 	c, err := code.Generate()
@@ -250,6 +260,22 @@ func senderPreview(sources []transfer.Source) []previewItem {
 		})
 	}
 	return items
+}
+
+// writeSendPreview writes a CSV (path,size) of the files that would be sent,
+// for --preview. Directories are structural and omitted so the rows match the
+// "N files" count; encoding/csv quotes any path containing a comma or quote.
+func writeSendPreview(w io.Writer, sources []transfer.Source) error {
+	cw := csv.NewWriter(w)
+	_ = cw.Write([]string{"path", "size"})
+	for _, s := range sources {
+		if s.Entry.Type == wire.EntryDir {
+			continue
+		}
+		_ = cw.Write([]string{s.Entry.RelativePath, strconv.FormatUint(s.Entry.Size, 10)})
+	}
+	cw.Flush()
+	return cw.Error()
 }
 
 // senderStats reports a finished send's tallies. skippedFiles counts entries

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -243,7 +243,7 @@ own code phrase, while fsend always picks it for you.
 | Receiver confirmation prompt | ✓ (`--yes` to skip) | ✓ (`--yes`) | ✓ (`--accept-file`) |
 | Resume after interruption | **✓ (BLAKE3-verified)** | **✓ (chunk-based)** | ✗ (classic transit restarts) |
 | Skip unchanged files on re-send | **✓ (size+mtime; `--checksum`)** | **✓ (always hashes)** | ✗ |
-| Dry-run preview | **✓ `--dry-run`** | ✗ | ✗ |
+| Preview / manifest | **✓ `--preview` (sender), `--manifest` (receiver)** | ✗ | ✗ |
 | Password on top of the code | **✓ `--pass`** | code phrase doubles as secret | ✗ (the code is the secret) |
 | Exclude paths in a directory | **✓ `--exclude`** | **✓ `--exclude` (+ `--git`)** | ✗ |
 | Custom output dir / name | `--out` | `--out` | `--output-file` |
@@ -311,8 +311,9 @@ it; or Python is already your path of least resistance.
   lengthen anything;
 - you want **defense-in-depth** (SPAKE2 *over* TLS 1.3) and
   **post-quantum** forward secrecy — neither of the others has either;
-- you want **resume**, a separate **`--pass`** secret, **`--dry-run`**,
-  **multi-file** transfers, or **binary stdin/stdout** streaming;
+- you want **resume**, a separate **`--pass`** secret, a **`--preview`**
+  of what you'd send, **multi-file** transfers, or **binary stdin/stdout**
+  streaming;
 - you'd rather deploy **one static binary** than a Python environment.
 
 ---

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -243,7 +243,8 @@ own code phrase, while fsend always picks it for you.
 | Receiver confirmation prompt | ✓ (`--yes` to skip) | ✓ (`--yes`) | ✓ (`--accept-file`) |
 | Resume after interruption | **✓ (BLAKE3-verified)** | **✓ (chunk-based)** | ✗ (classic transit restarts) |
 | Skip unchanged files on re-send | **✓ (size+mtime; `--checksum`)** | **✓ (always hashes)** | ✗ |
-| Preview / manifest | **✓ `--preview` (sender), `--manifest` (receiver)** | ✗ | ✗ |
+| Preview what you'd send | **✓ `--preview`** — list every file + size as CSV, locally, without sending | ✗ | ✗ |
+| Record of what was received | **✓ `--manifest`** — CSV of each file with its outcome (new / identical / overwritten / kept / resumed) | ✗ | ✗ |
 | Password on top of the code | **✓ `--pass`** | code phrase doubles as secret | ✗ (the code is the secret) |
 | Exclude paths in a directory | **✓ `--exclude`** | **✓ `--exclude` (+ `--git`)** | ✗ |
 | Custom output dir / name | `--out` | `--out` | `--output-file` |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -89,7 +89,8 @@ contents**, so fsend kept your local copy and didn't overwrite it. The
 rest of the transfer completed.
 
 - To replace differing files, receive again with `--overwrite`.
-- To see what would change first, use `--dry-run`.
+- The accept prompt shows the breakdown (new / up to date / differ) before
+  you confirm; `--manifest <file>` records the exact per-file outcome.
 - Byte-identical files are always skipped silently — this only fires on
   real differences.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -69,6 +69,7 @@ without a positional argument.
 | `--pass <password>` | Require the receiver to supply this password. Bare `--pass` prompts interactively with a random default. Also `FSEND_PASS`. |
 | `--exclude <glob,…>` | Skip entries when bundling a directory. |
 | `--name <hostname>` | Override the hostname shown to the peer. |
+| `--preview` | List what would be sent as CSV (`path,size`) and exit — no code, no transfer. Redirect with `> files.csv` to inspect. |
 
 ```sh
 fsend report.pdf
@@ -111,7 +112,7 @@ sending, then confirms. Pass `--yes` to skip.
 | `--out <dir>` | Receive into this directory (must already exist). Default: cwd. |
 | `--out -` | Stream the payload to stdout instead of saving a file (single file, text, or piped stream — not directories). Retries are disabled: emitted bytes can't be rewound. |
 | `--overwrite` | Replace existing files whose contents **differ**. Without it they're kept and the receiver exits `E013`. (Identical files are skipped either way.) |
-| `--dry-run` | Show what would transfer — `new` / `identical` / `differs` (and `conflict` / `resume` in edge cases) per path on stdout — and write nothing. |
+| `--manifest <file>` | After receiving, write a CSV record (`path,size,status`) to `<file>` — what fsend did with each file (`new` / `identical` / `overwritten` / `kept` / `resumed`). |
 | `--checksum` | Decide what's already present by hashing **contents** (BLAKE3) instead of comparing size + mtime — like rsync's `-c`. See [below](#when-a-file-already-exists). |
 | `--pass <password>` | Supply the sender's password non-interactively. Also `FSEND_PASS`. |
 
@@ -137,9 +138,9 @@ decides:
 
 When a file *does* differ, fsend keeps your local copy by default
 (protecting your edits) and exits `E013`; pass `--overwrite` to replace
-it. Byte-identical files are always skipped silently. Use `--dry-run` to
-preview the per-path breakdown (`new` / `identical` / `differs`, plus
-`conflict` / `resume` in edge cases) before writing anything.
+it. Byte-identical files are always skipped silently. The accept prompt shows
+this breakdown (`N new · M up to date · K differ`) before you confirm, and
+`--manifest <file>` records the exact per-file outcome after a receive.
 
 ### Resuming an interrupted transfer
 

--- a/internal/transfer/classify.go
+++ b/internal/transfer/classify.go
@@ -57,8 +57,7 @@ type classifySummary struct {
 }
 
 // SummaryEntry is one regular file (or symlink) the receiver is offered, with
-// the per-entry status the preview annotates rows with. Status uses the same
-// vocabulary as ClassifiedEntry.Category, plus "resume" for a partial on disk.
+// the per-entry status the preview annotates rows with.
 type SummaryEntry struct {
 	RelativePath  string
 	Size          uint64

--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -436,3 +436,28 @@ func TestEngine_SummaryBreakdown(t *testing.T) {
 }
 
 func pad(i int) string { return fmt.Sprintf("%03d", i) }
+
+// manifestStatus is the single source of truth for the --manifest "status"
+// column, so pin every (disposition, decision) combination it can see.
+// TestEngine_Manifest only exercises new/identical end-to-end; the
+// overwritten/kept/resumed branches are unreachable without a prior
+// local copy and an overwrite choice, so cover them here directly.
+func TestManifestStatus(t *testing.T) {
+	for _, tc := range []struct {
+		disp disposition
+		act  wire.DecisionAction
+		want string
+	}{
+		{dispNew, wire.DecisionSend, "new"},
+		{dispDiffers, wire.DecisionSend, "overwritten"},
+		{dispConflict, wire.DecisionSend, "overwritten"},
+		{dispIdentical, wire.DecisionSkip, "identical"},
+		{dispDiffers, wire.DecisionSkip, "kept"},
+		{dispConflict, wire.DecisionSkip, "kept"},
+		{dispResume, wire.DecisionResume, "resumed"},
+	} {
+		if got := manifestStatus(tc.disp, tc.act); got != tc.want {
+			t.Errorf("manifestStatus(%v, %v) = %q, want %q", tc.disp, tc.act, got, tc.want)
+		}
+	}
+}

--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -367,38 +367,37 @@ func TestEngine_TypeConflictFileVsDir(t *testing.T) {
 	}
 }
 
-func TestEngine_DryRun(t *testing.T) {
+func TestEngine_Manifest(t *testing.T) {
 	src, dst := t.TempDir(), t.TempDir()
 	writeFile(t, filepath.Join(src, "new.txt"), []byte("new"))
 	writeFile(t, filepath.Join(src, "same.txt"), []byte("same"))
 	writeFile(t, filepath.Join(dst, "same.txt"), []byte("same"))
-	// Make mtime match for the identical one.
+	// Make mtime match so the identical one is skipped.
 	srcSt, _ := os.Stat(filepath.Join(src, "same.txt"))
 	_ = os.Chtimes(filepath.Join(dst, "same.txt"), srcSt.ModTime(), srcSt.ModTime())
 
-	var got []ClassifiedEntry
-	// Dry run declines the transfer, so the receiver succeeds (it did its
-	// job: report the plan) while the sender sees a decline.
-	_, re := fileTransfer(t, []string{filepath.Join(src, "new.txt"), filepath.Join(src, "same.txt")}, dst, func(o *RecvOptions) {
-		o.DryRun = true
-		o.OnClassified = func(e []ClassifiedEntry) { got = e }
+	var got []ManifestEntry
+	// A real receive — OnManifest fires after it completes, recording what
+	// fsend did with each file.
+	se, re := fileTransfer(t, []string{filepath.Join(src, "new.txt"), filepath.Join(src, "same.txt")}, dst, func(o *RecvOptions) {
+		o.OnManifest = func(e []ManifestEntry) { got = e }
 	})
-	if re != nil {
-		t.Fatalf("dry-run recv=%v", re)
+	if se != nil || re != nil {
+		t.Fatalf("transfer send=%v recv=%v", se, re)
 	}
-	cats := map[string]string{}
+	status := map[string]string{}
 	for _, e := range got {
-		cats[e.RelativePath] = e.Category
+		status[e.RelativePath] = e.Status
 	}
-	if cats["new.txt"] != "new" {
-		t.Errorf("new.txt category = %q", cats["new.txt"])
+	if status["new.txt"] != "new" {
+		t.Errorf("new.txt status = %q, want new", status["new.txt"])
 	}
-	if cats["same.txt"] != "identical" {
-		t.Errorf("same.txt category = %q", cats["same.txt"])
+	if status["same.txt"] != "identical" {
+		t.Errorf("same.txt status = %q, want identical", status["same.txt"])
 	}
-	// Dry run must not write anything new.
-	if _, err := os.Stat(filepath.Join(dst, "new.txt")); err == nil {
-		t.Error("dry run wrote a file")
+	// It's a real receive: the new file actually landed.
+	if _, err := os.Stat(filepath.Join(dst, "new.txt")); err != nil {
+		t.Errorf("new.txt should have been written: %v", err)
 	}
 }
 

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -25,7 +25,6 @@ type RecvOptions struct {
 	ClientVersion string
 	TargetDir     string // where files are written
 	Overwrite     bool
-	DryRun        bool
 	Checksum      bool // verify same-size files by content hash, not mtime
 
 	// Accept is shown the HELLO and (ModeFiles) the classification breakdown.
@@ -46,9 +45,9 @@ type RecvOptions struct {
 	// OnConflictKept fires once per differing/conflicting entry left
 	// untouched (no consent). The CLI uses it to set a non-zero exit code.
 	OnConflictKept func(rel string)
-	// OnClassified, when set and DryRun is true, receives the full
-	// categorization; the transfer is then declined.
-	OnClassified func(entries []ClassifiedEntry)
+	// OnManifest, when set, receives one row per file after a successful
+	// receive — its path, size, and what fsend did with it — backing --manifest.
+	OnManifest func(entries []ManifestEntry)
 
 	// Sink, when non-nil, streams a ModeStream payload here instead of
 	// writing under TargetDir.
@@ -58,10 +57,12 @@ type RecvOptions struct {
 // ClassifySummary is the breakdown surfaced to the accept prompt.
 type ClassifySummary = classifySummary
 
-// ClassifiedEntry is one dry-run categorization row.
-type ClassifiedEntry struct {
+// ManifestEntry is one row of the post-transfer --manifest record: a file and
+// what fsend did with it.
+type ManifestEntry struct {
 	RelativePath string
-	Category     string // new | identical | differs | conflict
+	Size         uint64
+	Status       string // new | identical | overwritten | kept | resumed
 }
 
 // Recv executes the full receiver-side protocol over the supplied streams.
@@ -130,14 +131,6 @@ func recvFiles(ctx context.Context, s *Streams, hello *wire.SenderHello, opts Re
 		}
 	}
 
-	if opts.DryRun {
-		if opts.OnClassified != nil {
-			opts.OnClassified(classifiedEntries(plans))
-		}
-		declineTransfer(s, wire.ErrCodeCancelled, "dry run")
-		return nil
-	}
-
 	summary := summarize(plans)
 	if opts.Accept != nil && !opts.Accept(*hello, summary) {
 		declineTransfer(s, wire.ErrCodeDeclined, "receiver declined")
@@ -185,7 +178,13 @@ func recvFiles(ctx context.Context, s *Streams, hello *wire.SenderHello, opts Re
 	if err := receiveData(ctx, s, byIndex, decisions, plans, expected, opts); err != nil {
 		return err
 	}
-	return finishRecv(s)
+	if err := finishRecv(s); err != nil {
+		return err
+	}
+	if opts.OnManifest != nil {
+		opts.OnManifest(manifestEntries(plans, decisions))
+	}
+	return nil
 }
 
 // finishRecv reads the sender's TRANSFER_COMPLETE, acks it, and waits for the
@@ -715,25 +714,38 @@ func recvStream(ctx context.Context, s *Streams, hello *wire.SenderHello, opts R
 
 // --- helpers ---
 
-func classifiedEntries(plans []entryPlan) []ClassifiedEntry {
-	out := make([]ClassifiedEntry, len(plans))
-	for i, p := range plans {
-		out[i] = ClassifiedEntry{RelativePath: p.entry.RelativePath, Category: categoryName(p.disp)}
+// manifestEntries pairs each non-directory entry with what fsend did to it,
+// for the --manifest record. Directories are structural, not user files.
+func manifestEntries(plans []entryPlan, decisions []wire.Decision) []ManifestEntry {
+	out := make([]ManifestEntry, 0, len(plans))
+	for i := range plans {
+		if plans[i].entry.Type == wire.EntryDir {
+			continue
+		}
+		out = append(out, ManifestEntry{
+			RelativePath: plans[i].entry.RelativePath,
+			Size:         plans[i].entry.Size,
+			Status:       manifestStatus(plans[i].disp, decisions[i].Action),
+		})
 	}
 	return out
 }
 
-func categoryName(d disposition) string {
-	switch d {
-	case dispIdentical:
-		return "identical"
-	case dispDiffers:
-		return "differs"
-	case dispConflict:
-		return "conflict"
-	case dispResume:
-		return "resume"
-	default:
+// manifestStatus names the outcome from the disposition and the decision the
+// receiver sent (which already folded in the overwrite choice).
+func manifestStatus(d disposition, a wire.DecisionAction) string {
+	switch a {
+	case wire.DecisionResume:
+		return "resumed"
+	case wire.DecisionSkip:
+		if d == dispIdentical {
+			return "identical"
+		}
+		return "kept" // differs/conflict left untouched (no consent)
+	default: // DecisionSend
+		if d == dispDiffers || d == dispConflict {
+			return "overwritten"
+		}
 		return "new"
 	}
 }


### PR DESCRIPTION
## What

`--dry-run` was receiver-only and inherently clunky — it had to *pair* (which burns the one-shot code) and then decline, so you could never preview-then-receive (the sender exits, and the code returns `E002`). This splits its job into two purpose-built flags and removes it.

### `--preview` (send-side)
```
$ fsend ./proj --preview
path,size
proj/big.bin,921600
proj/latest,921600
proj/note.txt,2
proj/sub/small.bin,51200
```
Walks locally and prints a CSV of what *would* be sent, then exits — **no code, no pairing, no transfer**. Honors `--exclude`, reflects followed symlinks (`latest` is shown at its target's size). Pipe with `> files.csv` to analyze. Rejected on the receive side.

### `--manifest <file>` (receive-side)
After a **real** receive, writes a CSV recording what fsend did with each file:
```
path,size,status
proj/big.bin,921600,identical
proj/note.txt,2,overwritten
proj/sub/small.bin,51200,identical
```
`status` ∈ `new` / `identical` / `overwritten` / `kept` / `resumed`. It works with `--yes`/`--quiet`, **never burns the code** (it's part of a real receive), and writes to an **explicit path** — not into the payload folder (no round-trip contamination). Rejected on send and with `--out -`.

## Why this shape
- The receiver's interactive "should I accept?" need is already covered by the pre-transfer preview (#80). `--manifest` is the *post-transfer, scriptable record* — the unique value being the per-file `status`, which a plain `ls` can't tell you.
- `--dry-run` is **deleted outright** (no hidden alias) — the tool is new enough that a clean break beats carrying a deprecated flag.

## Testing
- New: `TestEngine_Manifest` (engine fires `OnManifest` with correct statuses on a real receive), `TestWriteSendPreview` (CSV format, dirs dropped, comma-quoting), and three dispatch-rejection cases (`--preview` on receive, `--manifest` on send, `--manifest` + `--out -`).
- Verified end-to-end with real LAN transfers: `--preview` lists + exits (no transfer); `--manifest` produced correct `new`/`identical`/`kept`/`overwritten` across fresh/re-send/`--overwrite` runs, and the CSV is **not** written into the output folder.
- Docs updated (`usage.md`, `comparison.md`, `troubleshooting.md`). `gofmt`, full `go test ./...`, `-race`, and a Windows cross-compile all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)