### PR TITLE
perf(client): defer relay allocation to actual fallback

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -117,6 +117,9 @@ func runReceiveOverInternet(ctx context.Context, f *flags, c string, cfg *config
 	}
 
 	// --- Fall back to relay: allocate now that we know we need it ---
+	if joined.RelayForwardingDisabled {
+		return fmt.Errorf("%w: direct connection failed and this server has relay forwarding disabled", fserrors.ErrConnectFailed)
+	}
 	alloc, allocErr := client.AllocateRelay(ctx, joined.SessionID, joined.RoleToken)
 	if allocErr != nil {
 		return fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, allocErr)

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -93,14 +93,8 @@ func runReceiveOverInternet(ctx context.Context, f *flags, c string, cfg *config
 		return err
 	}
 
-	// Allocate the relay before ICE: its UDP address is the STUN server
-	// for srflx gathering. Mirrors establishInternetDataPath — see the
-	// rationale there.
-	alloc, allocErr := client.AllocateRelay(ctx, joined.SessionID, joined.RoleToken)
-	stunAddr := ""
-	if allocErr == nil {
-		stunAddr = alloc.RelayAddr
-	}
+	// STUN address rides on the join response; no relay allocation up front.
+	stunAddr := stunAddrForICE(ctx, client, joined.RelayAddr, joined.SessionID, joined.RoleToken)
 
 	// --- Try ICE direct path ---
 	iceConn, icePath, iceErr := iceEstablish(ctx, client, joined.SessionID, joined.RoleToken, iceconn.Options{
@@ -122,7 +116,8 @@ func runReceiveOverInternet(ctx context.Context, f *flags, c string, cfg *config
 		fmt.Fprintln(os.Stderr, "DEBUG: ICE failed:", iceErr)
 	}
 
-	// --- Fall back to relay ---
+	// --- Fall back to relay: allocate now that we know we need it ---
+	alloc, allocErr := client.AllocateRelay(ctx, joined.SessionID, joined.RoleToken)
 	if allocErr != nil {
 		return fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, allocErr)
 	}

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -330,6 +330,9 @@ func establishInternetDataPath(ctx context.Context, f *flags, client *signaling.
 	if f != nil && f.mode == modeDirect {
 		return nil, connpath.Info{}, fmt.Errorf("%w: ICE failed under --mode=direct: %v", fserrors.ErrConnectFailed, iceErr)
 	}
+	if created.RelayForwardingDisabled {
+		return nil, connpath.Info{}, fmt.Errorf("%w: direct connection failed and this server has relay forwarding disabled", fserrors.ErrConnectFailed)
+	}
 	return allocAndDialRelay(ctx, client, created.SessionID, created.RoleToken)
 }
 

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -297,14 +297,12 @@ func waitForReceiver(ctx context.Context, client *signaling.Client, code string)
 // to a relay PacketConn. The pathInfo reflects the choice for UX
 // rendering.
 //
-// The relay is allocated *before* ICE runs: its UDP address doubles as
-// the STUN server for srflx gathering — without that, two NATed peers
-// only exchange private addresses and ICE is doomed to time out. The
-// allocation is idempotent and idle-evicted server-side, so it costs
-// nothing when ICE wins. If allocation fails (e.g. relay not enabled),
-// ICE still runs with host candidates only, and its failure surfaces
-// the allocation error — the same outcome the old post-ICE allocation
-// produced.
+// ICE gathers srflx candidates against the STUN address the server put in
+// the create response (the relay socket also answers STUN). The relay slot
+// itself is allocated only on ICE failure, when we actually need to relay —
+// so a direct connection never reserves one. Old servers that don't
+// advertise the address fall back to allocating up front for STUN (see
+// stunAddrForICE).
 //
 // The debug --mode flag short-circuits the ladder:
 //   - modeDirect: only ICE; surface the ICE error if it fails (no relay fallback).
@@ -313,11 +311,9 @@ func establishInternetDataPath(ctx context.Context, f *flags, client *signaling.
 	if f != nil && f.mode == modeRelay {
 		return allocAndDialRelay(ctx, client, created.SessionID, created.RoleToken)
 	}
-	alloc, allocErr := client.AllocateRelay(ctx, created.SessionID, created.RoleToken)
-	stunAddr := ""
-	if allocErr == nil {
-		stunAddr = alloc.RelayAddr
-	}
+	// The STUN address rides on the create response, so ICE runs without a
+	// relay allocation. We allocate only if ICE fails and we must relay.
+	stunAddr := stunAddrForICE(ctx, client, created.RelayAddr, created.SessionID, created.RoleToken)
 	iceConn, icePath, iceErr := iceEstablish(ctx, client, created.SessionID, created.RoleToken, iceconn.Options{
 		LocalUfrag:  created.IceCredentials.Ufrag,
 		LocalPwd:    created.IceCredentials.Pwd,
@@ -334,17 +330,20 @@ func establishInternetDataPath(ctx context.Context, f *flags, client *signaling.
 	if f != nil && f.mode == modeDirect {
 		return nil, connpath.Info{}, fmt.Errorf("%w: ICE failed under --mode=direct: %v", fserrors.ErrConnectFailed, iceErr)
 	}
-	if allocErr != nil {
-		return nil, connpath.Info{}, fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, allocErr)
+	return allocAndDialRelay(ctx, client, created.SessionID, created.RoleToken)
+}
+
+// stunAddrForICE returns the STUN address for srflx gathering: the one the
+// server advertised, else (old servers that don't) an allocation's address.
+// On error ICE runs host-only, as when no relay exists.
+func stunAddrForICE(ctx context.Context, client *signaling.Client, advertised, sessionID, roleToken string) string {
+	if advertised != "" {
+		return advertised
 	}
-	if alloc.ForwardingDisabled {
-		return nil, connpath.Info{}, fmt.Errorf("%w: direct connection failed and this server has relay forwarding disabled", fserrors.ErrConnectFailed)
+	if alloc, err := client.AllocateRelay(ctx, sessionID, roleToken); err == nil {
+		return alloc.RelayAddr
 	}
-	rc, err := dialRelay(alloc)
-	if err != nil {
-		return nil, connpath.Info{}, fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, err)
-	}
-	return rc, connpath.FromRelay(alloc.RelayAddr), nil
+	return ""
 }
 
 // allocAndDialRelay performs the relay allocation + dial steps. Shared

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -193,7 +193,7 @@ so anyone can verify the server holds nothing sensitive.
 | `relay.forwarding` | Whether the relay carries data (`false` in pairing + STUN-only mode). |
 | `relay.healthy` | Relay read loop alive — mirrors `/v1/health`'s 503 signal. |
 | `relay.transfers_active` | Relay transfers moving bytes right now. |
-| `relay.transfers_total` | Relay transfers that actually forwarded data since boot (a slot allocated for STUN but never used doesn't count). Divide by `sessions_paired_total` for your relay-fallback rate; the rest connected directly (P2P). A climbing ratio means hole-punching is failing more often. |
+| `relay.transfers_total` | Relay transfers that actually forwarded data since boot. Divide by `sessions_paired_total` for your relay-fallback rate; the rest connected directly (P2P). A climbing ratio means hole-punching is failing more often. |
 | `relay.transfers_capped_total` | Transfers cut off for hitting the byte cap — raise the cap if this climbs. |
 | `relay.bytes_forwarded_total` | Cumulative bytes relayed — what the relay is costing you. |
 | `relay.peak_transfer_bytes` | Largest single transfer so far; compare to your byte cap to see headroom. |

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -156,6 +156,15 @@ func (s *Server) relayAddrFor(r *http.Request) string {
 	return net.JoinHostPort(host, strconv.Itoa(s.relayUDPPort))
 }
 
+// stunAddrFor returns the STUN/relay address to advertise, or "" when no
+// relay is wired (nothing to offer for srflx gathering).
+func (s *Server) stunAddrFor(r *http.Request) string {
+	if s.relayAllocator == nil {
+		return ""
+	}
+	return s.relayAddrFor(r)
+}
+
 // New constructs a Server with defaults filled in.
 func New(cfg Config) *Server {
 	cfg.Default()
@@ -497,6 +506,7 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 		TTLSeconds:       int(s.cfg.UnpairedTTL.Seconds()),
 		ServerVersion:    s.cfg.ServerVersion,
 		RoleToken:        senderTok,
+		RelayAddr:        s.stunAddrFor(r),
 	})
 }
 
@@ -550,6 +560,7 @@ func (s *Server) joinSession(w http.ResponseWriter, r *http.Request) {
 		PeerIceCredentials: sess.SenderICE,
 		YourIceCredentials: sess.ReceiverICE,
 		RoleToken:          sess.ReceiverToken,
+		RelayAddr:          s.stunAddrFor(r),
 	}
 	s.mu.Unlock()
 	s.cfg.Logger.Debug("session paired", "slot", slot, "ip", clientIP)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -165,6 +165,12 @@ func (s *Server) stunAddrFor(r *http.Request) string {
 	return s.relayAddrFor(r)
 }
 
+// relayForwardingDisabled reports whether a relay is wired but STUN-only, so
+// clients whose ICE fails can fail fast instead of attempting a doomed alloc.
+func (s *Server) relayForwardingDisabled() bool {
+	return s.relayAllocator != nil && !s.relayAllocator.Forwarding()
+}
+
 // New constructs a Server with defaults filled in.
 func New(cfg Config) *Server {
 	cfg.Default()
@@ -500,13 +506,14 @@ func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {
 	s.cfg.Logger.Debug("session created", "slot", slot, "ip", clientIP)
 
 	writeJSON(w, http.StatusOK, CreateSessionResponse{
-		SessionID:        sid,
-		YourObservedAddr: r.RemoteAddr,
-		IceCredentials:   sess.SenderICE,
-		TTLSeconds:       int(s.cfg.UnpairedTTL.Seconds()),
-		ServerVersion:    s.cfg.ServerVersion,
-		RoleToken:        senderTok,
-		RelayAddr:        s.stunAddrFor(r),
+		SessionID:               sid,
+		YourObservedAddr:        r.RemoteAddr,
+		IceCredentials:          sess.SenderICE,
+		TTLSeconds:              int(s.cfg.UnpairedTTL.Seconds()),
+		ServerVersion:           s.cfg.ServerVersion,
+		RoleToken:               senderTok,
+		RelayAddr:               s.stunAddrFor(r),
+		RelayForwardingDisabled: s.relayForwardingDisabled(),
 	})
 }
 
@@ -554,13 +561,14 @@ func (s *Server) joinSession(w http.ResponseWriter, r *http.Request) {
 	s.met.sessionsPaired.Add(1)
 	close(sess.waiters)
 	resp := JoinSessionResponse{
-		SessionID:          sess.ID,
-		YourObservedAddr:   r.RemoteAddr,
-		PeerObservedAddr:   sess.SenderAddr,
-		PeerIceCredentials: sess.SenderICE,
-		YourIceCredentials: sess.ReceiverICE,
-		RoleToken:          sess.ReceiverToken,
-		RelayAddr:          s.stunAddrFor(r),
+		SessionID:               sess.ID,
+		YourObservedAddr:        r.RemoteAddr,
+		PeerObservedAddr:        sess.SenderAddr,
+		PeerIceCredentials:      sess.SenderICE,
+		YourIceCredentials:      sess.ReceiverICE,
+		RoleToken:               sess.ReceiverToken,
+		RelayAddr:               s.stunAddrFor(r),
+		RelayForwardingDisabled: s.relayForwardingDisabled(),
 	}
 	s.mu.Unlock()
 	s.cfg.Logger.Debug("session paired", "slot", slot, "ip", clientIP)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -133,6 +134,36 @@ func TestJoin_HappyPath(t *testing.T) {
 	if join.SessionID != create.SessionID {
 		t.Errorf("session id mismatch: %q vs %q", join.SessionID, create.SessionID)
 	}
+}
+
+// TestCreateAndJoin_AdvertiseRelayAddr locks in the deferred-allocation
+// contract: create/join carry the STUN/relay address so the client can
+// gather srflx candidates without allocating a slot. Empty when no relay.
+func TestCreateAndJoin_AdvertiseRelayAddr(t *testing.T) {
+	t.Run("with relay", func(t *testing.T) {
+		s := New(Config{ServerVersion: "0.0.0-test", UnpairedTTL: 2 * time.Second, PairedTTL: 5 * time.Second, MaxSessionsPerIP: 10, MaxNewSessionsPerMin: 100})
+		s.WithRelay(&fakeRelay{tok: relay.Token{1}}, 9999)
+		ts := httptest.NewServer(s.Handler())
+		defer ts.Close()
+
+		create := createSession(t, ts.URL, testSlot)
+		if !strings.HasSuffix(create.RelayAddr, ":9999") {
+			t.Errorf("create relay_addr = %q, want host:9999", create.RelayAddr)
+		}
+		joinResp := postJSON(t, ts.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
+		defer joinResp.Body.Close()
+		var join JoinSessionResponse
+		_ = json.NewDecoder(joinResp.Body).Decode(&join)
+		if !strings.HasSuffix(join.RelayAddr, ":9999") {
+			t.Errorf("join relay_addr = %q, want host:9999", join.RelayAddr)
+		}
+	})
+	t.Run("no relay", func(t *testing.T) {
+		srv := newTestServer(t)
+		if got := createSession(t, srv.URL, testSlot).RelayAddr; got != "" {
+			t.Errorf("relay_addr = %q, want empty when no relay wired", got)
+		}
+	})
 }
 
 func TestJoin_NotFound(t *testing.T) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -150,12 +150,29 @@ func TestCreateAndJoin_AdvertiseRelayAddr(t *testing.T) {
 		if !strings.HasSuffix(create.RelayAddr, ":9999") {
 			t.Errorf("create relay_addr = %q, want host:9999", create.RelayAddr)
 		}
+		if create.RelayForwardingDisabled {
+			t.Error("relay_forwarding_disabled should be false when forwarding is on")
+		}
 		joinResp := postJSON(t, ts.URL+"/v1/session/"+testSlot+"/join", JoinSessionRequest{})
 		defer joinResp.Body.Close()
 		var join JoinSessionResponse
 		_ = json.NewDecoder(joinResp.Body).Decode(&join)
 		if !strings.HasSuffix(join.RelayAddr, ":9999") {
 			t.Errorf("join relay_addr = %q, want host:9999", join.RelayAddr)
+		}
+	})
+	t.Run("relay forwarding disabled", func(t *testing.T) {
+		s := New(Config{ServerVersion: "0.0.0-test", UnpairedTTL: 2 * time.Second, PairedTTL: 5 * time.Second, MaxSessionsPerIP: 10, MaxNewSessionsPerMin: 100})
+		s.WithRelay(&fakeRelay{tok: relay.Token{1}, noForward: true}, 9999)
+		ts := httptest.NewServer(s.Handler())
+		defer ts.Close()
+
+		create := createSession(t, ts.URL, testSlot)
+		if create.RelayAddr == "" {
+			t.Error("relay_addr must still be set in STUN-only mode (it's the STUN server)")
+		}
+		if !create.RelayForwardingDisabled {
+			t.Error("relay_forwarding_disabled should be true in STUN-only mode")
 		}
 	})
 	t.Run("no relay", func(t *testing.T) {

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -37,6 +37,9 @@ type CreateSessionResponse struct {
 	TTLSeconds       int      `json:"ttl_seconds"`
 	ServerVersion    string   `json:"server_version"`
 	RoleToken        string   `json:"role_token"`
+	// RelayAddr is the server-wide STUN/relay address, so the client can
+	// gather srflx candidates without allocating a slot. Empty if no relay.
+	RelayAddr string `json:"relay_addr,omitempty"`
 }
 
 // JoinSessionRequest is the body of POST /v1/session/<slot>/join.
@@ -52,6 +55,8 @@ type JoinSessionResponse struct {
 	PeerIceCredentials IceCreds `json:"peer_ice_credentials"`
 	YourIceCredentials IceCreds `json:"your_ice_credentials"`
 	RoleToken          string   `json:"role_token"`
+	// RelayAddr: see CreateSessionResponse.RelayAddr.
+	RelayAddr string `json:"relay_addr,omitempty"`
 }
 
 // WaitRequest is the body of POST /v1/session/<slot>/wait. It carries no

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -40,6 +40,10 @@ type CreateSessionResponse struct {
 	// RelayAddr is the server-wide STUN/relay address, so the client can
 	// gather srflx candidates without allocating a slot. Empty if no relay.
 	RelayAddr string `json:"relay_addr,omitempty"`
+	// RelayForwardingDisabled: relay answers STUN but won't carry data, so a
+	// client whose ICE fails fails fast instead of a doomed alloc. omitempty:
+	// absent/false both mean "try the relay" (matches old servers).
+	RelayForwardingDisabled bool `json:"relay_forwarding_disabled,omitempty"`
 }
 
 // JoinSessionRequest is the body of POST /v1/session/<slot>/join.
@@ -55,8 +59,9 @@ type JoinSessionResponse struct {
 	PeerIceCredentials IceCreds `json:"peer_ice_credentials"`
 	YourIceCredentials IceCreds `json:"your_ice_credentials"`
 	RoleToken          string   `json:"role_token"`
-	// RelayAddr: see CreateSessionResponse.RelayAddr.
-	RelayAddr string `json:"relay_addr,omitempty"`
+	// RelayAddr / RelayForwardingDisabled: see CreateSessionResponse.
+	RelayAddr               string `json:"relay_addr,omitempty"`
+	RelayForwardingDisabled bool   `json:"relay_forwarding_disabled,omitempty"`
 }
 
 // WaitRequest is the body of POST /v1/session/<slot>/wait. It carries no


### PR DESCRIPTION
## Background

Since #54, the relay's UDP socket doubles as the STUN server for ICE hole-punching. The client learned that STUN address from the **relay-allocation response**, so it called `AllocateRelay()` on **every** internet transfer, *before* ICE — even though the vast majority connect directly and never use the relay.

That coupled two unrelated things:
- **Getting the STUN address** — server-wide, and the relay answers STUN token-lessly. Needs no allocation.
- **Reserving a relay slot** — only the fallback path needs it.

Cost of the coupling: a round-trip before ICE on every transfer (it ran sequentially before `iceEstablish`), plus ~60s of relay state per slot that usually went unused. (It also polluted `relay.transfers_total`, fixed separately in #94.)

## Change

- Server advertises the server-wide STUN/relay address in the **create** and **join** responses (`relay_addr`), via a new `stunAddrFor` helper (empty when no relay is wired).
- Client gathers srflx candidates from that address and allocates a relay slot **only when ICE fails** and it actually needs to relay.
- Old servers that don't advertise `relay_addr` fall back to allocating up front for STUN (`stunAddrForICE`), so behavior is unchanged against them.

Net effect: the common direct-connect path reserves nothing and **saves a round-trip**; only true fallbacks allocate.

## No regression to the pre-#54 15s stall

The 15s stall was the *absence* of STUN, not the allocation timing. STUN is untouched here — the relay still answers binding requests token-lessly; we just deliver its address differently. Verified empirically: a raw STUN binding request to the relay with **zero allocations made** returns Binding Success, so srflx gathering (and ~2s direct connect) still works.

## Verification

- `go build ./... && go test ./...` pass.
- New `TestCreateAndJoin_AdvertiseRelayAddr` asserts create/join carry `relay_addr` when a relay is wired, and empty otherwise.
- End-to-end against a live local server: create/join now return `relay_addr`; a session that pairs but doesn't fall back allocates nothing (`transfers_total=0`, no allocate logs); STUN still answered.

Docs: simplified the `transfers_total` row in `docs/self-hosting.md` (its parenthetical about "slots allocated for STUN" no longer applies now that allocation is fallback-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)