### PR TITLE
feat(server): add FSEND_ENABLE_RELAY (pairing + STUN only mode)

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -126,6 +126,9 @@ func runReceiveOverInternet(ctx context.Context, f *flags, c string, cfg *config
 	if allocErr != nil {
 		return fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, allocErr)
 	}
+	if alloc.ForwardingDisabled {
+		return fmt.Errorf("%w: direct connection failed and this server has relay forwarding disabled", fserrors.ErrConnectFailed)
+	}
 	relayConn, err := dialRelay(alloc)
 	if err != nil {
 		return fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, err)

--- a/cmd/fsend/relay_disabled_test.go
+++ b/cmd/fsend/relay_disabled_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/server"
+	"github.com/polius/fsend/internal/signaling"
+)
+
+// When the server allocates in stun-only mode (forwarding_disabled), the
+// client must fail fast with a clear ErrConnectFailed instead of dialing a
+// relay that would only drop its datagrams.
+func TestAllocAndDialRelay_ForwardingDisabled(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(server.RelayAllocateResponse{
+			RelayAddr:          "127.0.0.1:1",
+			SessionToken:       "01000000000000000000000000",
+			ForwardingDisabled: true,
+		})
+	}))
+	defer ts.Close()
+
+	_, _, err := allocAndDialRelay(context.Background(),
+		signaling.New(ts.URL, "test"), "sid", "role")
+	if !errors.Is(err, fserrors.ErrConnectFailed) {
+		t.Fatalf("err = %v, want ErrConnectFailed", err)
+	}
+	if !strings.Contains(err.Error(), "forwarding disabled") {
+		t.Errorf("err %q should explain relay forwarding is disabled", err)
+	}
+}

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -337,6 +337,9 @@ func establishInternetDataPath(ctx context.Context, f *flags, client *signaling.
 	if allocErr != nil {
 		return nil, connpath.Info{}, fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, allocErr)
 	}
+	if alloc.ForwardingDisabled {
+		return nil, connpath.Info{}, fmt.Errorf("%w: direct connection failed and this server has relay forwarding disabled", fserrors.ErrConnectFailed)
+	}
 	rc, err := dialRelay(alloc)
 	if err != nil {
 		return nil, connpath.Info{}, fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, err)
@@ -351,6 +354,9 @@ func allocAndDialRelay(ctx context.Context, client *signaling.Client, sessionID,
 	alloc, err := client.AllocateRelay(ctx, sessionID, roleToken)
 	if err != nil {
 		return nil, connpath.Info{}, fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, err)
+	}
+	if alloc.ForwardingDisabled {
+		return nil, connpath.Info{}, fmt.Errorf("%w: this server has relay forwarding disabled", fserrors.ErrConnectFailed)
 	}
 	rc, err := dialRelay(alloc)
 	if err != nil {

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -96,6 +96,7 @@ func runServer() error {
 	relaySrv := relay.NewServer(udpListener, relay.ServerConfig{
 		MaxBytesPerSession: cfg.maxBytesPerSession,
 		Logger:             logger,
+		DisableForwarding:  !cfg.enableRelay,
 	})
 	udpPort, err := udpPortFromAddr(cfg.udpAddr)
 	if err != nil {
@@ -110,6 +111,9 @@ func runServer() error {
 		}
 	}()
 	logger.Info("relay UDP listener up", "addr", cfg.udpAddr, "udp_port", udpPort)
+	if !cfg.enableRelay {
+		logger.Info("relay forwarding disabled (FSEND_ENABLE_RELAY=false); STUN/hole-punching still active")
+	}
 
 	httpSrv := &http.Server{
 		Addr:              cfg.httpAddr,
@@ -198,6 +202,7 @@ type serverRuntimeConfig struct {
 	maxNewSessionsPerMin int
 	maxBytesPerSession   uint64
 	serverPassword       string
+	enableRelay          bool
 }
 
 func loadServerConfig() (serverRuntimeConfig, error) {
@@ -214,6 +219,9 @@ func loadServerConfig() (serverRuntimeConfig, error) {
 		return cfg, err
 	}
 	if cfg.maxBytesPerSession, err = envBytes("FSEND_MAX_RELAY_BYTES_PER_SESSION", 100*1000*1000); err != nil {
+		return cfg, err
+	}
+	if cfg.enableRelay, err = envBool("FSEND_ENABLE_RELAY", true); err != nil {
 		return cfg, err
 	}
 	switch strings.ToLower(os.Getenv("FSEND_LOG_LEVEL")) {
@@ -249,6 +257,21 @@ func udpPortFromAddr(addr string) (int, error) {
 		return 0, fmt.Errorf("port out of range")
 	}
 	return p, nil
+}
+
+// envBool reads a boolean (strconv.ParseBool: 1/t/true, 0/f/false…) from
+// name. Unset/blank → def; anything unparseable is an error rather than a
+// silent default, so a typo'd toggle fails loudly instead of misbehaving.
+func envBool(name string, def bool) (bool, error) {
+	v := strings.TrimSpace(os.Getenv(name))
+	if v == "" {
+		return def, nil
+	}
+	b, err := strconv.ParseBool(v)
+	if err != nil {
+		return false, fmt.Errorf("%s=%q: not a boolean (use true/false)", name, v)
+	}
+	return b, nil
 }
 
 func envInt(name string, def int) (int, error) {
@@ -351,6 +374,10 @@ CONFIGURATION (environment variables — all optional)
                                         after compression (accepts B, KB, MB,
                                         GB, TB, or a plain byte count, e.g.
                                         "100MB", "500KB", "104857600")
+  FSEND_ENABLE_RELAY                    Default true. Set false for pairing +
+                                        STUN only: peers still hole-punch, but
+                                        the server carries no data (symmetric-NAT
+                                        transfers fail instead of relaying)
   FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every
                                         endpoint except /v1/health requires the
                                         X-Fsend-Auth header to match. Clients:

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -69,6 +69,22 @@ func TestServerEnvInt(t *testing.T) {
 	}
 }
 
+func TestServerEnvBool(t *testing.T) {
+	const k = "FSEND_TEST_ENV_BOOL"
+	os.Unsetenv(k)
+	if got, err := envBool(k, true); err != nil || !got {
+		t.Errorf("unset: got %v, %v; want true", got, err)
+	}
+	t.Setenv(k, "false")
+	if got, err := envBool(k, true); err != nil || got {
+		t.Errorf("set false: got %v, %v; want false", got, err)
+	}
+	t.Setenv(k, "maybe")
+	if _, err := envBool(k, true); err == nil {
+		t.Error("typo: want error, got nil")
+	}
+}
+
 func TestServerEnvBytes(t *testing.T) {
 	const k = "FSEND_TEST_ENV_BYTES"
 	const def uint64 = 100

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -174,7 +174,7 @@ All optional; defaults shown. Set them under the `fsend` service's
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
 | `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit. |
-| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `1GB` | Per-session relay cap — wire bytes after compression. Tune to your bandwidth budget. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`1073741824`). |
+| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MB` | Per-session relay cap — wire bytes after compression. Tune to your bandwidth budget. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`100000000`). |
 | `FSEND_ENABLE_RELAY` | `true` | Set `false` for **pairing + STUN only**: the server still helps peers hole-punch a direct path, but carries no file data. See [Pairing-only mode](#pairing-only-mode-no-relay). |
 
 ### Pairing-only mode (no relay)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -175,3 +175,17 @@ All optional; defaults shown. Set them under the `fsend` service's
 | `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
 | `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit. |
 | `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `1GB` | Per-session relay cap — wire bytes after compression. Tune to your bandwidth budget. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`1073741824`). |
+| `FSEND_ENABLE_RELAY` | `true` | Set `false` for **pairing + STUN only**: the server still helps peers hole-punch a direct path, but carries no file data. See [Pairing-only mode](#pairing-only-mode-no-relay). |
+
+### Pairing-only mode (no relay)
+
+Set `FSEND_ENABLE_RELAY=false` to run the server as a pure matchmaker: it
+answers STUN (so peers can still hole-punch directly across NATs) but never
+forwards a single byte of file data. Use this when you want to help peers
+find each other without paying for — or being liable for — relayed traffic.
+
+The trade-off: when hole-punching fails (typically symmetric NAT on both
+ends), there is no fallback. Those transfers fail with a clear
+"relay forwarding disabled" error instead of relaying. Same-LAN and
+direct-internet transfers are unaffected. The UDP listener still binds (STUN
+needs it); only forwarding is off.

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -203,6 +203,95 @@ func TestServer_STUNBinding(t *testing.T) {
 	<-srvErr
 }
 
+// TestForwardingDisabled verifies stun-only mode: the relay still answers
+// STUN binding requests but never forwards data datagrams.
+func TestForwardingDisabled(t *testing.T) {
+	serverConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	relayAddr := serverConn.LocalAddr().(*net.UDPAddr)
+
+	srv := NewServer(serverConn, ServerConfig{DisableForwarding: true})
+	if srv.Forwarding() {
+		t.Fatal("Forwarding() should be false when DisableForwarding is set")
+	}
+	tok, err := srv.Allocate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srvErr := make(chan error, 1)
+	go func() { srvErr <- srv.Run(ctx) }()
+
+	clientA, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientA.Close()
+	clientB, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer clientB.Close()
+	connA := NewClient(clientA, relayAddr, tok)
+	connB := NewClient(clientB, relayAddr, tok)
+
+	// Both peers register, then A sends a payload that must NOT reach B.
+	if _, err := connA.WriteTo([]byte("hello"), nil); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := connB.WriteTo([]byte("register"), nil); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(50 * time.Millisecond)
+	if _, err := connA.WriteTo([]byte("real message"), nil); err != nil {
+		t.Fatal(err)
+	}
+	buf := make([]byte, 1500)
+	_ = connB.SetReadDeadline(time.Now().Add(500 * time.Millisecond))
+	if n, _, err := connB.ReadFrom(buf); err == nil {
+		t.Fatalf("relay forwarded %q with forwarding disabled", buf[:n])
+	}
+
+	// STUN must still answer in stun-only mode.
+	stunClient, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer stunClient.Close()
+	req, err := stun.Build(stun.TransactionID, stun.BindingRequest)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := stunClient.WriteTo(req.Raw, relayAddr); err != nil {
+		t.Fatal(err)
+	}
+	_ = stunClient.SetReadDeadline(time.Now().Add(2 * time.Second))
+	n, _, err := stunClient.ReadFrom(buf)
+	if err != nil {
+		t.Fatalf("no STUN response in stun-only mode: %v", err)
+	}
+	resp := &stun.Message{Raw: buf[:n]}
+	if err := resp.Decode(); err != nil {
+		t.Fatalf("decode STUN response: %v", err)
+	}
+	if resp.Type != stun.BindingSuccess {
+		t.Fatalf("STUN type: got %v, want BindingSuccess", resp.Type)
+	}
+
+	cancel()
+	_ = serverConn.Close()
+	<-srvErr
+}
+
+func TestForwardingEnabledByDefault(t *testing.T) {
+	if !NewServer(nil, ServerConfig{}).Forwarding() {
+		t.Fatal("a default relay should forward")
+	}
+}
+
 func TestAllowSTUNResponse_RateCap(t *testing.T) {
 	s := &Server{}
 	base := time.Unix(1700000000, 0)

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -81,6 +81,9 @@ const TombstoneTTL = 5 * time.Minute
 type ServerConfig struct {
 	MaxBytesPerSession uint64
 	Logger             *slog.Logger
+	// DisableForwarding makes the relay answer STUN but never carry data
+	// (pairing + hole-punching only). Negative so the zero value forwards.
+	DisableForwarding bool
 }
 
 // janitorInterval is how often the eviction loop sweeps idle
@@ -159,6 +162,12 @@ func (s *Server) ActiveAllocations() int {
 // signaling layer can include it in the relay-status response.
 func (s *Server) MaxBytesPerSession() uint64 {
 	return s.cfg.MaxBytesPerSession
+}
+
+// Forwarding reports whether the relay carries data, so the signaling
+// layer can tell clients to skip the relay fallback when it doesn't.
+func (s *Server) Forwarding() bool {
+	return !s.cfg.DisableForwarding
 }
 
 // Status returns the eviction reason for a token, or "" if the
@@ -257,6 +266,9 @@ func (s *Server) handle(datagram []byte, src *net.UDPAddr) {
 	if len(datagram) > 0 && datagram[0] != ProtocolVersion {
 		s.handleSTUN(datagram, src)
 		return
+	}
+	if s.cfg.DisableForwarding {
+		return // stun-only mode: STUN answered above, data never carried
 	}
 	ver, token, _, ok := Parse(datagram)
 	if !ok || ver != ProtocolVersion {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -122,6 +122,7 @@ type RelayAllocator interface {
 	Allocate() (relay.Token, error)
 	Status(relay.Token) string
 	MaxBytesPerSession() uint64
+	Forwarding() bool
 }
 
 // WithRelay wires a relay allocator into the signaling layer.
@@ -316,9 +317,10 @@ func (s *Server) allocateRelay(w http.ResponseWriter, r *http.Request) {
 	relayTok := sess.relayToken
 	s.mu.Unlock()
 	writeJSON(w, http.StatusOK, RelayAllocateResponse{
-		RelayAddr:    s.relayAddrFor(r),
-		SessionToken: relayTok.String(),
-		TTLSeconds:   600,
+		RelayAddr:          s.relayAddrFor(r),
+		SessionToken:       relayTok.String(),
+		TTLSeconds:         600,
+		ForwardingDisabled: !s.relayAllocator.Forwarding(),
 	})
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -480,16 +480,18 @@ func TestServerPassword_OpenByDefault(t *testing.T) {
 // fakeRelay implements RelayAllocator with fixed responses, so the
 // relay-status handler can be exercised without standing up a UDP relay.
 type fakeRelay struct {
-	tok      relay.Token
-	reason   string
-	maxBytes uint64
-	dead     bool
+	tok       relay.Token
+	reason    string
+	maxBytes  uint64
+	dead      bool
+	noForward bool
 }
 
 func (f *fakeRelay) Allocate() (relay.Token, error) { return f.tok, nil }
 func (f *fakeRelay) Status(t relay.Token) string    { return f.reason }
 func (f *fakeRelay) MaxBytesPerSession() uint64     { return f.maxBytes }
 func (f *fakeRelay) Healthy() bool                  { return !f.dead }
+func (f *fakeRelay) Forwarding() bool               { return !f.noForward }
 
 // /v1/health must flip to 503/degraded once the relay read loop has died,
 // so an orchestrator restarts the container instead of trusting a zombie.
@@ -583,6 +585,56 @@ func TestRelayStatus_IncludesConfiguredLimits(t *testing.T) {
 			}
 			if body.LimitBytes != c.wantBytes {
 				t.Errorf("limit_bytes = %d, want %d", body.LimitBytes, c.wantBytes)
+			}
+		})
+	}
+}
+
+// TestRelayAllocate_ForwardingDisabledFlag checks the allocate response
+// mirrors the relay's forwarding mode: the flag is set only in stun-only
+// mode, and RelayAddr is always populated (it's the STUN server).
+func TestRelayAllocate_ForwardingDisabledFlag(t *testing.T) {
+	cases := []struct {
+		name      string
+		noForward bool
+		want      bool
+	}{
+		{name: "forwarding", noForward: false, want: false},
+		{name: "stun_only", noForward: true, want: true},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			s := New(Config{
+				ServerVersion:        "0.0.0-test",
+				UnpairedTTL:          2 * time.Second,
+				PairedTTL:            5 * time.Second,
+				MaxSessionsPerIP:     10,
+				MaxNewSessionsPerMin: 100,
+			})
+			s.WithRelay(&fakeRelay{tok: relay.Token{1, 2, 3, 4}, noForward: c.noForward}, 9999)
+			ts := httptest.NewServer(s.Handler())
+			defer ts.Close()
+
+			cr := createSession(t, ts.URL, testSlot)
+			req, _ := http.NewRequest(http.MethodPost, ts.URL+"/v1/relay/allocate",
+				bytes.NewReader(mustJSON(t, RelayAllocateRequest{SessionID: cr.SessionID})))
+			req.Header.Set("Content-Type", "application/json")
+			req.Header.Set("Authorization", "Bearer "+cr.RoleToken)
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+			var body RelayAllocateResponse
+			if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+				t.Fatal(err)
+			}
+			if body.ForwardingDisabled != c.want {
+				t.Errorf("forwarding_disabled = %v, want %v", body.ForwardingDisabled, c.want)
+			}
+			if body.RelayAddr == "" {
+				t.Error("relay_addr must be set even in stun-only mode (it's the STUN server)")
 			}
 		})
 	}

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -82,10 +82,16 @@ type RelayAllocateRequest struct {
 }
 
 // RelayAllocateResponse is the body returned on relay allocation.
+//
+// ForwardingDisabled is set when the server does pairing + STUN only and
+// won't carry data. RelayAddr is still returned (it's the STUN server);
+// the client uses it for srflx gathering but skips the relay fallback.
+// omitempty so older servers round-trip as false (forwarding capable).
 type RelayAllocateResponse struct {
-	RelayAddr    string `json:"relay_addr"`
-	SessionToken string `json:"session_token"` // Crockford-base32 encoded 16 bytes
-	TTLSeconds   int    `json:"ttl_seconds"`
+	RelayAddr          string `json:"relay_addr"`
+	SessionToken       string `json:"session_token"` // Crockford-base32 encoded 16 bytes
+	TTLSeconds         int    `json:"ttl_seconds"`
+	ForwardingDisabled bool   `json:"forwarding_disabled,omitempty"`
 }
 
 // HealthResponse is the body of GET /v1/health.


### PR DESCRIPTION
## What

Adds `FSEND_ENABLE_RELAY` (default `true`). Setting it `false` runs the server in **stun-only mode**: it still answers STUN so peers can hole-punch a direct path, but carries no file data. For operators who want to help peers connect without paying for — or being liable for — relayed traffic.

Default behaviour is unchanged (byte-identical to today); no protocol break.

## Why

In the current architecture one UDP socket does three jobs: STUN binding, STUN-address delivery (via the allocate response), and byte forwarding. So a naive "disable the relay" that tears down the listener would *also* kill hole-punching, leaving same-LAN + public-IP peers only. This change decouples forwarding from STUN: STUN/pairing stay, only data forwarding is gated.

## How

Two enforcement points:

- **Relay teeth** (`internal/relay`): `ServerConfig.DisableForwarding` (negative-framed so the zero value forwards). A one-line gate in `handle` drops data datagrams *after* the STUN dispatch — bytes never move even for a non-compliant/old client. `Forwarding()` exposes the mode to the signaling layer.
- **Client signal** (`internal/server` + `cmd/fsend`): allocate response gains `forwarding_disabled` (`omitempty`, so old servers round-trip as `false` = forwarding-capable). The client keeps using `RelayAddr` for STUN but skips the relay dial and fails fast with a clear `ErrConnectFailed` instead of timing out on a relay that would only drop its packets. Applied at all three consumer sites (sender fallback, receiver fallback, `--mode=relay`).

The UDP listener always binds (STUN needs it); only forwarding is gated. Bearer-token gate on allocate is unchanged. A startup log line announces stun-only mode.

## Behaviour matrix

| client → server | result |
|---|---|
| new ↔ stun-only | fast, clean "relay forwarding disabled" error |
| old ↔ stun-only | still tries the relay dial → slow QUIC timeout (degraded but safe) |
| any ↔ old server | field absent → `false` → unchanged |

## Tests (all pass, `-race` clean)

- `TestForwardingDisabled` — data dropped while STUN still answers (the core guarantee, one test)
- `TestForwardingEnabledByDefault` — default forwards
- `TestRelayAllocate_ForwardingDisabledFlag` — response flag mirrors the mode; `RelayAddr` always set
- `TestAllocAndDialRelay_ForwardingDisabled` — client fails cleanly without dialing
- `TestServerEnvBool` — `envBool` parses and rejects typos loudly (matches `envInt`/`envBytes`)

Verified locally: `go build`, `go vet`, `gofmt -l`, full suite incl. `-race`. (golangci-lint couldn't run locally — its binary targets go1.25 vs the repo's 1.26.4; CI covers it.)

## Docs

`docs/self-hosting.md`: config row + a "Pairing-only mode" section spelling out the trade-off (symmetric-NAT transfers fail rather than relay; UDP still binds for STUN). `fsend server --help` updated.

## Note

Second commit is an unrelated **pre-existing** doc fix (`FSEND_MAX_RELAY_BYTES_PER_SESSION` default was documented as 1GB; the real default is 100MB). Kept separate so it can be dropped/cherry-picked independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)