### PR TITLE
refactor(server): move per-IP rate limits to FSEND_SERVER_* namespace

### DIFF
--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -212,10 +212,10 @@ func loadServerConfig() (serverRuntimeConfig, error) {
 		serverPassword: os.Getenv("FSEND_SERVER_PASSWORD"),
 	}
 	var err error
-	if cfg.maxSessionsPerIP, err = envInt("FSEND_PAIRING_MAX_SESSIONS_PER_IP", 5); err != nil {
+	if cfg.maxSessionsPerIP, err = envInt("FSEND_SERVER_MAX_SESSIONS_PER_IP", 5); err != nil {
 		return cfg, err
 	}
-	if cfg.maxNewSessionsPerMin, err = envInt("FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN", 30); err != nil {
+	if cfg.maxNewSessionsPerMin, err = envInt("FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN", 30); err != nil {
 		return cfg, err
 	}
 	if cfg.maxBytesPerSession, err = envBytes("FSEND_RELAY_MAX_BYTES_PER_SESSION", 1000*1000*1000); err != nil { // 1GB
@@ -366,20 +366,21 @@ EXAMPLE
 
 CONFIGURATION (environment variables — all optional)
 
-  General:
+  Server-wide:
     FSEND_LOG_LEVEL                   Default info (debug/info/warn/error).
     FSEND_SERVER_PASSWORD             Optional shared secret. When set, all
                                       endpoints except /v1/health require the
                                       X-Fsend-Auth header. Connect with
                                       fsend --connect <host:port>,<password>.
+    FSEND_SERVER_MAX_SESSIONS_PER_IP  Default 5 — how many sessions one IP
+                                      may have alive at once (concurrency
+                                      cap; gates relay access too).
+    FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN
+                                      Default 30 — how many new sessions one
+                                      IP may create per minute (rate cap).
 
   Pairing (TCP signaling/control plane):
     FSEND_PAIRING_ADDR                Default :8080 (TCP).
-    FSEND_PAIRING_MAX_SESSIONS_PER_IP Default 5 — concurrent sessions per
-                                      source IP.
-    FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN
-                                      Default 30 — new sessions per source
-                                      IP per minute.
 
   Relay (UDP data plane — also answers STUN):
     FSEND_RELAY_ENABLED               Default true. false = pairing + STUN

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -150,8 +150,8 @@ func clearServerEnv(t *testing.T) {
 		"FSEND_PAIRING_ADDR",
 		"FSEND_RELAY_ADDR",
 		"FSEND_LOG_LEVEL",
-		"FSEND_PAIRING_MAX_SESSIONS_PER_IP",
-		"FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN",
+		"FSEND_SERVER_MAX_SESSIONS_PER_IP",
+		"FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN",
 		"FSEND_RELAY_MAX_BYTES_PER_SESSION",
 	} {
 		os.Unsetenv(k)
@@ -188,8 +188,8 @@ func TestServerLoadConfigOverrides(t *testing.T) {
 	clearServerEnv(t)
 	t.Setenv("FSEND_PAIRING_ADDR", ":19999")
 	t.Setenv("FSEND_RELAY_ADDR", ":29999")
-	t.Setenv("FSEND_PAIRING_MAX_SESSIONS_PER_IP", "12")
-	t.Setenv("FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN", "120")
+	t.Setenv("FSEND_SERVER_MAX_SESSIONS_PER_IP", "12")
+	t.Setenv("FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN", "120")
 	t.Setenv("FSEND_RELAY_MAX_BYTES_PER_SESSION", "250MB")
 	cfg, err := loadServerConfig()
 	if err != nil {
@@ -215,9 +215,9 @@ func TestServerLoadConfigOverrides(t *testing.T) {
 func TestServerLoadConfigRejectsBadValues(t *testing.T) {
 	// A typo'd limit must stop the server, not silently run the default.
 	cases := map[string]string{
-		"FSEND_RELAY_MAX_BYTES_PER_SESSION":             "1GiB",
-		"FSEND_PAIRING_MAX_SESSIONS_PER_IP":             "many",
-		"FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN": "-1",
+		"FSEND_RELAY_MAX_BYTES_PER_SESSION":        "1GiB",
+		"FSEND_SERVER_MAX_SESSIONS_PER_IP":         "many",
+		"FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN": "-1",
 	}
 	for k, v := range cases {
 		t.Run(k+"="+v, func(t *testing.T) {

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -166,17 +166,18 @@ Connecting without it — or with the wrong one — fails with `E028`.
 All optional; defaults shown. Set them under the `fsend` service's
 `environment:` block in `docker-compose.yml`.
 
-Variables are grouped by subsystem: **general**, **pairing** (the TCP
-signaling/control plane), and **relay** (the UDP data plane, which also
-answers STUN).
+Variables are grouped into **server-wide** controls (apply to the whole
+server, relay included), the **pairing** listener (TCP signaling/control
+plane), and **relay** settings (the UDP data plane, which also answers
+STUN).
 
 | Variable | Default | Notes |
 |---|---|---|
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret restricting all endpoints except `/v1/health` — see [Require a password](#require-a-password-optional). |
+| `FSEND_SERVER_MAX_SESSIONS_PER_IP` | `5` | **Concurrency cap** — how many sessions one source IP may have **alive at once**. A session gates relay allocation too, so this caps relay access as well. |
+| `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN` | `30` | **Rate cap** — how many **new** sessions one source IP may **create per minute**. Distinct from the concurrency cap above: this limits inflow over time, that limits standing count. |
 | `FSEND_PAIRING_ADDR` | `:8080` | TCP signaling listener. |
-| `FSEND_PAIRING_MAX_SESSIONS_PER_IP` | `5` | Concurrent sessions per client IP. |
-| `FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `30` | New-session rate limit, per source IP. |
 | `FSEND_RELAY_ENABLED` | `true` | Set `false` for **pairing + STUN only**: the server still helps peers hole-punch a direct path, but carries no file data. See [Pairing-only mode](#pairing-only-mode-no-relay). |
 | `FSEND_RELAY_ADDR` | `:443` | UDP relay listener — also the STUN endpoint, so it stays in use even when forwarding is off. The server tells clients to dial `<request-host>:<this port>`, so no separate public-address knob is needed. |
 | `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `1GB` | Per-session relay cap — wire bytes after compression. Tune to your bandwidth budget. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`1000000000`). |

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -282,7 +282,7 @@ var catalog = map[error]Entry{
 		Action: "Wait a minute and try again, or switch servers:\n" +
 			"    fsend --connect <host:port>\n" +
 			"  Or self-host your own server (`fsend server`) and raise\n" +
-			"  FSEND_PAIRING_MAX_SESSIONS_PER_IP / FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN.",
+			"  FSEND_SERVER_MAX_SESSIONS_PER_IP / FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN.",
 	},
 	ErrServerRetired: {
 		Code: "E018", Exit: 18,

--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -115,8 +115,8 @@ func startHarness() (*harness, error) {
 		// the production default of 30/min would throttle the harness
 		// itself. Production sender/receiver come from distinct IPs
 		// and each get their own bucket.
-		"FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN=10000",
-		"FSEND_PAIRING_MAX_SESSIONS_PER_IP=1000",
+		"FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN=10000",
+		"FSEND_SERVER_MAX_SESSIONS_PER_IP=1000",
 	)
 	hh.serverCmd.Stdout = &hh.serverOutput
 	hh.serverCmd.Stderr = &hh.serverOutput

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -117,8 +117,8 @@ func TestServer_PasswordGate(t *testing.T) {
 		"FSEND_RELAY_ADDR=:"+strconv.Itoa(udpPort),
 		"FSEND_LOG_LEVEL=warn",
 		"FSEND_SERVER_PASSWORD=swordfish",
-		"FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN=10000",
-		"FSEND_PAIRING_MAX_SESSIONS_PER_IP=1000",
+		"FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN=10000",
+		"FSEND_SERVER_MAX_SESSIONS_PER_IP=1000",
 	)
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start guarded server: %v", err)


### PR DESCRIPTION
## What

Moves the two per-IP session limits out of the `PAIRING_*` namespace into the **server-wide** group, drops the redundant `NEW` token, and clarifies what each limit does.

| Old | New |
|---|---|
| `FSEND_PAIRING_MAX_SESSIONS_PER_IP` | `FSEND_SERVER_MAX_SESSIONS_PER_IP` |
| `FSEND_PAIRING_MAX_NEW_SESSIONS_PER_IP_PER_MIN` | `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN` |

## Why

These limits gate access to the **whole server**, not just pairing: every endpoint needs a session, and relay-allocate is gated by one too. So `PAIRING_*` was misleading — it implied the relay was exempt, when tightening these throttles relay access as well. They belong with `FSEND_SERVER_PASSWORD` as cross-cutting server-wide controls (same principle by which the password isn't subsystem-scoped).

`NEW` is dropped because the `_PER_MIN` suffix already marks it a rate; the help/doc descriptions retain "new sessions per minute" for clarity.

## The two limits are kept and clearly distinguished

They guard different threats and are **not** redundant:

- **`MAX_SESSIONS_PER_IP` (concurrency cap)** — how many sessions one IP may have *alive at once*. Bounds standing memory/slot footprint.
- **`MAX_SESSIONS_PER_IP_PER_MIN` (rate cap)** — how many *new* sessions one IP may *create per minute*. Bounds attempt velocity; this is the share-code online-brute-force defense.

The rate cap doesn't supersede the concurrency cap (it only loosely bounds standing count at rate×TTL ≈ 1800/IP vs a hard 5), and the concurrency cap doesn't supersede the rate cap (a failed/short-lived attempt never trips it). `--help` and `self-hosting.md` now spell out the distinction so operators don't conflate them.

## Grouping

`--help` and the docs table are regrouped **Server-wide / Pairing / Relay**. `FSEND_PAIRING_ADDR` and `FSEND_RELAY_ADDR` stay as the two concrete listeners.

## Breaking change

Env var names change with **no compatibility shim** (by decision) — old names are silently ignored after upgrade. Release notes will carry the banner. This stacks on the earlier `FSEND_*` renames already merged.

## Tests

Mechanical rename + description wording. `TestServerLoadConfigDefaults`/`Overrides` updated to the new names; e2e harness env updated. Verified locally: `go build`, `go vet`, `gofmt -l`, full suite incl. `-race` and e2e — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)