### PR TITLE
feat(release): publish Homebrew cask via goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,3 +48,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -64,6 +64,34 @@ archives:
       - LICENSE
       - README.md
 
+homebrew_casks:
+  # Publishes a cask to github.com/polius/homebrew-tap so macOS users can:
+  #   brew install polius/tap/fsend   (Intel + Apple Silicon)
+  - name: fsend
+    ids:
+      - fsend
+    repository:
+      owner: polius
+      name: homebrew-tap
+      branch: main
+      token: '{{ .Env.HOMEBREW_TAP_TOKEN }}'
+    directory: Casks
+    homepage: 'https://github.com/polius/fsend'
+    description: 'Peer-to-peer, end-to-end encrypted file transfer'
+    # Binaries aren't Apple-notarized, so Homebrew quarantines them and Gatekeeper
+    # blocks the first run. Strip the quarantine attr on install.
+    hooks:
+      post:
+        install: |
+          if system_command("/usr/bin/xattr", args: ["-h"]).exit_status == 0
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/fsend"]
+          end
+    skip_upload: auto
+    commit_author:
+      name: goreleaser-bot
+      email: goreleaser-bot@users.noreply.github.com
+    commit_msg_template: 'brew: fsend {{ .Tag }}'
+
 checksum:
   name_template: 'checksums.txt'
   algorithm: sha256


### PR DESCRIPTION
## What

Adds a `homebrew_casks` block to `.goreleaser.yml` so every tagged release publishes a Homebrew cask to [`polius/homebrew-tap`](https://github.com/polius/homebrew-tap). macOS users can then install with:

```bash
brew install polius/tap/fsend   # Intel + Apple Silicon
```

## Why the postflight quarantine hook

Our macOS binaries aren't Apple-notarized (cosign signs `checksums.txt`, which is supply-chain signing, not Apple code signing). Without intervention, Homebrew quarantines the binary and Gatekeeper blocks the first run with *"developer cannot be verified."*

The `postflight` hook strips `com.apple.quarantine` on install so `fsend` runs cleanly. This is the [pattern GoReleaser documents](https://goreleaser.com/customization/homebrew_casks/) for unsigned binaries and is used by 1,100+ public casks (incl. Homebrew's own cask repo, Oracle, Replicate, Timescale). Full Apple notarization is the only durable alternative — a future upgrade, not a blocker.

## release.yml change

One line: passes `HOMEBREW_TAP_TOKEN` (a fine-grained PAT, `Contents: read+write` scoped to the tap repo only) to the goreleaser step. The built-in `GITHUB_TOKEN` can only write to `polius/fsend`, not the separate tap repo — hence the PAT. The secret is already configured in repo settings.

## Notes

- The tap is already live and bootstrapped off v1.9.0 (cask committed manually using the published checksums), and `brew install polius/tap/fsend` is verified working on macOS.
- `skip_upload: auto` means prereleases won't push a cask — only full releases update the tap.
- ⚠️ Merge this **before** tagging the next release, so the auto-regenerated cask retains the quarantine hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)