### PR TITLE
feat(server): default the three caps to 0 = unlimited

### DIFF
--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -210,11 +210,14 @@ const (
 	envRelayEnabled         = "FSEND_RELAY_ENABLED"
 	envLogLevel             = "FSEND_LOG_LEVEL"
 
-	defaultPairingAddr          = ":8080"
-	defaultRelayAddr            = ":443"
-	defaultMaxSessionsPerIP     = 5
-	defaultMaxNewSessionsPerMin = 30
-	defaultMaxBytesPerSession   = 1000 * 1000 * 1000 // 1 GB (decimal, matches displayed units)
+	defaultPairingAddr = ":8080"
+	defaultRelayAddr   = ":443"
+	// The three caps default to 0 = unlimited: an unconfigured server
+	// imposes no per-IP session limits and no relay byte cap. Operators
+	// opt into protection by setting a positive value.
+	defaultMaxSessionsPerIP     = 0
+	defaultMaxNewSessionsPerMin = 0
+	defaultMaxBytesPerSession   = 0
 	defaultRelayEnabled         = true
 )
 
@@ -313,7 +316,7 @@ func formatServerConfig(cfg serverRuntimeConfig) string {
 	return b.String()
 }
 
-// capCount renders a session cap, spelling out the 0 = unlimited case.
+// capCount renders a session cap, showing 0 as "0 (unlimited)".
 func capCount(n int) string {
 	if n == 0 {
 		return "0 (unlimited)"
@@ -321,10 +324,10 @@ func capCount(n int) string {
 	return strconv.Itoa(n)
 }
 
-// capBytes renders the per-session byte cap, spelling out 0 = unlimited.
+// capBytes renders the per-session byte cap, showing 0 as "0 (unlimited)".
 func capBytes(n uint64) string {
 	if n == 0 {
-		return "unlimited"
+		return "0 (unlimited)"
 	}
 	return uxlog.HumanBytes(int64(n))
 }
@@ -479,14 +482,14 @@ CONFIGURATION (environment variables — all optional)
                                       endpoints except /v1/health require the
                                       X-Fsend-Auth header. Connect with
                                       fsend --connect <host:port>,<password>.
-    FSEND_SERVER_MAX_SESSIONS_PER_IP  Default 5 — how many sessions one IP
-                                      may have alive at once (concurrency
-                                      cap; gates relay access too). 0 =
-                                      unlimited.
+    FSEND_SERVER_MAX_SESSIONS_PER_IP  How many sessions one IP may have
+                                      alive at once (concurrency cap; gates
+                                      relay access too). Default 0 =
+                                      unlimited; set a positive value to cap.
     FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN
-                                      Default 30 — how many new sessions one
-                                      IP may create per minute (rate cap).
-                                      0 = unlimited.
+                                      How many new sessions one IP may create
+                                      per minute (rate cap). Default 0 =
+                                      unlimited; set a positive value to cap.
 
   Pairing (TCP signaling/control plane):
     FSEND_PAIRING_ADDR                Default :8080 (TCP).
@@ -498,10 +501,10 @@ CONFIGURATION (environment variables — all optional)
     FSEND_RELAY_ADDR                  Default :443 (UDP). Also the STUN
                                       endpoint, so it stays in use even
                                       when forwarding is disabled.
-    FSEND_RELAY_MAX_BYTES_PER_SESSION Default 1GB — wire bytes after
+    FSEND_RELAY_MAX_BYTES_PER_SESSION Per-session wire bytes after
                                       compression. Accepts B, KB, MB, GB,
-                                      TB, or a plain byte count. 0 =
-                                      unlimited.
+                                      TB, or a plain byte count. Default 0 =
+                                      unlimited; set a value to cap.
 
 LEARN MORE
   https://github.com/polius/fsend

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -171,14 +171,15 @@ func TestServerLoadConfigDefaults(t *testing.T) {
 	if cfg.udpAddr != ":443" {
 		t.Errorf("udpAddr: got %q, want :443", cfg.udpAddr)
 	}
-	if cfg.maxSessionsPerIP != 5 {
-		t.Errorf("maxSessionsPerIP: got %d, want 5", cfg.maxSessionsPerIP)
+	// The three caps default to 0 = unlimited when unset.
+	if cfg.maxSessionsPerIP != 0 {
+		t.Errorf("maxSessionsPerIP: got %d, want 0 (unlimited)", cfg.maxSessionsPerIP)
 	}
-	if cfg.maxNewSessionsPerMin != 30 {
-		t.Errorf("maxNewSessionsPerMin: got %d, want 30", cfg.maxNewSessionsPerMin)
+	if cfg.maxNewSessionsPerMin != 0 {
+		t.Errorf("maxNewSessionsPerMin: got %d, want 0 (unlimited)", cfg.maxNewSessionsPerMin)
 	}
-	if cfg.maxBytesPerSession != 1000*srvMB { // 1GB
-		t.Errorf("maxBytesPerSession: got %d, want %d", cfg.maxBytesPerSession, 1000*srvMB)
+	if cfg.maxBytesPerSession != 0 {
+		t.Errorf("maxBytesPerSession: got %d, want 0 (unlimited)", cfg.maxBytesPerSession)
 	}
 	if cfg.logLevel != slog.LevelInfo {
 		t.Errorf("logLevel: got %v, want info", cfg.logLevel)
@@ -282,12 +283,16 @@ func TestFormatServerConfig_AllDefaults(t *testing.T) {
 	if !strings.Contains(out, "(not set)") {
 		t.Errorf("password must read '(not set)' when empty:\n%s", out)
 	}
+	// The three caps default to 0 and must render as "0 (unlimited)".
+	if n := strings.Count(out, "0 (unlimited)"); n != 3 {
+		t.Errorf("want 3 '0 (unlimited)' lines (the default caps), got %d:\n%s", n, out)
+	}
 }
 
 func TestFormatServerConfig_Overrides(t *testing.T) {
 	cfg := defaultServerConfig()
 	cfg.serverPassword = "hunter2-do-not-leak"
-	cfg.maxSessionsPerIP = 0 // unlimited
+	cfg.maxSessionsPerIP = 10 // a finite cap differs from the unlimited default
 	cfg.enableRelay = false
 
 	out := formatServerConfig(cfg)
@@ -299,8 +304,12 @@ func TestFormatServerConfig_Overrides(t *testing.T) {
 	if !strings.Contains(out, "(set)") {
 		t.Errorf("password must read '(set)':\n%s", out)
 	}
+	// A finite cap shows the number; the still-default caps stay unlimited.
+	if !strings.Contains(out, "10\n") {
+		t.Errorf("finite cap must render as its number:\n%s", out)
+	}
 	if !strings.Contains(out, "0 (unlimited)") {
-		t.Errorf("a 0 cap must render as unlimited:\n%s", out)
+		t.Errorf("default caps must still render as '0 (unlimited)':\n%s", out)
 	}
 	if !strings.Contains(out, "3 of 8 customized") {
 		t.Errorf("want '3 of 8 customized':\n%s", out)

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -247,13 +247,13 @@ whether one is set):
 ```
 fsend server configuration (2 of 8 customized; * = changed from default):
   * FSEND_SERVER_PASSWORD                      (set)
-  * FSEND_SERVER_MAX_SESSIONS_PER_IP           0 (unlimited)
+  * FSEND_SERVER_MAX_SESSIONS_PER_IP           10
     FSEND_LOG_LEVEL                            info
-    FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN   30
+    FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN   0 (unlimited)
     FSEND_PAIRING_ADDR                         :8080
     FSEND_RELAY_ENABLED                        true
     FSEND_RELAY_ADDR                           :443
-    FSEND_RELAY_MAX_BYTES_PER_SESSION          1 GB
+    FSEND_RELAY_MAX_BYTES_PER_SESSION          0 (unlimited)
 ```
 
 Variables are grouped into **server-wide** controls (apply to the whole
@@ -265,12 +265,12 @@ STUN).
 |---|---|---|
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
 | `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret restricting all endpoints except `/v1/health` — see [Require a password](#require-a-password-optional). |
-| `FSEND_SERVER_MAX_SESSIONS_PER_IP` | `5` | **Concurrency cap** — how many sessions one source IP may have **alive at once**. A session gates relay allocation too, so this caps relay access as well. `0` = unlimited (removes a DoS protection — only on a trusted/gated server). |
-| `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN` | `30` | **Rate cap** — how many **new** sessions one source IP may **create per minute**. Distinct from the concurrency cap above: this limits inflow over time, that limits standing count. `0` = unlimited (removes a DoS protection — only on a trusted/gated server). |
+| `FSEND_SERVER_MAX_SESSIONS_PER_IP` | `0` (unlimited) | **Concurrency cap** — how many sessions one source IP may have **alive at once**. A session gates relay allocation too, so this caps relay access as well. Defaults to unlimited; **set a positive value to enable this DoS protection** (recommended on a public server). |
+| `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN` | `0` (unlimited) | **Rate cap** — how many **new** sessions one source IP may **create per minute**. Distinct from the concurrency cap above: this limits inflow over time, that limits standing count. Defaults to unlimited; **set a positive value to enable this DoS protection** (recommended on a public server). |
 | `FSEND_PAIRING_ADDR` | `:8080` | TCP signaling listener. |
 | `FSEND_RELAY_ENABLED` | `true` | Set `false` for **pairing + STUN only**: the server still helps peers hole-punch a direct path, but carries no file data. See [Pairing-only mode](#pairing-only-mode-no-relay). |
 | `FSEND_RELAY_ADDR` | `:443` | UDP relay listener — also the STUN endpoint, so it stays in use even when forwarding is off. The server tells clients to dial `<request-host>:<this port>`, so no separate public-address knob is needed. |
-| `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `1GB` | Per-session relay cap — wire bytes after compression. Tune to your bandwidth budget. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`1000000000`). `0` = unlimited. |
+| `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `0` (unlimited) | Per-session relay cap — wire bytes after compression. Defaults to unlimited; set a value to bound per-transfer bandwidth. Accepts `B`, `KB`, `MB`, `GB`, `TB` suffixes (decimal, e.g. `500MB`, `1GB`) or a plain byte count (`1000000000`). |
 
 ### Pairing-only mode (no relay)
 


### PR DESCRIPTION
## Summary

The three cap env vars now **default to `0` (unlimited)** when unset, instead of `5` / `30` / `1 GB`:

| Variable | Old default | New default |
|---|---|---|
| `FSEND_SERVER_MAX_SESSIONS_PER_IP` | `5` | `0` (unlimited) |
| `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN` | `30` | `0` (unlimited) |
| `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `1 GB` | `0` (unlimited) |

An unconfigured server now imposes no per-IP session limits and no relay byte cap. Operators opt into protection by setting a positive value (the enforcement already treats `0` as unlimited from the earlier work).

The startup summary renders an unset/0 cap as **`0 (unlimited)`** — for both the session counts and the byte cap, consistently. Empirically, a server started with no cap vars set:

```
fsend server configuration (0 of 8 customized; * = changed from default):
    FSEND_LOG_LEVEL                           info
    FSEND_SERVER_PASSWORD                     (not set)
    FSEND_SERVER_MAX_SESSIONS_PER_IP          0 (unlimited)
    FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MIN  0 (unlimited)
    FSEND_PAIRING_ADDR                        :8080
    FSEND_RELAY_ENABLED                       true
    FSEND_RELAY_ADDR                          :443
    FSEND_RELAY_MAX_BYTES_PER_SESSION         0 (unlimited)
```

## ⚠️ Security implication (deliberate)

This turns **off the per-IP DoS protections that previously shipped on by default**. The canonical `deploy/compose/docker-compose.yml` does not set these vars, so the default deployment is now **uncapped** unless the operator opts back in. The help text and self-hosting docs now recommend setting a positive value on public-facing servers.

## Changes
- Default constants for the three caps set to `0` (`cmd/fsend/server.go`).
- `capCount` / `capBytes` both render `0` as `0 (unlimited)`.
- `--help` text and `docs/self-hosting.md` updated: default column → `0 (unlimited)`, notes reframed to "set a positive value to enable this DoS protection".
- Tests updated: `TestServerLoadConfigDefaults` expects `0`; the format tests cover the new default display and use a finite value to exercise the "customized" path.

## Testing
- `go test ./...` green; `golangci-lint run ./...` reports 0 issues (verified locally with a go1.26-built linter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)