### PR TITLE
feat(server): print effective config at startup, flagging non-default settings

### DIFF
--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -20,6 +20,7 @@ import (
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/relay"
 	"github.com/polius/fsend/internal/server"
+	"github.com/polius/fsend/internal/uxlog"
 	"github.com/polius/fsend/internal/version"
 )
 
@@ -75,6 +76,10 @@ func runServer() error {
 	}
 	logger := slog.New(slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{Level: cfg.logLevel}))
 	slog.SetDefault(logger)
+
+	// Print the effective config before the structured logs so an operator
+	// can confirm their FSEND_* overrides took effect.
+	_, _ = fmt.Fprint(os.Stdout, formatServerConfig(cfg))
 
 	s := server.New(server.Config{
 		ServerVersion:        version.Version,
@@ -193,6 +198,26 @@ func drainRelay(ctx context.Context, r *relay.Server, logger *slog.Logger) {
 	}
 }
 
+// Server env-var names and their built-in defaults. Shared by the config
+// loader and the startup summary so the two can't drift on a rename or a
+// changed default.
+const (
+	envPairingAddr          = "FSEND_PAIRING_ADDR"
+	envRelayAddr            = "FSEND_RELAY_ADDR"
+	envMaxSessionsPerIP     = "FSEND_SERVER_MAX_SESSIONS_PER_IP"
+	envMaxNewSessionsPerMin = "FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN"
+	envMaxBytesPerSession   = "FSEND_RELAY_MAX_BYTES_PER_SESSION"
+	envRelayEnabled         = "FSEND_RELAY_ENABLED"
+	envLogLevel             = "FSEND_LOG_LEVEL"
+
+	defaultPairingAddr          = ":8080"
+	defaultRelayAddr            = ":443"
+	defaultMaxSessionsPerIP     = 5
+	defaultMaxNewSessionsPerMin = 30
+	defaultMaxBytesPerSession   = 1000 * 1000 * 1000 // 1 GB (decimal, matches displayed units)
+	defaultRelayEnabled         = true
+)
+
 // serverRuntimeConfig is the parsed environment for `fsend server`.
 type serverRuntimeConfig struct {
 	httpAddr             string
@@ -207,24 +232,24 @@ type serverRuntimeConfig struct {
 
 func loadServerConfig() (serverRuntimeConfig, error) {
 	cfg := serverRuntimeConfig{
-		httpAddr:       envOr("FSEND_PAIRING_ADDR", ":8080"),
-		udpAddr:        envOr("FSEND_RELAY_ADDR", ":443"),
+		httpAddr:       envOr(envPairingAddr, defaultPairingAddr),
+		udpAddr:        envOr(envRelayAddr, defaultRelayAddr),
 		serverPassword: os.Getenv("FSEND_SERVER_PASSWORD"),
 	}
 	var err error
-	if cfg.maxSessionsPerIP, err = envInt("FSEND_SERVER_MAX_SESSIONS_PER_IP", 5); err != nil {
+	if cfg.maxSessionsPerIP, err = envInt(envMaxSessionsPerIP, defaultMaxSessionsPerIP); err != nil {
 		return cfg, err
 	}
-	if cfg.maxNewSessionsPerMin, err = envInt("FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN", 30); err != nil {
+	if cfg.maxNewSessionsPerMin, err = envInt(envMaxNewSessionsPerMin, defaultMaxNewSessionsPerMin); err != nil {
 		return cfg, err
 	}
-	if cfg.maxBytesPerSession, err = envBytes("FSEND_RELAY_MAX_BYTES_PER_SESSION", 1000*1000*1000); err != nil { // 1GB
+	if cfg.maxBytesPerSession, err = envBytes(envMaxBytesPerSession, defaultMaxBytesPerSession); err != nil {
 		return cfg, err
 	}
-	if cfg.enableRelay, err = envBool("FSEND_RELAY_ENABLED", true); err != nil {
+	if cfg.enableRelay, err = envBool(envRelayEnabled, defaultRelayEnabled); err != nil {
 		return cfg, err
 	}
-	switch strings.ToLower(os.Getenv("FSEND_LOG_LEVEL")) {
+	switch strings.ToLower(os.Getenv(envLogLevel)) {
 	case "debug":
 		cfg.logLevel = slog.LevelDebug
 	case "warn":
@@ -235,6 +260,88 @@ func loadServerConfig() (serverRuntimeConfig, error) {
 		cfg.logLevel = slog.LevelInfo
 	}
 	return cfg, nil
+}
+
+// formatServerConfig renders the effective server configuration as a
+// human-readable block, flagging each setting whose value differs from its
+// built-in default with a leading "*". Printed once at startup so an
+// operator can confirm at a glance that their FSEND_* overrides were
+// picked up. The password is never printed — only whether one is set.
+func formatServerConfig(cfg serverRuntimeConfig) string {
+	type setting struct {
+		name     string
+		value    string
+		modified bool
+	}
+	password := "(not set)"
+	if cfg.serverPassword != "" {
+		password = "(set)"
+	}
+	settings := []setting{
+		{envLogLevel, logLevelName(cfg.logLevel), cfg.logLevel != slog.LevelInfo},
+		// Env-var name inlined (not a shared const) so gosec G101 doesn't
+		// mistake a password-named identifier for a hardcoded credential.
+		{"FSEND_SERVER_PASSWORD", password, cfg.serverPassword != ""},
+		{envMaxSessionsPerIP, capCount(cfg.maxSessionsPerIP), cfg.maxSessionsPerIP != defaultMaxSessionsPerIP},
+		{envMaxNewSessionsPerMin, capCount(cfg.maxNewSessionsPerMin), cfg.maxNewSessionsPerMin != defaultMaxNewSessionsPerMin},
+		{envPairingAddr, cfg.httpAddr, cfg.httpAddr != defaultPairingAddr},
+		{envRelayEnabled, strconv.FormatBool(cfg.enableRelay), !cfg.enableRelay},
+		{envRelayAddr, cfg.udpAddr, cfg.udpAddr != defaultRelayAddr},
+		{envMaxBytesPerSession, capBytes(cfg.maxBytesPerSession), cfg.maxBytesPerSession != defaultMaxBytesPerSession},
+	}
+
+	width, modified := 0, 0
+	for _, s := range settings {
+		if len(s.name) > width {
+			width = len(s.name)
+		}
+		if s.modified {
+			modified++
+		}
+	}
+
+	var b strings.Builder
+	fmt.Fprintf(&b, "fsend server configuration (%d of %d customized; * = changed from default):\n",
+		modified, len(settings))
+	for _, s := range settings {
+		mark := " "
+		if s.modified {
+			mark = "*"
+		}
+		fmt.Fprintf(&b, "  %s %-*s  %s\n", mark, width, s.name, s.value)
+	}
+	return b.String()
+}
+
+// capCount renders a session cap, spelling out the 0 = unlimited case.
+func capCount(n int) string {
+	if n == 0 {
+		return "0 (unlimited)"
+	}
+	return strconv.Itoa(n)
+}
+
+// capBytes renders the per-session byte cap, spelling out 0 = unlimited.
+func capBytes(n uint64) string {
+	if n == 0 {
+		return "unlimited"
+	}
+	return uxlog.HumanBytes(int64(n))
+}
+
+// logLevelName maps the parsed level back to the lowercase form operators
+// set in FSEND_LOG_LEVEL (slog's own String() is uppercase).
+func logLevelName(l slog.Level) string {
+	switch l {
+	case slog.LevelDebug:
+		return "debug"
+	case slog.LevelWarn:
+		return "warn"
+	case slog.LevelError:
+		return "error"
+	default:
+		return "info"
+	}
 }
 
 func envOr(name, def string) string {
@@ -329,7 +436,7 @@ func envBytes(name string, def uint64) (uint64, error) {
 // HTTP address. Exits 0 on healthy, 1 on anything else. Designed for
 // Docker HEALTHCHECK.
 func healthCheck() error {
-	addr := envOr("FSEND_PAIRING_ADDR", ":8080")
+	addr := envOr(envPairingAddr, defaultPairingAddr)
 	if strings.HasPrefix(addr, ":") {
 		addr = "127.0.0.1" + addr
 	}

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -7,6 +7,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -255,6 +256,63 @@ func TestServerLoadConfigLogLevels(t *testing.T) {
 				t.Errorf("FSEND_LOG_LEVEL=%q: got %v, want %v", input, cfg.logLevel, want)
 			}
 		})
+	}
+}
+
+func defaultServerConfig() serverRuntimeConfig {
+	return serverRuntimeConfig{
+		httpAddr:             defaultPairingAddr,
+		udpAddr:              defaultRelayAddr,
+		logLevel:             slog.LevelInfo,
+		maxSessionsPerIP:     defaultMaxSessionsPerIP,
+		maxNewSessionsPerMin: defaultMaxNewSessionsPerMin,
+		maxBytesPerSession:   defaultMaxBytesPerSession,
+		enableRelay:          defaultRelayEnabled,
+	}
+}
+
+func TestFormatServerConfig_AllDefaults(t *testing.T) {
+	out := formatServerConfig(defaultServerConfig())
+	if strings.Contains(out, "* FSEND") {
+		t.Errorf("all-default config must mark nothing customized:\n%s", out)
+	}
+	if !strings.Contains(out, "0 of 8 customized") {
+		t.Errorf("want '0 of 8 customized':\n%s", out)
+	}
+	if !strings.Contains(out, "(not set)") {
+		t.Errorf("password must read '(not set)' when empty:\n%s", out)
+	}
+}
+
+func TestFormatServerConfig_Overrides(t *testing.T) {
+	cfg := defaultServerConfig()
+	cfg.serverPassword = "hunter2-do-not-leak"
+	cfg.maxSessionsPerIP = 0 // unlimited
+	cfg.enableRelay = false
+
+	out := formatServerConfig(cfg)
+
+	// The password value must never appear — only that one is set.
+	if strings.Contains(out, "hunter2-do-not-leak") {
+		t.Fatalf("password value leaked into output:\n%s", out)
+	}
+	if !strings.Contains(out, "(set)") {
+		t.Errorf("password must read '(set)':\n%s", out)
+	}
+	if !strings.Contains(out, "0 (unlimited)") {
+		t.Errorf("a 0 cap must render as unlimited:\n%s", out)
+	}
+	if !strings.Contains(out, "3 of 8 customized") {
+		t.Errorf("want '3 of 8 customized':\n%s", out)
+	}
+	for _, name := range []string{"FSEND_SERVER_PASSWORD", envMaxSessionsPerIP, envRelayEnabled} {
+		if !strings.Contains(out, "* "+name) {
+			t.Errorf("expected '* %s' marker line:\n%s", name, out)
+		}
+	}
+	// An unchanged setting must stay unmarked.
+	if strings.Contains(out, "* "+envPairingAddr) {
+		t.Errorf("unchanged %s must not be marked:\n%s", envPairingAddr, out)
 	}
 }
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -239,6 +239,23 @@ one keeps its metrics to whoever holds the password.
 All optional; defaults shown. Set them under the `fsend` service's
 `environment:` block in `docker-compose.yml`.
 
+On startup the server prints its effective configuration, marking with a
+`*` every setting you changed from its default — a quick way to confirm
+your overrides were picked up (the password value is never printed, only
+whether one is set):
+
+```
+fsend server configuration (2 of 8 customized; * = changed from default):
+  * FSEND_SERVER_PASSWORD                      (set)
+  * FSEND_SERVER_MAX_SESSIONS_PER_IP           0 (unlimited)
+    FSEND_LOG_LEVEL                            info
+    FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN   30
+    FSEND_PAIRING_ADDR                         :8080
+    FSEND_RELAY_ENABLED                        true
+    FSEND_RELAY_ADDR                           :443
+    FSEND_RELAY_MAX_BYTES_PER_SESSION          1 GB
+```
+
 Variables are grouped into **server-wide** controls (apply to the whole
 server, relay included), the **pairing** listener (TCP signaling/control
 plane), and **relay** settings (the UDP data plane, which also answers


### PR DESCRIPTION
## Summary

On startup, `fsend server` now prints a summary of all `FSEND_*` settings, marking with a `*` every setting whose value differs from its built-in default. This makes it easy to confirm that env-var overrides were actually picked up — especially handy after the v1.8.0 renames and the new `0 = unlimited` cap behavior.

Example (with a password and an unlimited per-IP cap set):

```
fsend server configuration (2 of 8 customized; * = changed from default):
  * FSEND_SERVER_PASSWORD                      (set)
  * FSEND_SERVER_MAX_SESSIONS_PER_IP           0 (unlimited)
    FSEND_LOG_LEVEL                            info
    FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN   30
    FSEND_PAIRING_ADDR                         :8080
    FSEND_RELAY_ENABLED                        true
    FSEND_RELAY_ADDR                           :443
    FSEND_RELAY_MAX_BYTES_PER_SESSION          1 GB
```

## Design choices
- **"Modified" = value differs from default** (not merely "env var present"). Directly answers "is my value non-default?" and naturally surfaces the `0 → unlimited` case.
- **Password redacted** — prints `(set)` / `(not set)`, never the secret. Printing it to logs would be a real leak.
- **ASCII `*` marker** (no color/unicode) so it stays readable in Docker logs and non-TTY pipes.
- **Printed once at startup, before the structured logs**, to stdout (same stream as the logger).
- **Shared name + default constants** between the config loader and the summary, so a future rename or default change can't desync the two.

## Testing
- `TestFormatServerConfig_AllDefaults` — nothing marked, `(not set)` shown.
- `TestFormatServerConfig_Overrides` — correct settings marked, `0 (unlimited)` rendered, and an explicit assertion that the **password value never appears** in the output.
- `gofmt`, `go vet`, and `go test ./...` all green (19 packages).

## Notes
- `RELEASE_NOTES_v1.8.0.md` is intentionally **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)