### PR TITLE
feat(server): standardize /v1/metrics schema; add pairing + relay-fallback metrics; 0 = unlimited caps

### DIFF
--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -374,10 +374,12 @@ CONFIGURATION (environment variables — all optional)
                                       fsend --connect <host:port>,<password>.
     FSEND_SERVER_MAX_SESSIONS_PER_IP  Default 5 — how many sessions one IP
                                       may have alive at once (concurrency
-                                      cap; gates relay access too).
+                                      cap; gates relay access too). 0 =
+                                      unlimited.
     FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN
                                       Default 30 — how many new sessions one
                                       IP may create per minute (rate cap).
+                                      0 = unlimited.
 
   Pairing (TCP signaling/control plane):
     FSEND_PAIRING_ADDR                Default :8080 (TCP).
@@ -391,7 +393,8 @@ CONFIGURATION (environment variables — all optional)
                                       when forwarding is disabled.
     FSEND_RELAY_MAX_BYTES_PER_SESSION Default 1GB — wire bytes after
                                       compression. Accepts B, KB, MB, GB,
-                                      TB, or a plain byte count.
+                                      TB, or a plain byte count. 0 =
+                                      unlimited.
 
 LEARN MORE
   https://github.com/polius/fsend

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -161,14 +161,16 @@ Connecting without it — or with the wrong one — fails with `E028`.
   "uptime_seconds": 84213,
   "sessions_active": 3,
   "sessions_created_total": 1284,
-  "rejected_total": { "rate_limit": 12, "ip_cap": 3, "unauthorized": 0 },
+  "sessions_paired_total": 901,
+  "sessions_rejected_total": { "rate_limit": 12, "concurrency_limit": 3, "unauthorized": 0 },
   "relay": {
     "forwarding": true,
     "healthy": true,
     "transfers_active": 1,
+    "transfers_total": 412,
+    "transfers_capped_total": 4,
     "bytes_forwarded_total": 5839201023,
-    "peak_session_bytes": 940000000,
-    "cap_hits_total": 4
+    "peak_transfer_bytes": 940000000
   }
 }
 ```
@@ -183,16 +185,18 @@ so anyone can verify the server holds nothing sensitive.
 | `version` | Build currently running. |
 | `uptime_seconds` | Seconds since the process started — spot restarts. |
 | `sessions_active` | Pairing sessions live right now — current load. |
-| `sessions_created_total` | Sessions created since boot — total usage. |
-| `rejected_total.rate_limit` | Requests refused by the new-session rate cap (`FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN`) — bursts or brute-force. |
-| `rejected_total.ip_cap` | Requests refused by the concurrency cap (`FSEND_SERVER_MAX_SESSIONS_PER_IP`). |
-| `rejected_total.unauthorized` | Wrong/missing `FSEND_SERVER_PASSWORD` — brute-force or misconfigured clients (always `0` on an open server). |
+| `sessions_created_total` | Sessions a sender opened since boot — total usage. |
+| `sessions_paired_total` | Sessions a receiver successfully joined. Compared to `sessions_created_total`, the gap is senders who never found a receiver (abandoned codes). |
+| `sessions_rejected_total.rate_limit` | Sessions refused by the per-IP rate cap (`FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN`) — bursts or brute-force. |
+| `sessions_rejected_total.concurrency_limit` | Sessions refused by the per-IP concurrency cap (`FSEND_SERVER_MAX_SESSIONS_PER_IP`). |
+| `sessions_rejected_total.unauthorized` | Wrong/missing `FSEND_SERVER_PASSWORD` — brute-force or misconfigured clients (always `0` on an open server). |
 | `relay.forwarding` | Whether the relay carries data (`false` in pairing + STUN-only mode). |
 | `relay.healthy` | Relay read loop alive — mirrors `/v1/health`'s 503 signal. |
 | `relay.transfers_active` | Relay transfers moving bytes right now. |
+| `relay.transfers_total` | Relay transfers since boot. Divide by `sessions_paired_total` for your relay-fallback rate; the rest connected directly (P2P). A climbing ratio means hole-punching is failing more often. |
+| `relay.transfers_capped_total` | Transfers cut off for hitting the byte cap — raise the cap if this climbs. |
 | `relay.bytes_forwarded_total` | Cumulative bytes relayed — what the relay is costing you. |
-| `relay.peak_session_bytes` | Largest single session so far; compare to your byte cap to see headroom. |
-| `relay.cap_hits_total` | Transfers cut off for hitting the byte cap — raise the cap if this climbs. |
+| `relay.peak_transfer_bytes` | Largest single transfer so far; compare to your byte cap to see headroom. |
 
 The `relay` block is omitted when the server runs without a relay.
 
@@ -244,12 +248,12 @@ STUN).
 |---|---|---|
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret restricting all endpoints except `/v1/health` — see [Require a password](#require-a-password-optional). |
-| `FSEND_SERVER_MAX_SESSIONS_PER_IP` | `5` | **Concurrency cap** — how many sessions one source IP may have **alive at once**. A session gates relay allocation too, so this caps relay access as well. |
-| `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN` | `30` | **Rate cap** — how many **new** sessions one source IP may **create per minute**. Distinct from the concurrency cap above: this limits inflow over time, that limits standing count. |
+| `FSEND_SERVER_MAX_SESSIONS_PER_IP` | `5` | **Concurrency cap** — how many sessions one source IP may have **alive at once**. A session gates relay allocation too, so this caps relay access as well. `0` = unlimited (removes a DoS protection — only on a trusted/gated server). |
+| `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN` | `30` | **Rate cap** — how many **new** sessions one source IP may **create per minute**. Distinct from the concurrency cap above: this limits inflow over time, that limits standing count. `0` = unlimited (removes a DoS protection — only on a trusted/gated server). |
 | `FSEND_PAIRING_ADDR` | `:8080` | TCP signaling listener. |
 | `FSEND_RELAY_ENABLED` | `true` | Set `false` for **pairing + STUN only**: the server still helps peers hole-punch a direct path, but carries no file data. See [Pairing-only mode](#pairing-only-mode-no-relay). |
 | `FSEND_RELAY_ADDR` | `:443` | UDP relay listener — also the STUN endpoint, so it stays in use even when forwarding is off. The server tells clients to dial `<request-host>:<this port>`, so no separate public-address knob is needed. |
-| `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `1GB` | Per-session relay cap — wire bytes after compression. Tune to your bandwidth budget. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`1000000000`). |
+| `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `1GB` | Per-session relay cap — wire bytes after compression. Tune to your bandwidth budget. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`1000000000`). `0` = unlimited. |
 
 ### Pairing-only mode (no relay)
 

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -293,7 +293,7 @@ func TestForwardingEnabledByDefault(t *testing.T) {
 }
 
 // TestMetricsCounters checks that a forwarded datagram bumps bytes_forwarded
-// and peak_session_bytes, and that exceeding the cap bumps cap_hits.
+// and peak_transfer_bytes, and that exceeding the cap bumps transfers_capped.
 func TestMetricsCounters(t *testing.T) {
 	serverConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
 	if err != nil {
@@ -331,11 +331,11 @@ func TestMetricsCounters(t *testing.T) {
 	if m.BytesForwardedTotal == 0 {
 		t.Error("bytes_forwarded_total should be > 0 after a forward")
 	}
-	if m.PeakSessionBytes == 0 {
-		t.Error("peak_session_bytes should be > 0 after a forward")
+	if m.PeakTransferBytes == 0 {
+		t.Error("peak_transfer_bytes should be > 0 after a forward")
 	}
-	if m.CapHitsTotal != 0 {
-		t.Errorf("cap_hits_total = %d, want 0", m.CapHitsTotal)
+	if m.TransfersCappedTotal != 0 {
+		t.Errorf("transfers_capped_total = %d, want 0", m.TransfersCappedTotal)
 	}
 	if !m.Forwarding {
 		t.Error("forwarding should be true")
@@ -371,13 +371,55 @@ func TestMetricsCapHit(t *testing.T) {
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {
-		if srv.Metrics().CapHitsTotal > 0 {
+		if srv.Metrics().TransfersCappedTotal > 0 {
 			break
 		}
 		time.Sleep(20 * time.Millisecond)
 	}
-	if got := srv.Metrics().CapHitsTotal; got != 1 {
-		t.Errorf("cap_hits_total = %d, want 1", got)
+	if got := srv.Metrics().TransfersCappedTotal; got != 1 {
+		t.Errorf("transfers_capped_total = %d, want 1", got)
+	}
+
+	cancel()
+	_ = serverConn.Close()
+	<-srvErr
+}
+
+// TestMaxBytes_ZeroMeansUnlimited locks in the operator escape hatch: a
+// 0 byte cap forwards without ever tripping cap_hit. The hot path guards
+// with `MaxBytesPerSession > 0`, so this guards against Default() (or a
+// future refactor) re-mapping 0 back to a finite limit.
+func TestMaxBytes_ZeroMeansUnlimited(t *testing.T) {
+	serverConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	relayAddr := serverConn.LocalAddr().(*net.UDPAddr)
+	srv := NewServer(serverConn, ServerConfig{MaxBytesPerSession: 0}) // unlimited
+	tok, _ := srv.Allocate()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srvErr := make(chan error, 1)
+	go func() { srvErr <- srv.Run(ctx) }()
+
+	clientA, _ := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	defer clientA.Close()
+	clientB, _ := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	defer clientB.Close()
+	connA := NewClient(clientA, relayAddr, tok)
+	connB := NewClient(clientB, relayAddr, tok)
+
+	_, _ = connA.WriteTo([]byte("hello"), nil)
+	_, _ = connB.WriteTo([]byte("register"), nil)
+	time.Sleep(50 * time.Millisecond)
+	_, _ = connA.WriteTo([]byte("a real payload"), nil)
+	buf := make([]byte, 1500)
+	_ = connB.SetReadDeadline(time.Now().Add(2 * time.Second))
+	if _, _, err := connB.ReadFrom(buf); err != nil {
+		t.Fatalf("B did not receive the forwarded payload: %v", err)
+	}
+	if got := srv.Metrics().TransfersCappedTotal; got != 0 {
+		t.Errorf("transfers_capped_total = %d, want 0 (cap disabled)", got)
 	}
 
 	cancel()

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -50,30 +50,33 @@ type Server struct {
 	draining atomic.Bool
 
 	// Aggregate counters for /v1/metrics (cumulative since boot).
-	bytesForwarded   atomic.Uint64
-	peakSessionBytes atomic.Uint64 // most any single session has forwarded
-	capHits          atomic.Uint64
+	bytesForwarded    atomic.Uint64
+	peakTransferBytes atomic.Uint64 // most any single transfer has forwarded
+	transfersCapped   atomic.Uint64 // transfers cut off for exceeding the byte cap
+	transfersTotal    atomic.Uint64 // relay allocations handed out; vs paired sessions = relay-fallback rate
 }
 
 // Metrics is an aggregate snapshot of relay activity for /v1/metrics.
 type Metrics struct {
-	Forwarding          bool   `json:"forwarding"`
-	Healthy             bool   `json:"healthy"`
-	TransfersActive     int    `json:"transfers_active"`
-	BytesForwardedTotal uint64 `json:"bytes_forwarded_total"`
-	PeakSessionBytes    uint64 `json:"peak_session_bytes"`
-	CapHitsTotal        uint64 `json:"cap_hits_total"`
+	Forwarding           bool   `json:"forwarding"`
+	Healthy              bool   `json:"healthy"`
+	TransfersActive      int    `json:"transfers_active"`
+	TransfersTotal       uint64 `json:"transfers_total"`
+	TransfersCappedTotal uint64 `json:"transfers_capped_total"`
+	BytesForwardedTotal  uint64 `json:"bytes_forwarded_total"`
+	PeakTransferBytes    uint64 `json:"peak_transfer_bytes"`
 }
 
 // Metrics returns the current aggregate snapshot.
 func (s *Server) Metrics() Metrics {
 	return Metrics{
-		Forwarding:          !s.cfg.DisableForwarding,
-		Healthy:             s.healthy.Load(),
-		TransfersActive:     s.ActiveAllocations(),
-		BytesForwardedTotal: s.bytesForwarded.Load(),
-		PeakSessionBytes:    s.peakSessionBytes.Load(),
-		CapHitsTotal:        s.capHits.Load(),
+		Forwarding:           !s.cfg.DisableForwarding,
+		Healthy:              s.healthy.Load(),
+		TransfersActive:      s.ActiveAllocations(),
+		TransfersTotal:       s.transfersTotal.Load(),
+		TransfersCappedTotal: s.transfersCapped.Load(),
+		BytesForwardedTotal:  s.bytesForwarded.Load(),
+		PeakTransferBytes:    s.peakTransferBytes.Load(),
 	}
 }
 
@@ -106,6 +109,9 @@ const TombstoneTTL = 5 * time.Minute
 
 // ServerConfig holds the per-session tuning.
 type ServerConfig struct {
+	// MaxBytesPerSession caps wire bytes a single session may forward.
+	// 0 means unlimited. The unset default (1 GB) is applied by the env
+	// layer in cmd/fsend, so a bare ServerConfig{} here is uncapped.
 	MaxBytesPerSession uint64
 	Logger             *slog.Logger
 	// DisableForwarding makes the relay answer STUN but never carry data
@@ -123,11 +129,10 @@ const janitorInterval = 30 * time.Second
 // raising or lowering it doesn't affect well-behaved sessions.
 const sessionIdleTimeout = 60 * time.Second
 
-// Default fills in zero values.
+// Default fills in zero values. MaxBytesPerSession is deliberately not
+// defaulted here — 0 means unlimited; the env layer supplies the 1 GB
+// default for an unset var.
 func (c *ServerConfig) Default() {
-	if c.MaxBytesPerSession == 0 {
-		c.MaxBytesPerSession = 1000 * 1000 * 1000 // 1 GB (decimal, matches displayed units)
-	}
 	if c.Logger == nil {
 		c.Logger = slog.Default()
 	}
@@ -235,6 +240,7 @@ func (s *Server) Allocate() (Token, error) {
 	}
 	s.allocs[t] = a
 	s.mu.Unlock()
+	s.transfersTotal.Add(1)
 	return t, nil
 }
 
@@ -341,15 +347,15 @@ func (s *Server) handle(datagram []byte, src *net.UDPAddr) {
 	wireSize := uint64(len(datagram))
 	total := a.bytes.Add(wireSize)
 	if s.cfg.MaxBytesPerSession > 0 && total > s.cfg.MaxBytesPerSession {
-		s.capHits.Add(1)
+		s.transfersCapped.Add(1)
 		s.evict(token, ReasonCapHit)
 		return
 	}
 
 	s.bytesForwarded.Add(wireSize)
-	for { // raise the global peak to this session's running total
-		cur := s.peakSessionBytes.Load()
-		if total <= cur || s.peakSessionBytes.CompareAndSwap(cur, total) {
+	for { // raise the global peak to this transfer's running total
+		cur := s.peakTransferBytes.Load()
+		if total <= cur || s.peakTransferBytes.CompareAndSwap(cur, total) {
 			break
 		}
 	}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -12,19 +12,22 @@ import (
 // it can't leak what the server doesn't store. Relay is omitted when no
 // relay is wired.
 type MetricsResponse struct {
-	Version              string         `json:"version"`
-	UptimeSeconds        int64          `json:"uptime_seconds"`
-	SessionsActive       int            `json:"sessions_active"`
-	SessionsCreatedTotal uint64         `json:"sessions_created_total"`
-	RejectedTotal        RejectedCounts `json:"rejected_total"`
-	Relay                *relay.Metrics `json:"relay,omitempty"`
+	Version               string         `json:"version"`
+	UptimeSeconds         int64          `json:"uptime_seconds"`
+	SessionsActive        int            `json:"sessions_active"`
+	SessionsCreatedTotal  uint64         `json:"sessions_created_total"`
+	SessionsPairedTotal   uint64         `json:"sessions_paired_total"`
+	SessionsRejectedTotal RejectedCounts `json:"sessions_rejected_total"`
+	Relay                 *relay.Metrics `json:"relay,omitempty"`
 }
 
-// RejectedCounts breaks down turned-away requests by reason.
+// RejectedCounts breaks down turned-away sessions by reason. RateLimit and
+// ConcurrencyLimit are both per-IP caps — named by what they cap (inflow
+// rate vs standing count), not by "IP", since both key on the source IP.
 type RejectedCounts struct {
-	RateLimit    uint64 `json:"rate_limit"`
-	IPCap        uint64 `json:"ip_cap"`
-	Unauthorized uint64 `json:"unauthorized"`
+	RateLimit        uint64 `json:"rate_limit"`
+	ConcurrencyLimit uint64 `json:"concurrency_limit"`
+	Unauthorized     uint64 `json:"unauthorized"`
 }
 
 func (s *Server) metrics(w http.ResponseWriter, _ *http.Request) {
@@ -37,10 +40,11 @@ func (s *Server) metrics(w http.ResponseWriter, _ *http.Request) {
 		UptimeSeconds:        int64(time.Since(s.started).Seconds()),
 		SessionsActive:       active,
 		SessionsCreatedTotal: s.met.sessionsCreated.Load(),
-		RejectedTotal: RejectedCounts{
-			RateLimit:    s.met.rejRate.Load(),
-			IPCap:        s.met.rejIPCap.Load(),
-			Unauthorized: s.met.rejAuth.Load(),
+		SessionsPairedTotal:  s.met.sessionsPaired.Load(),
+		SessionsRejectedTotal: RejectedCounts{
+			RateLimit:        s.met.rejRate.Load(),
+			ConcurrencyLimit: s.met.rejConcurrency.Load(),
+			Unauthorized:     s.met.rejAuth.Load(),
 		},
 	}
 	if s.relayAllocator != nil {

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -47,7 +47,8 @@ func TestMetrics_Shape(t *testing.T) {
 
 	top := map[string]bool{
 		"version": true, "uptime_seconds": true, "sessions_active": true,
-		"sessions_created_total": true, "rejected_total": true, "relay": true,
+		"sessions_created_total": true, "sessions_paired_total": true,
+		"sessions_rejected_total": true, "relay": true,
 	}
 	for k := range raw {
 		if !top[k] {
@@ -59,10 +60,11 @@ func TestMetrics_Shape(t *testing.T) {
 			t.Errorf("missing field %q", k)
 		}
 	}
-	assertKeys(t, raw["rejected_total"], "rejected_total", "rate_limit", "ip_cap", "unauthorized")
+	assertKeys(t, raw["sessions_rejected_total"], "sessions_rejected_total",
+		"rate_limit", "concurrency_limit", "unauthorized")
 	assertKeys(t, raw["relay"], "relay",
-		"forwarding", "healthy", "transfers_active",
-		"bytes_forwarded_total", "peak_session_bytes", "cap_hits_total")
+		"forwarding", "healthy", "transfers_active", "transfers_total",
+		"transfers_capped_total", "bytes_forwarded_total", "peak_transfer_bytes")
 }
 
 func assertKeys(t *testing.T, v any, name string, want ...string) {
@@ -103,8 +105,8 @@ func TestMetrics_Counters(t *testing.T) {
 	if m.SessionsActive != 1 {
 		t.Errorf("sessions_active = %d, want 1", m.SessionsActive)
 	}
-	if m.RejectedTotal.RateLimit != 1 {
-		t.Errorf("rejected_total.rate_limit = %d, want 1", m.RejectedTotal.RateLimit)
+	if m.SessionsRejectedTotal.RateLimit != 1 {
+		t.Errorf("sessions_rejected_total.rate_limit = %d, want 1", m.SessionsRejectedTotal.RateLimit)
 	}
 }
 
@@ -142,8 +144,8 @@ func TestMetrics_GatedByPassword(t *testing.T) {
 	if err := json.NewDecoder(resp2.Body).Decode(&m); err != nil {
 		t.Fatal(err)
 	}
-	if m.RejectedTotal.Unauthorized != 1 {
-		t.Errorf("rejected_total.unauthorized = %d, want 1", m.RejectedTotal.Unauthorized)
+	if m.SessionsRejectedTotal.Unauthorized != 1 {
+		t.Errorf("sessions_rejected_total.unauthorized = %d, want 1", m.SessionsRejectedTotal.Unauthorized)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -29,8 +29,8 @@ type Config struct {
 	AbandonedTTL         time.Duration // default 5m
 	PairedTTL            time.Duration // default 600s
 	LongPollTimeout      time.Duration // default 25s
-	MaxSessionsPerIP     int           // default 5
-	MaxNewSessionsPerMin int           // default 30
+	MaxSessionsPerIP     int           // 0 = unlimited; unset default 5 applied by env layer
+	MaxNewSessionsPerMin int           // 0 = unlimited; unset default 30 applied by env layer
 	Logger               *slog.Logger
 
 	// ServerPassword, when non-empty, gates every endpoint except
@@ -63,12 +63,9 @@ func (c *Config) Default() {
 	if c.LongPollTimeout == 0 {
 		c.LongPollTimeout = 25 * time.Second
 	}
-	if c.MaxSessionsPerIP == 0 {
-		c.MaxSessionsPerIP = 5
-	}
-	if c.MaxNewSessionsPerMin == 0 {
-		c.MaxNewSessionsPerMin = 30
-	}
+	// MaxSessionsPerIP / MaxNewSessionsPerMin are not defaulted here: 0
+	// means unlimited, and the env layer supplies the unset defaults
+	// (5 / 30). Mapping 0→default here would make "unlimited" unreachable.
 	if c.Logger == nil {
 		c.Logger = slog.Default()
 	}
@@ -122,8 +119,9 @@ type Server struct {
 // since boot). sessions_active is read from the live map at scrape time.
 type serverMetrics struct {
 	sessionsCreated atomic.Uint64
+	sessionsPaired  atomic.Uint64 // sessions a receiver successfully joined
 	rejRate         atomic.Uint64 // rate-limit rejections
-	rejIPCap        atomic.Uint64 // concurrent-cap rejections
+	rejConcurrency  atomic.Uint64 // concurrency-cap rejections
 	rejAuth         atomic.Uint64 // wrong/missing server password
 }
 
@@ -454,9 +452,9 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusTooManyRequests, "rate limit hit")
 		return
 	}
-	if s.ipCounts[rateKey] >= s.cfg.MaxSessionsPerIP {
+	if s.cfg.MaxSessionsPerIP > 0 && s.ipCounts[rateKey] >= s.cfg.MaxSessionsPerIP {
 		s.mu.Unlock()
-		s.met.rejIPCap.Add(1)
+		s.met.rejConcurrency.Add(1)
 		writeJSONError(w, http.StatusTooManyRequests, "too many concurrent sessions for this IP")
 		return
 	}
@@ -530,9 +528,9 @@ func (s *Server) joinSession(w http.ResponseWriter, r *http.Request) {
 		writeJSONError(w, http.StatusConflict, "session already paired")
 		return
 	}
-	if s.ipCounts[rateKey] >= s.cfg.MaxSessionsPerIP {
+	if s.cfg.MaxSessionsPerIP > 0 && s.ipCounts[rateKey] >= s.cfg.MaxSessionsPerIP {
 		s.mu.Unlock()
-		s.met.rejIPCap.Add(1)
+		s.met.rejConcurrency.Add(1)
 		writeJSONError(w, http.StatusTooManyRequests, "too many concurrent sessions for this IP")
 		return
 	}
@@ -543,6 +541,7 @@ func (s *Server) joinSession(w http.ResponseWriter, r *http.Request) {
 	sess.State = "paired"
 	sess.PairedAt = time.Now()
 	s.ipCounts[rateKey]++
+	s.met.sessionsPaired.Add(1)
 	close(sess.waiters)
 	resp := JoinSessionResponse{
 		SessionID:          sess.ID,
@@ -731,6 +730,9 @@ func (s *Server) deleteSession(w http.ResponseWriter, r *http.Request) {
 // allowNewSession must be called with s.mu held. key is the
 // rateLimitKey-collapsed identity (raw v4, /64 for v6).
 func (s *Server) allowNewSession(key string, now time.Time) bool {
+	if s.cfg.MaxNewSessionsPerMin <= 0 {
+		return true // unlimited
+	}
 	b := s.ipBucket[key]
 	if b == nil {
 		b = &rateBucket{}

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -234,8 +234,8 @@ func TestWait_UnknownSlotIsRateLimited(t *testing.T) {
 // behind one NAT stay comfortably under. Simulated against the bucket
 // directly so the test covers a full hour without sleeping.
 func TestWaitRateLimit_PollCadenceStaysUnderBudget(t *testing.T) {
-	s := New(Config{}) // prod defaults: 30 new sessions/min, 25s long-poll
-	const senders = 5  // MaxSessionsPerIP default — worst legitimate case
+	s := New(Config{MaxNewSessionsPerMin: 30}) // prod default: 30 new sessions/min, 25s long-poll
+	const senders = 5                          // MaxSessionsPerIP default — worst legitimate case
 	now := time.Now()
 
 	s.mu.Lock()
@@ -792,6 +792,45 @@ func TestRateLimit_V6BypassClosed(t *testing.T) {
 	}
 	if throttled != 15 {
 		t.Errorf("throttled = %d, want 15", throttled)
+	}
+}
+
+// TestSessionCaps_ZeroMeansUnlimited locks in the operator escape hatch:
+// 0 disables the per-IP concurrency and per-minute rate caps entirely.
+// A regression here (e.g. Default() re-mapping 0→5) would silently
+// re-impose a limit the operator explicitly removed — or, worse, turn 0
+// into "block everything" via the >= comparison.
+func TestSessionCaps_ZeroMeansUnlimited(t *testing.T) {
+	s := New(Config{
+		ServerVersion:        "0.0.0-test",
+		UnpairedTTL:          time.Hour,
+		PairedTTL:            time.Hour,
+		LongPollTimeout:      500 * time.Millisecond,
+		MaxSessionsPerIP:     0, // unlimited concurrency
+		MaxNewSessionsPerMin: 0, // unlimited rate
+	})
+	srv := httptest.NewServer(s.Handler())
+	defer srv.Close()
+
+	// 20 sessions from one IP would clamp to 5 (or 429 on rate) under the
+	// defaults; with both caps at 0 every create must succeed.
+	const n = 20
+	for i := 0; i < n; i++ {
+		body := mustJSON(t, CreateSessionRequest{Slot: fmt.Sprintf("%032x", i+1)})
+		req, err := http.NewRequest(http.MethodPost, srv.URL+"/v1/session", bytes.NewReader(body))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("X-Real-IP", "203.0.113.7")
+		req.Header.Set("Content-Type", "application/json")
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		_ = resp.Body.Close()
+		if resp.StatusCode != 200 {
+			t.Fatalf("create #%d: status %d, want 200 (caps disabled)", i+1, resp.StatusCode)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Two related server-side changes for v1.8.0, both touching the metrics/config surface.

### 1. `/v1/metrics` schema standardization + new metrics
- **`sessions_paired_total`** (new) — incremented on a successful receiver join. This is the *correct* denominator for the relay-fallback rate: unpaired sessions (sender opened a code, no receiver showed up) never transfer anything, so dividing by `sessions_created_total` would overstate the direct-connection rate.
- **`relay.transfers_total`** (new) — relay allocations handed out since boot. `relay.transfers_total / sessions_paired_total` = relay-fallback rate; the rest connected directly (P2P).
- **Renames** for a consistent two-layer noun scheme — `sessions_*` at the pairing layer, `transfers_*` in the relay block:

  | before | after |
  |---|---|
  | `rejected_total` | `sessions_rejected_total` |
  | `rejected_total.ip_cap` | `sessions_rejected_total.concurrency_limit` |
  | `relay.sessions_total` | `relay.transfers_total` |
  | `relay.cap_hits_total` | `relay.transfers_capped_total` |
  | `relay.peak_session_bytes` | `relay.peak_transfer_bytes` |

  (`ip_cap` → `concurrency_limit` because *both* per-IP caps are IP-based; the real distinction is rate vs concurrency.)
- Relay fields reordered so the `transfers_*` counts group together.

### 2. `0 = unlimited` on the three cap env vars
`FSEND_SERVER_MAX_SESSIONS_PER_IP`, `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN`, and `FSEND_RELAY_MAX_BYTES_PER_SESSION` now treat an explicit `0` as "no cap". An **unset** var still gets its default (5 / 30 / 1 GB) from the env layer. Previously `0` silently collapsed to the default; for the two session caps a naive `0` at the enforcement site would have meant *block everything* (`count >= 0`), so guards were added rather than just dropping the `Default()` mapping.

## Notes / call-outs
- **Schema is pre-release** (v1.8.0 not yet tagged, `/v1/metrics` is new in #89), so these renames break no released consumer.
- **Docs guidance changed meaning:** `docs/self-hosting.md` previously said to divide the relay rate by `sessions_created_total`; corrected to `sessions_paired_total`.
- **Security posture:** setting a session cap to `0` disables a per-IP DoS protection — intentional operator escape hatch, documented with that caveat.
- `RELEASE_NOTES_v1.8.0.md` is intentionally **not** included in this PR.

## Testing
- Guard tests added: `TestSessionCaps_ZeroMeansUnlimited`, `TestMaxBytes_ZeroMeansUnlimited` (lock in the unlimited behavior against a future `Default()` regression).
- Metrics shape/behavioral tests updated to the new field names.
- `go build`, `go vet`, and `go test ./...` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)