### PR TITLE
docs(readme): add public server status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   <a href="https://github.com/polius/fsend/actions/workflows/checks.yml"><img src="https://github.com/polius/fsend/actions/workflows/checks.yml/badge.svg" alt="checks"></a>
   <a href="https://github.com/polius/fsend/releases"><img src="https://img.shields.io/github/v/release/polius/fsend" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
+  <a href="https://fsend.alzina.dev/v1/metrics"><img src="https://img.shields.io/website?url=https%3A%2F%2Ffsend.alzina.dev%2Fv1%2Fhealth&up_message=up&down_message=down&label=public%20server" alt="Public server status"></a>
 </p>
 
 <p align="center">


### PR DESCRIPTION
## Summary

Adds a fourth badge to the README header showing the public pairing server's up/down status.

- **Probe:** `/v1/health` via shields.io's `website` check (lightweight, purpose-built up/down).
- **Click-through:** `/v1/metrics` — the aggregate counters JSON, so curious visitors have somewhere to land.

The displayed text is `up`/`down`.

## Notes

- Metrics are aggregate-only (no per-transfer/per-IP data), so linking them publicly leaks nothing.
- Caveat: shields' `website` probe can occasionally time out and render a false `down`. If that proves annoying in practice, a dedicated uptime monitor (UptimeRobot/BetterStack) with debounced checks is the more reliable follow-up.
- Click-through lands on raw JSON — fine for a developer audience; could later point at a rendered status page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)