### PR TITLE
refactor(server): group env vars by subsystem; relay cap default 1GB

### DIFF
--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -100,7 +100,7 @@ func runServer() error {
 	})
 	udpPort, err := udpPortFromAddr(cfg.udpAddr)
 	if err != nil {
-		return fmt.Errorf("%w: FSEND_UDP_ADDR %q: %v", fserrors.ErrServerStartup, cfg.udpAddr, err)
+		return fmt.Errorf("%w: FSEND_RELAY_ADDR %q: %v", fserrors.ErrServerStartup, cfg.udpAddr, err)
 	}
 	s.WithRelay(relaySrv, udpPort)
 	relayCtx, relayCancel := context.WithCancel(ctx)
@@ -112,7 +112,7 @@ func runServer() error {
 	}()
 	logger.Info("relay UDP listener up", "addr", cfg.udpAddr, "udp_port", udpPort)
 	if !cfg.enableRelay {
-		logger.Info("relay forwarding disabled (FSEND_ENABLE_RELAY=false); STUN/hole-punching still active")
+		logger.Info("relay forwarding disabled (FSEND_RELAY_ENABLED=false); STUN/hole-punching still active")
 	}
 
 	httpSrv := &http.Server{
@@ -207,21 +207,21 @@ type serverRuntimeConfig struct {
 
 func loadServerConfig() (serverRuntimeConfig, error) {
 	cfg := serverRuntimeConfig{
-		httpAddr:       envOr("FSEND_HTTP_ADDR", ":8080"),
-		udpAddr:        envOr("FSEND_UDP_ADDR", ":443"),
+		httpAddr:       envOr("FSEND_PAIRING_ADDR", ":8080"),
+		udpAddr:        envOr("FSEND_RELAY_ADDR", ":443"),
 		serverPassword: os.Getenv("FSEND_SERVER_PASSWORD"),
 	}
 	var err error
-	if cfg.maxSessionsPerIP, err = envInt("FSEND_MAX_SESSIONS_PER_IP", 5); err != nil {
+	if cfg.maxSessionsPerIP, err = envInt("FSEND_PAIRING_MAX_SESSIONS_PER_IP", 5); err != nil {
 		return cfg, err
 	}
-	if cfg.maxNewSessionsPerMin, err = envInt("FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN", 30); err != nil {
+	if cfg.maxNewSessionsPerMin, err = envInt("FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN", 30); err != nil {
 		return cfg, err
 	}
-	if cfg.maxBytesPerSession, err = envBytes("FSEND_MAX_RELAY_BYTES_PER_SESSION", 100*1000*1000); err != nil {
+	if cfg.maxBytesPerSession, err = envBytes("FSEND_RELAY_MAX_BYTES_PER_SESSION", 1000*1000*1000); err != nil { // 1GB
 		return cfg, err
 	}
-	if cfg.enableRelay, err = envBool("FSEND_ENABLE_RELAY", true); err != nil {
+	if cfg.enableRelay, err = envBool("FSEND_RELAY_ENABLED", true); err != nil {
 		return cfg, err
 	}
 	switch strings.ToLower(os.Getenv("FSEND_LOG_LEVEL")) {
@@ -329,7 +329,7 @@ func envBytes(name string, def uint64) (uint64, error) {
 // HTTP address. Exits 0 on healthy, 1 on anything else. Designed for
 // Docker HEALTHCHECK.
 func healthCheck() error {
-	addr := envOr("FSEND_HTTP_ADDR", ":8080")
+	addr := envOr("FSEND_PAIRING_ADDR", ":8080")
 	if strings.HasPrefix(addr, ":") {
 		addr = "127.0.0.1" + addr
 	}
@@ -365,23 +365,32 @@ EXAMPLE
   See deploy/compose/docker-compose.yml for a Caddy + Let's Encrypt setup.
 
 CONFIGURATION (environment variables — all optional)
-  FSEND_HTTP_ADDR                       Default :8080
-  FSEND_UDP_ADDR                        Default :443
-  FSEND_LOG_LEVEL                       Default info
-  FSEND_MAX_SESSIONS_PER_IP             Default 5
-  FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN Default 30
-  FSEND_MAX_RELAY_BYTES_PER_SESSION     Default 100MB, counted in wire bytes
-                                        after compression (accepts B, KB, MB,
-                                        GB, TB, or a plain byte count, e.g.
-                                        "100MB", "500KB", "104857600")
-  FSEND_ENABLE_RELAY                    Default true. Set false for pairing +
-                                        STUN only: peers still hole-punch, but
-                                        the server carries no data (symmetric-NAT
-                                        transfers fail instead of relaying)
-  FSEND_SERVER_PASSWORD                 Optional shared secret. When set, every
-                                        endpoint except /v1/health requires the
-                                        X-Fsend-Auth header to match. Clients:
-                                        fsend --connect <host:port>,<password>
+
+  General:
+    FSEND_LOG_LEVEL                   Default info (debug/info/warn/error).
+    FSEND_SERVER_PASSWORD             Optional shared secret. When set, all
+                                      endpoints except /v1/health require the
+                                      X-Fsend-Auth header. Connect with
+                                      fsend --connect <host:port>,<password>.
+
+  Pairing (TCP signaling/control plane):
+    FSEND_PAIRING_ADDR                Default :8080 (TCP).
+    FSEND_PAIRING_MAX_SESSIONS_PER_IP Default 5 — concurrent sessions per
+                                      source IP.
+    FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN
+                                      Default 30 — new sessions per source
+                                      IP per minute.
+
+  Relay (UDP data plane — also answers STUN):
+    FSEND_RELAY_ENABLED               Default true. false = pairing + STUN
+                                      only: peers still hole-punch, but the
+                                      server carries no file data.
+    FSEND_RELAY_ADDR                  Default :443 (UDP). Also the STUN
+                                      endpoint, so it stays in use even
+                                      when forwarding is disabled.
+    FSEND_RELAY_MAX_BYTES_PER_SESSION Default 1GB — wire bytes after
+                                      compression. Accepts B, KB, MB, GB,
+                                      TB, or a plain byte count.
 
 LEARN MORE
   https://github.com/polius/fsend

--- a/cmd/fsend/server_lifecycle_unix_test.go
+++ b/cmd/fsend/server_lifecycle_unix_test.go
@@ -34,8 +34,8 @@ func TestServerLifecycle(t *testing.T) {
 	udpPort := srvFreePortUDP(t)
 	httpAddr := fmt.Sprintf("127.0.0.1:%d", httpPort)
 	udpAddr := fmt.Sprintf("127.0.0.1:%d", udpPort)
-	t.Setenv("FSEND_HTTP_ADDR", httpAddr)
-	t.Setenv("FSEND_UDP_ADDR", udpAddr)
+	t.Setenv("FSEND_PAIRING_ADDR", httpAddr)
+	t.Setenv("FSEND_RELAY_ADDR", udpAddr)
 	t.Setenv("FSEND_LOG_LEVEL", "error")
 
 	sink := make(chan os.Signal, 1)

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -147,12 +147,12 @@ func TestServerEnvBytes(t *testing.T) {
 func clearServerEnv(t *testing.T) {
 	t.Helper()
 	for _, k := range []string{
-		"FSEND_HTTP_ADDR",
-		"FSEND_UDP_ADDR",
+		"FSEND_PAIRING_ADDR",
+		"FSEND_RELAY_ADDR",
 		"FSEND_LOG_LEVEL",
-		"FSEND_MAX_SESSIONS_PER_IP",
-		"FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN",
-		"FSEND_MAX_RELAY_BYTES_PER_SESSION",
+		"FSEND_PAIRING_MAX_SESSIONS_PER_IP",
+		"FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN",
+		"FSEND_RELAY_MAX_BYTES_PER_SESSION",
 	} {
 		os.Unsetenv(k)
 	}
@@ -176,8 +176,8 @@ func TestServerLoadConfigDefaults(t *testing.T) {
 	if cfg.maxNewSessionsPerMin != 30 {
 		t.Errorf("maxNewSessionsPerMin: got %d, want 30", cfg.maxNewSessionsPerMin)
 	}
-	if cfg.maxBytesPerSession != 100*srvMB {
-		t.Errorf("maxBytesPerSession: got %d, want %d", cfg.maxBytesPerSession, 100*srvMB)
+	if cfg.maxBytesPerSession != 1000*srvMB { // 1GB
+		t.Errorf("maxBytesPerSession: got %d, want %d", cfg.maxBytesPerSession, 1000*srvMB)
 	}
 	if cfg.logLevel != slog.LevelInfo {
 		t.Errorf("logLevel: got %v, want info", cfg.logLevel)
@@ -186,11 +186,11 @@ func TestServerLoadConfigDefaults(t *testing.T) {
 
 func TestServerLoadConfigOverrides(t *testing.T) {
 	clearServerEnv(t)
-	t.Setenv("FSEND_HTTP_ADDR", ":19999")
-	t.Setenv("FSEND_UDP_ADDR", ":29999")
-	t.Setenv("FSEND_MAX_SESSIONS_PER_IP", "12")
-	t.Setenv("FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN", "120")
-	t.Setenv("FSEND_MAX_RELAY_BYTES_PER_SESSION", "250MB")
+	t.Setenv("FSEND_PAIRING_ADDR", ":19999")
+	t.Setenv("FSEND_RELAY_ADDR", ":29999")
+	t.Setenv("FSEND_PAIRING_MAX_SESSIONS_PER_IP", "12")
+	t.Setenv("FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN", "120")
+	t.Setenv("FSEND_RELAY_MAX_BYTES_PER_SESSION", "250MB")
 	cfg, err := loadServerConfig()
 	if err != nil {
 		t.Fatalf("loadServerConfig: %v", err)
@@ -215,9 +215,9 @@ func TestServerLoadConfigOverrides(t *testing.T) {
 func TestServerLoadConfigRejectsBadValues(t *testing.T) {
 	// A typo'd limit must stop the server, not silently run the default.
 	cases := map[string]string{
-		"FSEND_MAX_RELAY_BYTES_PER_SESSION":     "1GiB",
-		"FSEND_MAX_SESSIONS_PER_IP":             "many",
-		"FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN": "-1",
+		"FSEND_RELAY_MAX_BYTES_PER_SESSION":             "1GiB",
+		"FSEND_PAIRING_MAX_SESSIONS_PER_IP":             "many",
+		"FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN": "-1",
 	}
 	for k, v := range cases {
 		t.Run(k+"="+v, func(t *testing.T) {
@@ -261,7 +261,7 @@ func TestServerLoadConfigLogLevels(t *testing.T) {
 func TestServerHealthCheckUnreachable(t *testing.T) {
 	// Bind+close to take a known-free port, then probe it (nothing listens).
 	port := srvFreePortTCP(t)
-	t.Setenv("FSEND_HTTP_ADDR", fmt.Sprintf("127.0.0.1:%d", port))
+	t.Setenv("FSEND_PAIRING_ADDR", fmt.Sprintf("127.0.0.1:%d", port))
 	if err := healthCheck(); err == nil {
 		t.Fatal("expected error against closed port")
 	}
@@ -269,7 +269,7 @@ func TestServerHealthCheckUnreachable(t *testing.T) {
 
 func TestServerHealthCheckBadStatus(t *testing.T) {
 	addr := startStubHealth(t, http.StatusInternalServerError, nil)
-	t.Setenv("FSEND_HTTP_ADDR", addr)
+	t.Setenv("FSEND_PAIRING_ADDR", addr)
 	err := healthCheck()
 	if err == nil {
 		t.Fatal("expected error for 500 response")
@@ -278,7 +278,7 @@ func TestServerHealthCheckBadStatus(t *testing.T) {
 
 func TestServerHealthCheckOK(t *testing.T) {
 	addr := startStubHealth(t, http.StatusOK, []byte(`{"ok":true}`))
-	t.Setenv("FSEND_HTTP_ADDR", addr)
+	t.Setenv("FSEND_PAIRING_ADDR", addr)
 	if err := healthCheck(); err != nil {
 		t.Errorf("healthCheck: %v", err)
 	}
@@ -286,7 +286,7 @@ func TestServerHealthCheckOK(t *testing.T) {
 
 // startStubHealth boots a minimal HTTP server that answers /v1/health with
 // the given status + body, and shuts it down when the test ends. Returns
-// the host:port the test should set as FSEND_HTTP_ADDR.
+// the host:port the test should set as FSEND_PAIRING_ADDR.
 func startStubHealth(t *testing.T, status int, body []byte) string {
 	t.Helper()
 	port := srvFreePortTCP(t)

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -17,17 +17,9 @@ services:
     restart: unless-stopped
     ports:
       - "443:443/udp"
-    environment:
-      # All env vars are optional.
-      FSEND_HTTP_ADDR: ":8080"
-      FSEND_UDP_ADDR: ":443"
-      FSEND_LOG_LEVEL: "info"
-      # Abuse limits — tune to your bandwidth budget.
-      FSEND_MAX_RELAY_BYTES_PER_SESSION: "1GB"
-      FSEND_MAX_SESSIONS_PER_IP: "5"
-      FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN: "30"
-      # Password to restrict server access (empty = open); clients use `fsend --connect <domain>,<password>`.
-      FSEND_SERVER_PASSWORD: ""
+    # See `fsend server --help` for all settings.
+    # environment:
+    #   FSEND_SERVER_PASSWORD: "change-me"   # restrict access (unset = open)
     healthcheck:
       test: ["CMD", "/fsend", "server", "--health-check"]
       interval: 30s

--- a/docs/development.md
+++ b/docs/development.md
@@ -68,8 +68,8 @@ For internet transfers (one peer behind NAT), the client needs a pairing
 server. To exercise the full client↔server↔client path:
 
 ```sh
-FSEND_HTTP_ADDR=":18080" \
-FSEND_UDP_ADDR=":18443" \
+FSEND_PAIRING_ADDR=":18080" \
+FSEND_RELAY_ADDR=":18443" \
 FSEND_LOG_LEVEL=debug \
 /tmp/fsend server
 ```
@@ -93,17 +93,17 @@ Reset to the public default:
 Health check (the env var tells the probe where to look):
 
 ```sh
-FSEND_HTTP_ADDR=":18080" /tmp/fsend server --health-check
+FSEND_PAIRING_ADDR=":18080" /tmp/fsend server --health-check
 ```
 
 ### Common server env vars
 
 | Var | Default | Notes |
 |---|---|---|
-| `FSEND_HTTP_ADDR` | `:8080` | Signaling listener |
-| `FSEND_UDP_ADDR` | `:443` | Relay listener (UDP) |
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
-| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MB` | Binary default; the [compose stack](self-hosting.md) sets `1GB`. |
+| `FSEND_PAIRING_ADDR` | `:8080` | Signaling listener (TCP) |
+| `FSEND_RELAY_ADDR` | `:443` | Relay listener (UDP); also the STUN endpoint |
+| `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `1GB` | Per-session relay cap (wire bytes, post-compression). |
 
 Full list: `/tmp/fsend server --help`. For deployment, ports, and all
 tunables, see [Self-hosting](self-hosting.md).

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -166,20 +166,24 @@ Connecting without it — or with the wrong one — fails with `E028`.
 All optional; defaults shown. Set them under the `fsend` service's
 `environment:` block in `docker-compose.yml`.
 
+Variables are grouped by subsystem: **general**, **pairing** (the TCP
+signaling/control plane), and **relay** (the UDP data plane, which also
+answers STUN).
+
 | Variable | Default | Notes |
 |---|---|---|
-| `FSEND_HTTP_ADDR` | `:8080` | TCP signaling listener. |
-| `FSEND_UDP_ADDR` | `:443` | UDP relay listener. The server tells clients to dial `<request-host>:<this port>`, so no separate public-address knob is needed. |
-| `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret restricting all endpoints except `/v1/health` — see [Require a password](#require-a-password-optional). |
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
-| `FSEND_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
-| `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit. |
-| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `100MB` | Per-session relay cap — wire bytes after compression. Tune to your bandwidth budget. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`100000000`). |
-| `FSEND_ENABLE_RELAY` | `true` | Set `false` for **pairing + STUN only**: the server still helps peers hole-punch a direct path, but carries no file data. See [Pairing-only mode](#pairing-only-mode-no-relay). |
+| `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret restricting all endpoints except `/v1/health` — see [Require a password](#require-a-password-optional). |
+| `FSEND_PAIRING_ADDR` | `:8080` | TCP signaling listener. |
+| `FSEND_PAIRING_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
+| `FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit, per source IP. |
+| `FSEND_RELAY_ENABLED` | `true` | Set `false` for **pairing + STUN only**: the server still helps peers hole-punch a direct path, but carries no file data. See [Pairing-only mode](#pairing-only-mode-no-relay). |
+| `FSEND_RELAY_ADDR` | `:443` | UDP relay listener — also the STUN endpoint, so it stays in use even when forwarding is off. The server tells clients to dial `<request-host>:<this port>`, so no separate public-address knob is needed. |
+| `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `1GB` | Per-session relay cap — wire bytes after compression. Tune to your bandwidth budget. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`1000000000`). |
 
 ### Pairing-only mode (no relay)
 
-Set `FSEND_ENABLE_RELAY=false` to run the server as a pure matchmaker: it
+Set `FSEND_RELAY_ENABLED=false` to run the server as a pure matchmaker: it
 answers STUN (so peers can still hole-punch directly across NATs) but never
 forwards a single byte of file data. Use this when you want to help peers
 find each other without paying for — or being liable for — relayed traffic.

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -282,7 +282,7 @@ var catalog = map[error]Entry{
 		Action: "Wait a minute and try again, or switch servers:\n" +
 			"    fsend --connect <host:port>\n" +
 			"  Or self-host your own server (`fsend server`) and raise\n" +
-			"  FSEND_MAX_SESSIONS_PER_IP / FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN.",
+			"  FSEND_PAIRING_MAX_SESSIONS_PER_IP / FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN.",
 	},
 	ErrServerRetired: {
 		Code: "E018", Exit: 18,
@@ -333,7 +333,7 @@ var catalog = map[error]Entry{
 			"  Workarounds:\n" +
 			"    - Run again from a different network so fsend can connect you directly.\n" +
 			"    - Self-host your own server (`fsend server`) and raise\n" +
-			"      FSEND_MAX_RELAY_BYTES_PER_SESSION.",
+			"      FSEND_RELAY_MAX_BYTES_PER_SESSION.",
 	},
 	ErrUsage: {
 		Code: "E024", Exit: 24,
@@ -370,7 +370,7 @@ var catalog = map[error]Entry{
 		Code: "E030", Exit: 30,
 		Message: "The server could not start.",
 		Action: "Fix the setting named above, or check that the ports are free and you\n" +
-			"  have permission to bind them (FSEND_HTTP_ADDR, FSEND_UDP_ADDR).\n" +
+			"  have permission to bind them (FSEND_PAIRING_ADDR, FSEND_RELAY_ADDR).\n" +
 			"  Binding :443 may need elevated privileges.",
 	},
 	ErrPasswordRequired: {

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -99,7 +99,7 @@ const sessionIdleTimeout = 60 * time.Second
 // Default fills in zero values.
 func (c *ServerConfig) Default() {
 	if c.MaxBytesPerSession == 0 {
-		c.MaxBytesPerSession = 100 * 1000 * 1000 // 100 MB (decimal, matches displayed units)
+		c.MaxBytesPerSession = 1000 * 1000 * 1000 // 1 GB (decimal, matches displayed units)
 	}
 	if c.Logger == nil {
 		c.Logger = slog.Default()

--- a/scripts/demo/demo.sh
+++ b/scripts/demo/demo.sh
@@ -69,7 +69,7 @@ do_setup() {
   ensure_payload
   ln -f "$PAYLOAD" "$HOME_DIR/$FILE"
 
-  FSEND_HTTP_ADDR="$HTTP_ADDR" FSEND_UDP_ADDR="$UDP_ADDR" FSEND_LOG_LEVEL=error \
+  FSEND_PAIRING_ADDR="$HTTP_ADDR" FSEND_RELAY_ADDR="$UDP_ADDR" FSEND_LOG_LEVEL=error \
     "$bin" server >"$ROOT/server.log" 2>&1 &
   echo $! > "$ROOT/server.pid"
   disown

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -106,8 +106,8 @@ func startHarness() (*harness, error) {
 
 	hh.serverCmd = exec.Command(hh.fsendBin, "server")
 	hh.serverCmd.Env = append(os.Environ(),
-		"FSEND_HTTP_ADDR=:"+strconv.Itoa(hh.httpPort),
-		"FSEND_UDP_ADDR=:"+strconv.Itoa(hh.udpPort),
+		"FSEND_PAIRING_ADDR=:"+strconv.Itoa(hh.httpPort),
+		"FSEND_RELAY_ADDR=:"+strconv.Itoa(hh.udpPort),
 		"FSEND_LOG_LEVEL=warn",
 		// Both peers in this harness come from 127.0.0.1, so a single
 		// pair burns two slots against one bucket. The suite runs
@@ -115,8 +115,8 @@ func startHarness() (*harness, error) {
 		// the production default of 30/min would throttle the harness
 		// itself. Production sender/receiver come from distinct IPs
 		// and each get their own bucket.
-		"FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN=10000",
-		"FSEND_MAX_SESSIONS_PER_IP=1000",
+		"FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN=10000",
+		"FSEND_PAIRING_MAX_SESSIONS_PER_IP=1000",
 	)
 	hh.serverCmd.Stdout = &hh.serverOutput
 	hh.serverCmd.Stderr = &hh.serverOutput

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -85,7 +85,7 @@ func TestServer_Help(t *testing.T) {
 func TestServer_HealthCheck(t *testing.T) {
 	requireE2E(t)
 	cmd := exec.Command(h.fsendBin, "server", "--health-check")
-	cmd.Env = append(os.Environ(), "FSEND_HTTP_ADDR=:"+strconv.Itoa(h.httpPort))
+	cmd.Env = append(os.Environ(), "FSEND_PAIRING_ADDR=:"+strconv.Itoa(h.httpPort))
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("--health-check exit: %v", err)
 	}
@@ -113,12 +113,12 @@ func TestServer_PasswordGate(t *testing.T) {
 
 	cmd := exec.Command(h.fsendBin, "server")
 	cmd.Env = append(os.Environ(),
-		"FSEND_HTTP_ADDR=:"+strconv.Itoa(httpPort),
-		"FSEND_UDP_ADDR=:"+strconv.Itoa(udpPort),
+		"FSEND_PAIRING_ADDR=:"+strconv.Itoa(httpPort),
+		"FSEND_RELAY_ADDR=:"+strconv.Itoa(udpPort),
 		"FSEND_LOG_LEVEL=warn",
 		"FSEND_SERVER_PASSWORD=swordfish",
-		"FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN=10000",
-		"FSEND_MAX_SESSIONS_PER_IP=1000",
+		"FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN=10000",
+		"FSEND_PAIRING_MAX_SESSIONS_PER_IP=1000",
 	)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start guarded server: %v", err)


### PR DESCRIPTION
## What

Renames the server's environment variables to a consistent
`FSEND_<DOMAIN>_<ATTRIBUTE>` scheme so related knobs group together and each
name says what it configures, and raises the per-session relay cap default
from 100MB to 1GB.

## Renames

| Old | New |
|---|---|
| `FSEND_UDP_ADDR` | `FSEND_RELAY_ADDR` |
| `FSEND_ENABLE_RELAY` | `FSEND_RELAY_ENABLED` |
| `FSEND_MAX_RELAY_BYTES_PER_SESSION` | `FSEND_RELAY_MAX_BYTES_PER_SESSION` |
| `FSEND_HTTP_ADDR` | `FSEND_PAIRING_ADDR` |
| `FSEND_MAX_SESSIONS_PER_IP` | `FSEND_PAIRING_MAX_SESSIONS_PER_IP` |
| `FSEND_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN` |

`FSEND_LOG_LEVEL` and `FSEND_SERVER_PASSWORD` stay unchanged — they're
server-wide, not subsystem-specific, and `SERVER_PASSWORD` must not be
confused with the client-side transfer password `FSEND_PASS`.

`--help` and the docs now list the vars grouped **General / Pairing /
Relay**, with aligned columns.

## Default change: relay cap 100MB → 1GB

100MB was too small to be a useful fallback: hole-punching fails most often
on *large* transfers, which is exactly when the relay is needed — a 100MB
cap fails the case the relay exists for. 1GB matches the value the compose
stack already ran and stays abuse-bounded (the per-IP session limits cap
concurrency). Applied to both the binary default and the relay package's
own `Default()`, so there's a single source of truth.

## Compose cleanup

The shipped `docker-compose.yml` no longer restates defaults (that
duplication is what produced an earlier 1GB-vs-100MB doc bug). It now sets
only `FSEND_DOMAIN` and shows the one override most self-hosters want
(`FSEND_SERVER_PASSWORD`) as a comment, pointing to `--help` for the rest.

## Breaking change

These are released env var names and there is **no compatibility shim** (by
decision). An existing deployment's old vars are silently ignored after
upgrade and fall back to defaults. The release notes will carry a banner;
nothing in-code warns. The biggest blast radius is `FSEND_HTTP_ADDR`
(config + the Docker `--health-check` path) — both updated here.

## Tests

Pure-rename mechanical change plus the one default bump:
- `TestServerLoadConfigDefaults` now asserts the 1GB default.
- All server/relay/e2e env references updated to the new names.
- Verified locally: `go build`, `go vet`, `gofmt -l`, full suite incl.
  `-race` and the e2e harness — all green.

## Not in scope (deliberate, discussed)

Rate-limit defaults (`5` / `30`) stay as-is — they're the abuse bound, fine
for individuals, and a documented tunable for shared-NAT orgs. Bare-metal
`:443` privilege and "set a password for a private server" are doc notes,
not value changes. `info` logging being near-silent is the upcoming
observability work, not a default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)