### PR TITLE
feat(server): add GET /v1/metrics aggregate JSON endpoint

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -257,6 +257,7 @@ own code phrase, while fsend always picks it for you.
 | SSH-key transfer helper | ✗ | ✗ | **✓ `wormhole ssh`** |
 | Library / protocol ecosystem | ✗ (app only) | ✗ (app only) | **✓ (importable, Dilation)** |
 | Self-host the server / relay | ✓ | ✓ | ✓ |
+| Server health / metrics endpoint | **✓ `/v1/health` + aggregate `/v1/metrics`** (load, relay bytes, cap hits, rejections — no per-user data) | ✗ | (server is a separate project) |
 
 ## Privacy: what a server can observe
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -151,6 +151,75 @@ Connecting without it — or with the wrong one — fails with `E028`.
 - **Tuning.** Every knob is an environment variable — see
   [Configuration](#configuration).
 
+## Metrics
+
+`GET /v1/metrics` returns a small JSON snapshot for monitoring:
+
+```json
+{
+  "version": "1.8.0",
+  "uptime_seconds": 84213,
+  "sessions_active": 3,
+  "sessions_created_total": 1284,
+  "rejected_total": { "rate_limit": 12, "ip_cap": 3, "unauthorized": 0 },
+  "relay": {
+    "forwarding": true,
+    "healthy": true,
+    "transfers_active": 1,
+    "bytes_forwarded_total": 5839201023,
+    "peak_session_bytes": 940000000,
+    "cap_hits_total": 4
+  }
+}
+```
+
+Every value is an **aggregate count or gauge** — there is no per-IP,
+per-session, or per-code data, so it can't leak anything the server doesn't
+store. That's deliberate: the endpoint is public on an open server precisely
+so anyone can verify the server holds nothing sensitive.
+
+| Field | What it tells you |
+|---|---|
+| `version` | Build currently running. |
+| `uptime_seconds` | Seconds since the process started — spot restarts. |
+| `sessions_active` | Pairing sessions live right now — current load. |
+| `sessions_created_total` | Sessions created since boot — total usage. |
+| `rejected_total.rate_limit` | Requests refused by the new-session rate cap (`FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN`) — bursts or brute-force. |
+| `rejected_total.ip_cap` | Requests refused by the concurrency cap (`FSEND_SERVER_MAX_SESSIONS_PER_IP`). |
+| `rejected_total.unauthorized` | Wrong/missing `FSEND_SERVER_PASSWORD` — brute-force or misconfigured clients (always `0` on an open server). |
+| `relay.forwarding` | Whether the relay carries data (`false` in pairing + STUN-only mode). |
+| `relay.healthy` | Relay read loop alive — mirrors `/v1/health`'s 503 signal. |
+| `relay.transfers_active` | Relay transfers moving bytes right now. |
+| `relay.bytes_forwarded_total` | Cumulative bytes relayed — what the relay is costing you. |
+| `relay.peak_session_bytes` | Largest single session so far; compare to your byte cap to see headroom. |
+| `relay.cap_hits_total` | Transfers cut off for hitting the byte cap — raise the cap if this climbs. |
+
+The `relay` block is omitted when the server runs without a relay.
+
+**Access.** `/v1/metrics` inherits the server's own openness, like every
+endpoint except `/v1/health`:
+
+- **Open server (no `FSEND_SERVER_PASSWORD`)** — public, no credentials:
+
+  ```sh
+  curl https://fs.example.com/v1/metrics
+  ```
+
+- **Password-protected server** — pass the password in the `X-Fsend-Auth`
+  header (the same one clients use):
+
+  ```sh
+  curl -H "X-Fsend-Auth: your-secret" https://fs.example.com/v1/metrics
+  ```
+
+  Without it you get `401`. Note a **web browser can't open this URL**
+  directly — it can't set the header — so use `curl`, or configure your
+  monitoring scraper to send `X-Fsend-Auth` (Prometheus: a static header
+  under the scrape job).
+
+So a public server is transparently inspectable by anyone, and a locked-down
+one keeps its metrics to whoever holds the password.
+
 ## Troubleshooting
 
 | Symptom | Likely cause |

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -292,6 +292,99 @@ func TestForwardingEnabledByDefault(t *testing.T) {
 	}
 }
 
+// TestMetricsCounters checks that a forwarded datagram bumps bytes_forwarded
+// and peak_session_bytes, and that exceeding the cap bumps cap_hits.
+func TestMetricsCounters(t *testing.T) {
+	serverConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	relayAddr := serverConn.LocalAddr().(*net.UDPAddr)
+	srv := NewServer(serverConn, ServerConfig{MaxBytesPerSession: 10 * 1024 * 1024})
+	tok, err := srv.Allocate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srvErr := make(chan error, 1)
+	go func() { srvErr <- srv.Run(ctx) }()
+
+	clientA, _ := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	defer clientA.Close()
+	clientB, _ := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	defer clientB.Close()
+	connA := NewClient(clientA, relayAddr, tok)
+	connB := NewClient(clientB, relayAddr, tok)
+
+	_, _ = connA.WriteTo([]byte("hello"), nil)
+	_, _ = connB.WriteTo([]byte("register"), nil)
+	time.Sleep(50 * time.Millisecond)
+	_, _ = connA.WriteTo([]byte("a real payload"), nil)
+	buf := make([]byte, 1500)
+	_ = connB.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, _, err := connB.ReadFrom(buf); err != nil {
+		t.Fatalf("B did not receive the forwarded payload: %v", err)
+	}
+
+	m := srv.Metrics()
+	if m.BytesForwardedTotal == 0 {
+		t.Error("bytes_forwarded_total should be > 0 after a forward")
+	}
+	if m.PeakSessionBytes == 0 {
+		t.Error("peak_session_bytes should be > 0 after a forward")
+	}
+	if m.CapHitsTotal != 0 {
+		t.Errorf("cap_hits_total = %d, want 0", m.CapHitsTotal)
+	}
+	if !m.Forwarding {
+		t.Error("forwarding should be true")
+	}
+
+	cancel()
+	_ = serverConn.Close()
+	<-srvErr
+}
+
+func TestMetricsCapHit(t *testing.T) {
+	serverConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	relayAddr := serverConn.LocalAddr().(*net.UDPAddr)
+	srv := NewServer(serverConn, ServerConfig{MaxBytesPerSession: 1}) // any forwarded datagram exceeds it
+	tok, _ := srv.Allocate()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srvErr := make(chan error, 1)
+	go func() { srvErr <- srv.Run(ctx) }()
+
+	clientA, _ := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	defer clientA.Close()
+	clientB, _ := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	defer clientB.Close()
+	connA := NewClient(clientA, relayAddr, tok)
+	connB := NewClient(clientB, relayAddr, tok)
+
+	_, _ = connA.WriteTo([]byte("x"), nil) // registers A as peerA
+	_, _ = connB.WriteTo([]byte("y"), nil) // registers B; first forwarded datagram trips the 1-byte cap
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if srv.Metrics().CapHitsTotal > 0 {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if got := srv.Metrics().CapHitsTotal; got != 1 {
+		t.Errorf("cap_hits_total = %d, want 1", got)
+	}
+
+	cancel()
+	_ = serverConn.Close()
+	<-srvErr
+}
+
 func TestAllowSTUNResponse_RateCap(t *testing.T) {
 	s := &Server{}
 	base := time.Unix(1700000000, 0)

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -48,6 +48,33 @@ type Server struct {
 	// draining rejects new allocations during graceful shutdown so the drain
 	// can converge while in-flight sessions finish.
 	draining atomic.Bool
+
+	// Aggregate counters for /v1/metrics (cumulative since boot).
+	bytesForwarded   atomic.Uint64
+	peakSessionBytes atomic.Uint64 // most any single session has forwarded
+	capHits          atomic.Uint64
+}
+
+// Metrics is an aggregate snapshot of relay activity for /v1/metrics.
+type Metrics struct {
+	Forwarding          bool   `json:"forwarding"`
+	Healthy             bool   `json:"healthy"`
+	TransfersActive     int    `json:"transfers_active"`
+	BytesForwardedTotal uint64 `json:"bytes_forwarded_total"`
+	PeakSessionBytes    uint64 `json:"peak_session_bytes"`
+	CapHitsTotal        uint64 `json:"cap_hits_total"`
+}
+
+// Metrics returns the current aggregate snapshot.
+func (s *Server) Metrics() Metrics {
+	return Metrics{
+		Forwarding:          !s.cfg.DisableForwarding,
+		Healthy:             s.healthy.Load(),
+		TransfersActive:     s.ActiveAllocations(),
+		BytesForwardedTotal: s.bytesForwarded.Load(),
+		PeakSessionBytes:    s.peakSessionBytes.Load(),
+		CapHitsTotal:        s.capHits.Load(),
+	}
 }
 
 // activeWindow bounds how recently an allocation must have forwarded a
@@ -314,10 +341,18 @@ func (s *Server) handle(datagram []byte, src *net.UDPAddr) {
 	wireSize := uint64(len(datagram))
 	total := a.bytes.Add(wireSize)
 	if s.cfg.MaxBytesPerSession > 0 && total > s.cfg.MaxBytesPerSession {
+		s.capHits.Add(1)
 		s.evict(token, ReasonCapHit)
 		return
 	}
 
+	s.bytesForwarded.Add(wireSize)
+	for { // raise the global peak to this session's running total
+		cur := s.peakSessionBytes.Load()
+		if total <= cur || s.peakSessionBytes.CompareAndSwap(cur, total) {
+			break
+		}
+	}
 	if _, err := s.conn.WriteTo(datagram, dst); err != nil {
 		s.logger.Debug("relay: write failed", "err", err)
 	}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -1,0 +1,51 @@
+package server
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/polius/fsend/internal/relay"
+)
+
+// MetricsResponse is the body of GET /v1/metrics. Everything is an
+// aggregate count or gauge — no per-IP, per-session, or per-code data, so
+// it can't leak what the server doesn't store. Relay is omitted when no
+// relay is wired.
+type MetricsResponse struct {
+	Version              string         `json:"version"`
+	UptimeSeconds        int64          `json:"uptime_seconds"`
+	SessionsActive       int            `json:"sessions_active"`
+	SessionsCreatedTotal uint64         `json:"sessions_created_total"`
+	RejectedTotal        RejectedCounts `json:"rejected_total"`
+	Relay                *relay.Metrics `json:"relay,omitempty"`
+}
+
+// RejectedCounts breaks down turned-away requests by reason.
+type RejectedCounts struct {
+	RateLimit    uint64 `json:"rate_limit"`
+	IPCap        uint64 `json:"ip_cap"`
+	Unauthorized uint64 `json:"unauthorized"`
+}
+
+func (s *Server) metrics(w http.ResponseWriter, _ *http.Request) {
+	s.mu.Lock()
+	active := len(s.byID)
+	s.mu.Unlock()
+
+	resp := MetricsResponse{
+		Version:              s.cfg.ServerVersion,
+		UptimeSeconds:        int64(time.Since(s.started).Seconds()),
+		SessionsActive:       active,
+		SessionsCreatedTotal: s.met.sessionsCreated.Load(),
+		RejectedTotal: RejectedCounts{
+			RateLimit:    s.met.rejRate.Load(),
+			IPCap:        s.met.rejIPCap.Load(),
+			Unauthorized: s.met.rejAuth.Load(),
+		},
+	}
+	if s.relayAllocator != nil {
+		m := s.relayAllocator.Metrics()
+		resp.Relay = &m
+	}
+	writeJSON(w, http.StatusOK, resp)
+}

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -1,0 +1,160 @@
+package server
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+func metricsConfig() Config {
+	return Config{
+		ServerVersion:        "0.0.0-test",
+		UnpairedTTL:          2 * time.Second,
+		PairedTTL:            2 * time.Second,
+		LongPollTimeout:      500 * time.Millisecond,
+		MaxSessionsPerIP:     10,
+		MaxNewSessionsPerMin: 100,
+	}
+}
+
+func getJSON(t *testing.T, url string, v any) {
+	t.Helper()
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET %s: status %d", url, resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestMetrics_Shape is the privacy guardrail: every emitted field must be in
+// the allowlist, so a future edit can't sneak in per-IP/per-session data.
+func TestMetrics_Shape(t *testing.T) {
+	s := New(metricsConfig())
+	s.WithRelay(&fakeRelay{}, 443)
+	srv := httptest.NewServer(s.Handler())
+	t.Cleanup(srv.Close)
+
+	var raw map[string]any
+	getJSON(t, srv.URL+"/v1/metrics", &raw)
+
+	top := map[string]bool{
+		"version": true, "uptime_seconds": true, "sessions_active": true,
+		"sessions_created_total": true, "rejected_total": true, "relay": true,
+	}
+	for k := range raw {
+		if !top[k] {
+			t.Errorf("unexpected top-level field %q — metrics must stay aggregate-only", k)
+		}
+	}
+	for k := range top {
+		if _, ok := raw[k]; !ok {
+			t.Errorf("missing field %q", k)
+		}
+	}
+	assertKeys(t, raw["rejected_total"], "rejected_total", "rate_limit", "ip_cap", "unauthorized")
+	assertKeys(t, raw["relay"], "relay",
+		"forwarding", "healthy", "transfers_active",
+		"bytes_forwarded_total", "peak_session_bytes", "cap_hits_total")
+}
+
+func assertKeys(t *testing.T, v any, name string, want ...string) {
+	t.Helper()
+	m, ok := v.(map[string]any)
+	if !ok {
+		t.Fatalf("%s is not an object", name)
+	}
+	for _, k := range want {
+		if _, ok := m[k]; !ok {
+			t.Errorf("%s missing %q", name, k)
+		}
+	}
+	if len(m) != len(want) {
+		t.Errorf("%s has %d keys, want %d (no extra fields)", name, len(m), len(want))
+	}
+}
+
+func TestMetrics_Counters(t *testing.T) {
+	cfg := metricsConfig()
+	cfg.MaxNewSessionsPerMin = 1 // so a second create from the same IP is rate-limited
+	s := New(cfg)
+	srv := httptest.NewServer(s.Handler())
+	t.Cleanup(srv.Close)
+
+	createSession(t, srv.URL, testSlot)
+	resp := postJSON(t, srv.URL+"/v1/session", CreateSessionRequest{ClientVersion: "test", Slot: testSlot2})
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("second create status = %d, want 429", resp.StatusCode)
+	}
+
+	var m MetricsResponse
+	getJSON(t, srv.URL+"/v1/metrics", &m)
+	if m.SessionsCreatedTotal != 1 {
+		t.Errorf("sessions_created_total = %d, want 1", m.SessionsCreatedTotal)
+	}
+	if m.SessionsActive != 1 {
+		t.Errorf("sessions_active = %d, want 1", m.SessionsActive)
+	}
+	if m.RejectedTotal.RateLimit != 1 {
+		t.Errorf("rejected_total.rate_limit = %d, want 1", m.RejectedTotal.RateLimit)
+	}
+}
+
+// With a server password set, /v1/metrics is gated like any other endpoint
+// (an open server, tested above, serves it publicly for transparency).
+func TestMetrics_GatedByPassword(t *testing.T) {
+	cfg := metricsConfig()
+	cfg.ServerPassword = "secret"
+	s := New(cfg)
+	srv := httptest.NewServer(s.Handler())
+	t.Cleanup(srv.Close)
+
+	// No password → 401, and that rejection is counted.
+	resp, err := http.Get(srv.URL + "/v1/metrics")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("metrics without password = %d, want 401", resp.StatusCode)
+	}
+
+	// With the password → 200, and the snapshot reports that one rejection.
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/v1/metrics", nil)
+	req.Header.Set(AuthHeader, "secret")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp2.Body.Close() }()
+	if resp2.StatusCode != http.StatusOK {
+		t.Fatalf("metrics with password = %d, want 200", resp2.StatusCode)
+	}
+	var m MetricsResponse
+	if err := json.NewDecoder(resp2.Body).Decode(&m); err != nil {
+		t.Fatal(err)
+	}
+	if m.RejectedTotal.Unauthorized != 1 {
+		t.Errorf("rejected_total.unauthorized = %d, want 1", m.RejectedTotal.Unauthorized)
+	}
+}
+
+func TestMetrics_OmitsRelayWhenAbsent(t *testing.T) {
+	s := New(metricsConfig())
+	srv := httptest.NewServer(s.Handler())
+	t.Cleanup(srv.Close)
+
+	var raw map[string]any
+	getJSON(t, srv.URL+"/v1/metrics", &raw)
+	if _, ok := raw["relay"]; ok {
+		t.Error("relay block must be omitted when no relay is wired")
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -13,6 +13,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/oklog/ulid/v2"
@@ -113,6 +114,17 @@ type Server struct {
 	// the configured UDP port. No operator config needed for stock setups.
 	relayAllocator RelayAllocator
 	relayUDPPort   int
+
+	met serverMetrics
+}
+
+// serverMetrics holds aggregate counters for /v1/metrics (cumulative
+// since boot). sessions_active is read from the live map at scrape time.
+type serverMetrics struct {
+	sessionsCreated atomic.Uint64
+	rejRate         atomic.Uint64 // rate-limit rejections
+	rejIPCap        atomic.Uint64 // concurrent-cap rejections
+	rejAuth         atomic.Uint64 // wrong/missing server password
 }
 
 // RelayAllocator is the minimal interface internal/relay.Server exposes
@@ -123,6 +135,7 @@ type RelayAllocator interface {
 	Status(relay.Token) string
 	MaxBytesPerSession() uint64
 	Forwarding() bool
+	Metrics() relay.Metrics
 }
 
 // WithRelay wires a relay allocator into the signaling layer.
@@ -200,6 +213,7 @@ func (s *Server) Handler() http.Handler {
 	m.HandleFunc("POST /v1/relay/allocate", s.allocateRelay)
 	m.HandleFunc("GET /v1/relay/status", s.relayStatus)
 	m.HandleFunc("GET /v1/health", s.health)
+	m.HandleFunc("GET /v1/metrics", s.metrics)
 	if s.cfg.ServerPassword == "" {
 		return m
 	}
@@ -218,6 +232,7 @@ func (s *Server) withServerAuth(inner http.Handler) http.Handler {
 		}
 		got := r.Header.Get(AuthHeader)
 		if got == "" || subtle.ConstantTimeCompare(want, []byte(got)) != 1 {
+			s.met.rejAuth.Add(1)
 			w.Header().Set("WWW-Authenticate", `X-Fsend-Auth realm="fsend"`)
 			writeJSONError(w, http.StatusUnauthorized, "server password required")
 			return
@@ -435,11 +450,13 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 	s.mu.Lock()
 	if !s.allowNewSession(rateKey, time.Now()) {
 		s.mu.Unlock()
+		s.met.rejRate.Add(1)
 		writeJSONError(w, http.StatusTooManyRequests, "rate limit hit")
 		return
 	}
 	if s.ipCounts[rateKey] >= s.cfg.MaxSessionsPerIP {
 		s.mu.Unlock()
+		s.met.rejIPCap.Add(1)
 		writeJSONError(w, http.StatusTooManyRequests, "too many concurrent sessions for this IP")
 		return
 	}
@@ -472,6 +489,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 	s.byID[sid] = sess
 	s.ipCounts[rateKey]++
 	s.mu.Unlock()
+	s.met.sessionsCreated.Add(1)
 	s.cfg.Logger.Debug("session created", "slot", slot, "ip", clientIP)
 
 	writeJSON(w, http.StatusOK, CreateSessionResponse{
@@ -497,6 +515,7 @@ func (s *Server) joinSession(w http.ResponseWriter, r *http.Request) {
 	// slot at line rate.
 	if !s.allowNewSession(rateKey, time.Now()) {
 		s.mu.Unlock()
+		s.met.rejRate.Add(1)
 		writeJSONError(w, http.StatusTooManyRequests, "rate limit hit")
 		return
 	}
@@ -513,6 +532,7 @@ func (s *Server) joinSession(w http.ResponseWriter, r *http.Request) {
 	}
 	if s.ipCounts[rateKey] >= s.cfg.MaxSessionsPerIP {
 		s.mu.Unlock()
+		s.met.rejIPCap.Add(1)
 		writeJSONError(w, http.StatusTooManyRequests, "too many concurrent sessions for this IP")
 		return
 	}
@@ -547,6 +567,7 @@ func (s *Server) waitSession(w http.ResponseWriter, r *http.Request) {
 	// 30/min budget — see TestWaitRateLimit_PollCadenceStaysUnderBudget.
 	if !s.allowNewSession(rateLimitKey(clientIP(r)), time.Now()) {
 		s.mu.Unlock()
+		s.met.rejRate.Add(1)
 		writeJSONError(w, http.StatusTooManyRequests, "rate limit hit")
 		return
 	}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -492,6 +492,9 @@ func (f *fakeRelay) Status(t relay.Token) string    { return f.reason }
 func (f *fakeRelay) MaxBytesPerSession() uint64     { return f.maxBytes }
 func (f *fakeRelay) Healthy() bool                  { return !f.dead }
 func (f *fakeRelay) Forwarding() bool               { return !f.noForward }
+func (f *fakeRelay) Metrics() relay.Metrics {
+	return relay.Metrics{Forwarding: !f.noForward, Healthy: !f.dead}
+}
 
 // /v1/health must flip to 503/degraded once the relay read loop has died,
 // so an orchestrator restarts the container instead of trusting a zombie.


### PR DESCRIPTION
## What

Adds an observability endpoint so a self-hoster can see what their server is doing. `GET /v1/metrics` returns a small JSON snapshot:

```json
{
  "version": "1.8.0",
  "uptime_seconds": 84213,
  "sessions_active": 3,
  "sessions_created_total": 1284,
  "rejected_total": { "rate_limit": 12, "ip_cap": 3, "unauthorized": 0 },
  "relay": {
    "forwarding": true,
    "healthy": true,
    "transfers_active": 1,
    "bytes_forwarded_total": 5839201023,
    "peak_session_bytes": 940000000,
    "cap_hits_total": 4
  }
}
```

Every value is an **aggregate count or gauge** — no per-IP, per-session, or per-code data — so it can't leak anything the server doesn't store. Each field maps to a concrete operator question (current load, abuse, relay cost, cap headroom, health). The `relay` block is omitted when no relay is wired.

## Access model

`/v1/metrics` inherits the server's own openness:

- **Open server** (no `FSEND_SERVER_PASSWORD`) → **public**, so anyone can verify the server holds nothing sensitive — transparency as a trust signal.
- **Password-protected server** → gated behind the password, like every endpoint except `/v1/health` (`curl -H "X-Fsend-Auth: <pw>"`).

No separate port or knob; the bundled Caddy needs no special rule.

## Why this field set

The set was deliberately pruned to only what an operator acts on — e.g. `peak_session_bytes` (proactive: are transfers approaching the cap) vs `cap_hits_total` (reactive: cap too low). Dropped along the way: session funnel/eviction counts, allocation counters, `goroutines`, and a `tracked_ips`-style gauge (optics + already an accepted risk). `bytes_forwarded_total` is the relay cost meter.

## Implementation

Atomic counters incremented at the existing event sites (session create, the three reject branches, relay forward / cap-hit); the relay exposes a `Metrics()` snapshot. `sessions_active` is read from the live map under the existing lock at scrape time — no new hot-path locking.

## Tests

- **Privacy guardrail** — asserts the emitted field set is *exactly* the allowlist, so a future edit can't sneak in per-peer data.
- Counter wiring (create + rate-limit reject), gated-by-password behavior, relay byte/peak/cap-hit counters.
- Verified locally: `go build`, `go vet`, `gofmt -l`, `-race`, full suite incl. e2e, plus a live curl of both the open and password-gated paths.

## Docs

`self-hosting.md` gets a **Metrics** section (a field-reference table + open-vs-password access with copy-paste `curl`), and `comparison.md` gets a row (croc/wormhole ship no equivalent; the wormhole cell uses the doc's "server is a separate project" convention — worth a source double-check before relying on it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)