### PR TITLE
docs(readme): add Homebrew install method for macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,19 @@ fsend is a **command-line tool** that lets any two computers transfer files and 
 curl -fsSL https://getfsend.alzina.dev | sh
 ```
 
+**macOS** — if you prefer [Homebrew](https://brew.sh):
+
+```bash
+brew install polius/tap/fsend
+```
+
 **Windows** — run this in PowerShell:
 
 ```powershell
 irm https://getfsend.alzina.dev/windows | iex
 ```
 
-Both installers verify the release's SHA-256 checksum before installing.
+All three verify the release's SHA-256 checksum before installing.
 
 <details>
 <summary>Other install methods</summary>


### PR DESCRIPTION
Adds a macOS Homebrew install option to the README, now that the tap is live and verified:

```bash
brew install polius/tap/fsend
```

Placed right after the `curl` one-liner (grouping the macOS options), and updated the checksum note to "All three verify…" — the cask carries per-arch `sha256` that Homebrew checks on download, so it's accurate.

Follow-up to #97 (which set up the cask publishing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)