### PR TITLE
fix(server): count relay transfers_total only when data is forwarded

### DIFF
--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -193,7 +193,7 @@ so anyone can verify the server holds nothing sensitive.
 | `relay.forwarding` | Whether the relay carries data (`false` in pairing + STUN-only mode). |
 | `relay.healthy` | Relay read loop alive — mirrors `/v1/health`'s 503 signal. |
 | `relay.transfers_active` | Relay transfers moving bytes right now. |
-| `relay.transfers_total` | Relay transfers since boot. Divide by `sessions_paired_total` for your relay-fallback rate; the rest connected directly (P2P). A climbing ratio means hole-punching is failing more often. |
+| `relay.transfers_total` | Relay transfers that actually forwarded data since boot (a slot allocated for STUN but never used doesn't count). Divide by `sessions_paired_total` for your relay-fallback rate; the rest connected directly (P2P). A climbing ratio means hole-punching is failing more often. |
 | `relay.transfers_capped_total` | Transfers cut off for hitting the byte cap — raise the cap if this climbs. |
 | `relay.bytes_forwarded_total` | Cumulative bytes relayed — what the relay is costing you. |
 | `relay.peak_transfer_bytes` | Largest single transfer so far; compare to your byte cap to see headroom. |

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -334,11 +334,52 @@ func TestMetricsCounters(t *testing.T) {
 	if m.PeakTransferBytes == 0 {
 		t.Error("peak_transfer_bytes should be > 0 after a forward")
 	}
+	if m.TransfersTotal != 1 {
+		t.Errorf("transfers_total = %d, want 1 after one transfer forwarded data", m.TransfersTotal)
+	}
 	if m.TransfersCappedTotal != 0 {
 		t.Errorf("transfers_capped_total = %d, want 0", m.TransfersCappedTotal)
 	}
 	if !m.Forwarding {
 		t.Error("forwarding should be true")
+	}
+
+	cancel()
+	_ = serverConn.Close()
+	<-srvErr
+}
+
+// TestMetricsTransfersTotal_OnlyCountsForwarded locks in the metric's
+// meaning: a slot allocated for STUN but that never forwards a byte (direct
+// path won, or only one peer showed up) must not inflate transfers_total.
+func TestMetricsTransfersTotal_OnlyCountsForwarded(t *testing.T) {
+	serverConn, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	relayAddr := serverConn.LocalAddr().(*net.UDPAddr)
+	srv := NewServer(serverConn, ServerConfig{})
+	tok, err := srv.Allocate()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got := srv.Metrics().TransfersTotal; got != 0 {
+		t.Fatalf("transfers_total = %d after allocate alone, want 0", got)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	srvErr := make(chan error, 1)
+	go func() { srvErr <- srv.Run(ctx) }()
+
+	// Only peerA ever sends: it registers but nothing is forwarded.
+	clientA, _ := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0})
+	defer clientA.Close()
+	connA := NewClient(clientA, relayAddr, tok)
+	_, _ = connA.WriteTo([]byte("hello"), nil)
+	time.Sleep(100 * time.Millisecond)
+
+	if got := srv.Metrics().TransfersTotal; got != 0 {
+		t.Errorf("transfers_total = %d with no data forwarded, want 0", got)
 	}
 
 	cancel()

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -53,7 +53,7 @@ type Server struct {
 	bytesForwarded    atomic.Uint64
 	peakTransferBytes atomic.Uint64 // most any single transfer has forwarded
 	transfersCapped   atomic.Uint64 // transfers cut off for exceeding the byte cap
-	transfersTotal    atomic.Uint64 // relay allocations handed out; vs paired sessions = relay-fallback rate
+	transfersTotal    atomic.Uint64 // transfers that forwarded ≥1 byte; vs paired sessions = relay-fallback rate
 }
 
 // Metrics is an aggregate snapshot of relay activity for /v1/metrics.
@@ -147,6 +147,9 @@ type allocation struct {
 	bytes        atomic.Uint64
 	lastActivity atomic.Int64 // unix nanos
 	createdAt    time.Time
+	// dataCounted: true once this allocation forwards its first byte, so
+	// transfersTotal counts it exactly once.
+	dataCounted atomic.Bool
 }
 
 // NewServer constructs a Server bound to the given net.PacketConn.
@@ -240,7 +243,8 @@ func (s *Server) Allocate() (Token, error) {
 	}
 	s.allocs[t] = a
 	s.mu.Unlock()
-	s.transfersTotal.Add(1)
+	// transfersTotal is bumped on first forwarded byte (see handle), not here:
+	// every pairing allocates a slot for STUN, so allocations aren't relay use.
 	return t, nil
 }
 
@@ -353,6 +357,9 @@ func (s *Server) handle(datagram []byte, src *net.UDPAddr) {
 	}
 
 	s.bytesForwarded.Add(wireSize)
+	if a.dataCounted.CompareAndSwap(false, true) {
+		s.transfersTotal.Add(1) // first byte forwarded = this allocation is a real transfer
+	}
 	for { // raise the global peak to this transfer's running total
 		cur := s.peakTransferBytes.Load()
 		if total <= cur || s.peakTransferBytes.CompareAndSwap(cur, total) {


### PR DESCRIPTION
## Problem

`relay.transfers_total` was incremented in `Allocate()` — once per relay slot handed out. But every internet pairing allocates a slot **up front, before ICE**, because the relay's UDP socket doubles as the STUN server for hole-punching (`cmd/fsend/internet.go:96`, `sendpair.go:300`). So the counter tracked *allocations*, not relay use:

- The documented fallback-rate ratio `transfers_total / sessions_paired_total` sat near **1.0** regardless of how often direct (P2P) connections actually succeeded — making it useless as the hole-punch-health signal it claims to be.
- A slot allocated for STUN but never used for data surfaced the confusing public-server state `transfers_total=1` with `peak_transfer_bytes=0` and `bytes_forwarded_total=0`.

## Fix

Bump `transfers_total` on the **first forwarded byte** instead, via a per-allocation `dataCounted atomic.Bool` CAS'd in `handle()` (after the cap check, so a datagram dropped at the cap doesn't count). `Allocate()` no longer touches the counter.

The metric now means **"transfers that actually moved data,"** consistent with `transfers_active` / `bytes_forwarded_total` / `peak_transfer_bytes`. The fallback ratio becomes meaningful, and `transfers_total>0` with `peak=0` is now structurally impossible.

## Verification

- `go test ./internal/relay/ ./internal/server/` passes.
- New `TestMetricsTransfersTotal_OnlyCountsForwarded` asserts an allocate-but-never-forward leaves the counter at 0; `TestMetricsCounters` now asserts it reaches 1 after a real transfer.
- Verified end-to-end against a live local server: `transfers_total` is `0` after a bare allocation, `1` only once data flows, and unused allocations don't inflate it.

Doc row in `docs/self-hosting.md` updated to state the data-bearing semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)