### PR TITLE
feat(server): root banner, unversion /health + /metrics, slim /health

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
   <a href="https://github.com/polius/fsend/actions/workflows/checks.yml"><img src="https://github.com/polius/fsend/actions/workflows/checks.yml/badge.svg" alt="checks"></a>
   <a href="https://github.com/polius/fsend/releases"><img src="https://img.shields.io/github/v/release/polius/fsend" alt="Release"></a>
   <a href="LICENSE"><img src="https://img.shields.io/badge/license-MIT-blue.svg" alt="License"></a>
-  <a href="https://fsend.alzina.dev/v1/metrics"><img src="https://img.shields.io/website?url=https%3A%2F%2Ffsend.alzina.dev%2Fv1%2Fhealth&up_message=up&down_message=down&label=public%20server" alt="Public server status"></a>
+  <a href="https://fsend.alzina.dev/metrics"><img src="https://img.shields.io/website?url=https%3A%2F%2Ffsend.alzina.dev%2Fhealth&up_message=up&down_message=down&label=public%20server" alt="Public server status"></a>
 </p>
 
 <p align="center">

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -57,7 +57,7 @@ func serverCmd() *cobra.Command {
 	}
 
 	c.Flags().BoolVar(&healthCheckFlag, "health-check", false,
-		"probe /v1/health and exit 0 if healthy (for Docker)")
+		"probe /health and exit 0 if healthy (for Docker)")
 
 	sht := boldHelpHeaders(serverHelpTemplate)
 	c.SetHelpTemplate(sht)
@@ -446,7 +446,7 @@ func envBytes(name string, def uint64) (uint64, error) {
 	return uint64(n * mul), nil
 }
 
-// healthCheck pings the local server's /v1/health on the configured
+// healthCheck pings the local server's /health on the configured
 // HTTP address. Exits 0 on healthy, 1 on anything else. Designed for
 // Docker HEALTHCHECK.
 func healthCheck() error {
@@ -454,7 +454,7 @@ func healthCheck() error {
 	if strings.HasPrefix(addr, ":") {
 		addr = "127.0.0.1" + addr
 	}
-	resp, err := http.Get("http://" + addr + "/v1/health")
+	resp, err := http.Get("http://" + addr + "/health")
 	if err != nil {
 		return fmt.Errorf("health: %w", err)
 	}
@@ -472,7 +472,7 @@ const serverHelpTemplate = `fsend server — pairing + relay server for fsend
 
 USAGE
   fsend server                 Run the server (config via env vars)
-  fsend server --health-check  Probe /v1/health and exit 0 if healthy
+  fsend server --health-check  Probe /health and exit 0 if healthy
   fsend server --help          Show this help
 
 EXAMPLE
@@ -490,7 +490,7 @@ CONFIGURATION (environment variables — all optional)
   Server-wide:
     FSEND_LOG_LEVEL                   Default info (debug/info/warn/error).
     FSEND_SERVER_PASSWORD             Optional shared secret. When set, all
-                                      endpoints except /v1/health require the
+                                      endpoints except /health require the
                                       X-Fsend-Auth header. Connect with
                                       fsend --connect <host:port>,<password>.
 

--- a/cmd/fsend/server_lifecycle_unix_test.go
+++ b/cmd/fsend/server_lifecycle_unix_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestServerLifecycle boots the real server in-process, verifies
-// /v1/health responds 200 (both directly and via healthCheck()), then
+// /health responds 200 (both directly and via healthCheck()), then
 // triggers a graceful SIGTERM shutdown and waits for runServer() to
 // return.
 //
@@ -47,13 +47,13 @@ func TestServerLifecycle(t *testing.T) {
 
 	srvWaitForPort(t, httpAddr, 5*time.Second)
 
-	resp, err := http.Get("http://" + httpAddr + "/v1/health")
+	resp, err := http.Get("http://" + httpAddr + "/health")
 	if err != nil {
-		t.Fatalf("GET /v1/health: %v", err)
+		t.Fatalf("GET /health: %v", err)
 	}
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		t.Fatalf("/v1/health: status %d", resp.StatusCode)
+		t.Fatalf("/health: status %d", resp.StatusCode)
 	}
 
 	if err := healthCheck(); err != nil {

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -359,7 +359,7 @@ func TestServerHealthCheckOK(t *testing.T) {
 	}
 }
 
-// startStubHealth boots a minimal HTTP server that answers /v1/health with
+// startStubHealth boots a minimal HTTP server that answers /health with
 // the given status + body, and shuts it down when the test ends. Returns
 // the host:port the test should set as FSEND_SERVER_ADDR.
 func startStubHealth(t *testing.T, status int, body []byte) string {
@@ -367,7 +367,7 @@ func startStubHealth(t *testing.T, status int, body []byte) string {
 	port := srvFreePortTCP(t)
 	addr := fmt.Sprintf("127.0.0.1:%d", port)
 	mux := http.NewServeMux()
-	mux.HandleFunc("/v1/health", func(w http.ResponseWriter, _ *http.Request) {
+	mux.HandleFunc("/health", func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(status)
 		if len(body) > 0 {
 			_, _ = w.Write(body)

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -257,7 +257,7 @@ own code phrase, while fsend always picks it for you.
 | SSH-key transfer helper | ✗ | ✗ | **✓ `wormhole ssh`** |
 | Library / protocol ecosystem | ✗ (app only) | ✗ (app only) | **✓ (importable, Dilation)** |
 | Self-host the server / relay | ✓ | ✓ | ✓ |
-| Server health / metrics endpoint | **✓ `/v1/health` + aggregate `/v1/metrics`** (load, relay bytes, cap hits, rejections — no per-user data) | ✗ | (server is a separate project) |
+| Server health / metrics endpoint | **✓ `/health` + aggregate `/metrics`** (load, relay bytes, cap hits, rejections — no per-user data) | ✗ | (server is a separate project) |
 
 ## Privacy: what a server can observe
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -92,9 +92,13 @@ indefinitely after that — there's no manual cert handling, ever.
 ### 3. Verify
 
 ```sh
-curl https://fs.example.com/v1/health
-# {"status":"ok",…}
+curl https://fs.example.com/health
+# {"status":"ok"}
 ```
+
+Or open `https://fs.example.com/` in a browser — the root path returns a
+plain-text "fsend server is up and running" banner. Both `/` and `/health`
+stay reachable without the password, so monitoring never needs the secret.
 
 No OK response? See [Troubleshooting](#troubleshooting).
 
@@ -127,7 +131,7 @@ and restart:
 docker compose up -d
 ```
 
-Now every endpoint except `/v1/health` requires the password, and clients
+Now every endpoint except `/` and `/health` requires the password, and clients
 append it to `--connect`, comma-separated:
 
 ```sh
@@ -153,7 +157,7 @@ Connecting without it — or with the wrong one — fails with `E028`.
 
 ## Metrics
 
-`GET /v1/metrics` returns a small JSON snapshot for monitoring:
+`GET /metrics` returns a small JSON snapshot for monitoring:
 
 ```json
 {
@@ -191,7 +195,7 @@ so anyone can verify the server holds nothing sensitive.
 | `sessions_rejected_total.concurrency_limit` | Sessions refused by the per-IP concurrency cap (`FSEND_SERVER_MAX_SESSIONS_PER_IP`). |
 | `sessions_rejected_total.unauthorized` | Wrong/missing `FSEND_SERVER_PASSWORD` — brute-force or misconfigured clients (always `0` on an open server). |
 | `relay.forwarding` | Whether the relay carries data (`false` in pairing + STUN-only mode). |
-| `relay.healthy` | Relay read loop alive — mirrors `/v1/health`'s 503 signal. |
+| `relay.healthy` | Relay read loop alive — mirrors `/health`'s 503 signal. |
 | `relay.transfers_active` | Relay transfers moving bytes right now. |
 | `relay.transfers_total` | Relay transfers that actually forwarded data since boot. Divide by `sessions_paired_total` for your relay-fallback rate; the rest connected directly (P2P). A climbing ratio means hole-punching is failing more often. |
 | `relay.transfers_capped_total` | Transfers cut off for hitting the per-session byte cap — raise the cap if this climbs. |
@@ -201,20 +205,20 @@ so anyone can verify the server holds nothing sensitive.
 
 The `relay` block is omitted when the server runs without a relay.
 
-**Access.** `/v1/metrics` inherits the server's own openness, like every
-endpoint except `/v1/health`:
+**Access.** `/metrics` inherits the server's own openness, like every
+endpoint except `/` and `/health`:
 
 - **Open server (no `FSEND_SERVER_PASSWORD`)** — public, no credentials:
 
   ```sh
-  curl https://fs.example.com/v1/metrics
+  curl https://fs.example.com/metrics
   ```
 
 - **Password-protected server** — pass the password in the `X-Fsend-Auth`
   header (the same one clients use):
 
   ```sh
-  curl -H "X-Fsend-Auth: your-secret" https://fs.example.com/v1/metrics
+  curl -H "X-Fsend-Auth: your-secret" https://fs.example.com/metrics
   ```
 
   Without it you get `401`. Note a **web browser can't open this URL**
@@ -231,7 +235,7 @@ one keeps its metrics to whoever holds the password.
 |---|---|
 | `docker compose up` errors out asking for `FSEND_DOMAIN` | You forgot `export FSEND_DOMAIN=…`. Set it and rerun. |
 | Caddy logs show "obtain certificate failed" (ACME error) | DNS A-record not yet pointing at this host, or `80/tcp` blocked at the firewall. |
-| `curl` to `/v1/health` works but clients hit `E001` on cross-network transfers | `443/udp` blocked at the firewall — many setups open TCP only and forget UDP. |
+| `curl` to `/health` works but clients hit `E001` on cross-network transfers | `443/udp` blocked at the firewall — many setups open TCP only and forget UDP. |
 | Pairing starts but the transfer hangs or drops | A reverse proxy in front of fsend (not the bundled Caddy) is buffering long-poll signaling. Caddy is configured for 30s read/write; nginx/Traefik need the same. |
 | Clients hit `E028` ("pairing server requires a password") | You set `FSEND_SERVER_PASSWORD` on the server. Clients must connect with `fsend --connect host:443,<password>`. |
 
@@ -266,7 +270,7 @@ TCP listener and per-IP session limits), and the **relay / data plane**
 | Variable | Default | Notes |
 |---|---|---|
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
-| `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret restricting all endpoints except `/v1/health` — see [Require a password](#require-a-password-optional). |
+| `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret restricting all endpoints except `/` and `/health` — see [Require a password](#require-a-password-optional). |
 | `FSEND_SERVER_ADDR` | `:8080` | TCP signaling listener. |
 | `FSEND_SERVER_MAX_SESSIONS_PER_IP` | `0` (unlimited) | **Concurrency cap** — how many sessions one source IP may have **alive at once**. A session gates relay allocation too, so this caps relay access as well. Defaults to unlimited; **set a positive value to enable this DoS protection** (recommended on a public server). |
 | `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MINUTE` | `0` (unlimited) | **Rate cap** — how many **new** sessions one source IP may **create per minute**. Distinct from the concurrency cap above: this limits inflow over time, that limits standing count. Defaults to unlimited; **set a positive value to enable this DoS protection** (recommended on a public server). |

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,7 +21,7 @@ What to try:
 
 - Check your internet connection.
 - If you run your own server, confirm it's up:
-  `curl https://your-server/v1/health`.
+  `curl https://your-server/health`.
 - Point at a different server with `fsend --connect <host>:443`, or back
   to the default with `fsend --connect default`.
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -247,7 +247,7 @@ environment variables.
 
 ```text
 fsend server                 Run the server
-fsend server --health-check  Probe /v1/health (exit 0 if healthy)
+fsend server --health-check  Probe /health (exit 0 if healthy)
 fsend server --help          Show help
 ```
 

--- a/internal/relay/budget.go
+++ b/internal/relay/budget.go
@@ -56,7 +56,7 @@ func (b *dayBudget) exhausted(now time.Time) bool {
 	return b.used >= b.limit
 }
 
-// usedToday returns bytes forwarded in the current window, for /v1/metrics.
+// usedToday returns bytes forwarded in the current window, for /metrics.
 func (b *dayBudget) usedToday(now time.Time) uint64 {
 	b.mu.Lock()
 	defer b.mu.Unlock()

--- a/internal/relay/server.go
+++ b/internal/relay/server.go
@@ -43,7 +43,7 @@ type Server struct {
 
 	// healthy is true while the read loop is forwarding; it flips false if
 	// Run exits on a real socket error (not a graceful ctx cancel) so the
-	// signaling layer's /v1/health can report the zombie instead of lying.
+	// signaling layer's /health can report the zombie instead of lying.
 	healthy atomic.Bool
 	// draining rejects new allocations during graceful shutdown so the drain
 	// can converge while in-flight sessions finish.
@@ -53,14 +53,14 @@ type Server struct {
 	// circuit breaker). Zero limit = unlimited.
 	budget dayBudget
 
-	// Aggregate counters for /v1/metrics (cumulative since boot).
+	// Aggregate counters for /metrics (cumulative since boot).
 	bytesForwarded    atomic.Uint64
 	peakTransferBytes atomic.Uint64 // most any single transfer has forwarded
 	transfersCapped   atomic.Uint64 // transfers cut off for exceeding the per-session byte cap
 	transfersTotal    atomic.Uint64 // transfers that forwarded ≥1 byte; vs paired sessions = relay-fallback rate
 }
 
-// Metrics is an aggregate snapshot of relay activity for /v1/metrics.
+// Metrics is an aggregate snapshot of relay activity for /metrics.
 type Metrics struct {
 	Forwarding           bool   `json:"forwarding"`
 	Healthy              bool   `json:"healthy"`
@@ -180,7 +180,7 @@ func NewServer(conn net.PacketConn, cfg ServerConfig) *Server {
 }
 
 // Healthy reports whether the relay read loop is still forwarding. It flips
-// false only when Run exits on a real socket error, so /v1/health can surface
+// false only when Run exits on a real socket error, so /health can surface
 // a dead relay rather than reporting a healthy zombie.
 func (s *Server) Healthy() bool { return s.healthy.Load() }
 
@@ -289,7 +289,7 @@ func (s *Server) Run(ctx context.Context) error {
 				return nil
 			}
 			// Other read errors (e.g. socket closed): the relay is dead.
-			// Flag it so /v1/health stops reporting a healthy zombie.
+			// Flag it so /health stops reporting a healthy zombie.
 			s.healthy.Store(false)
 			return fmt.Errorf("relay: read: %w", err)
 		}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -7,7 +7,7 @@ import (
 	"github.com/polius/fsend/internal/relay"
 )
 
-// MetricsResponse is the body of GET /v1/metrics. Everything is an
+// MetricsResponse is the body of GET /metrics. Everything is an
 // aggregate count or gauge — no per-IP, per-session, or per-code data, so
 // it can't leak what the server doesn't store. Relay is omitted when no
 // relay is wired.

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -43,7 +43,7 @@ func TestMetrics_Shape(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	var raw map[string]any
-	getJSON(t, srv.URL+"/v1/metrics", &raw)
+	getJSON(t, srv.URL+"/metrics", &raw)
 
 	top := map[string]bool{
 		"version": true, "uptime_seconds": true, "sessions_active": true,
@@ -99,7 +99,7 @@ func TestMetrics_Counters(t *testing.T) {
 	}
 
 	var m MetricsResponse
-	getJSON(t, srv.URL+"/v1/metrics", &m)
+	getJSON(t, srv.URL+"/metrics", &m)
 	if m.SessionsCreatedTotal != 1 {
 		t.Errorf("sessions_created_total = %d, want 1", m.SessionsCreatedTotal)
 	}
@@ -111,7 +111,7 @@ func TestMetrics_Counters(t *testing.T) {
 	}
 }
 
-// With a server password set, /v1/metrics is gated like any other endpoint
+// With a server password set, /metrics is gated like any other endpoint
 // (an open server, tested above, serves it publicly for transparency).
 func TestMetrics_GatedByPassword(t *testing.T) {
 	cfg := metricsConfig()
@@ -121,7 +121,7 @@ func TestMetrics_GatedByPassword(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	// No password → 401, and that rejection is counted.
-	resp, err := http.Get(srv.URL + "/v1/metrics")
+	resp, err := http.Get(srv.URL + "/metrics")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +131,7 @@ func TestMetrics_GatedByPassword(t *testing.T) {
 	}
 
 	// With the password → 200, and the snapshot reports that one rejection.
-	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/v1/metrics", nil)
+	req, _ := http.NewRequest(http.MethodGet, srv.URL+"/metrics", nil)
 	req.Header.Set(AuthHeader, "secret")
 	resp2, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -156,7 +156,7 @@ func TestMetrics_OmitsRelayWhenAbsent(t *testing.T) {
 	t.Cleanup(srv.Close)
 
 	var raw map[string]any
-	getJSON(t, srv.URL+"/v1/metrics", &raw)
+	getJSON(t, srv.URL+"/metrics", &raw)
 	if _, ok := raw["relay"]; ok {
 		t.Error("relay block must be omitted when no relay is wired")
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -35,7 +36,7 @@ type Config struct {
 	Logger               *slog.Logger
 
 	// ServerPassword, when non-empty, gates every endpoint except
-	// /v1/health behind a constant-time match on the X-Fsend-Auth
+	// /health behind a constant-time match on the X-Fsend-Auth
 	// header. Empty leaves the server open (the default for the public
 	// fsend.alzina.dev pairing server and for the canonical Docker stack).
 	ServerPassword string
@@ -116,7 +117,7 @@ type Server struct {
 	met serverMetrics
 }
 
-// serverMetrics holds aggregate counters for /v1/metrics (cumulative
+// serverMetrics holds aggregate counters for /metrics (cumulative
 // since boot). sessions_active is read from the live map at scrape time.
 type serverMetrics struct {
 	sessionsCreated atomic.Uint64
@@ -213,8 +214,8 @@ func (b *rateBucket) allow(now time.Time, limit int, window time.Duration) bool 
 const AuthHeader = "X-Fsend-Auth"
 
 // Handler returns the HTTP handler the server should expose. When
-// Config.ServerPassword is set, every endpoint except /v1/health is
-// wrapped in a constant-time password check; /v1/health stays open so
+// Config.ServerPassword is set, every endpoint except /health is
+// wrapped in a constant-time password check; /health stays open so
 // Docker HEALTHCHECK and monitoring don't need to share the secret.
 func (s *Server) Handler() http.Handler {
 	m := http.NewServeMux()
@@ -226,8 +227,10 @@ func (s *Server) Handler() http.Handler {
 	m.HandleFunc("DELETE /v1/session/{id}", s.deleteSession)
 	m.HandleFunc("POST /v1/relay/allocate", s.allocateRelay)
 	m.HandleFunc("GET /v1/relay/status", s.relayStatus)
-	m.HandleFunc("GET /v1/health", s.health)
-	m.HandleFunc("GET /v1/metrics", s.metrics)
+	m.HandleFunc("GET /health", s.health)
+	m.HandleFunc("GET /metrics", s.metrics)
+	// {$} matches exactly "/" so unknown paths still 404.
+	m.HandleFunc("GET /{$}", s.root)
 	if s.cfg.ServerPassword == "" {
 		return m
 	}
@@ -235,12 +238,12 @@ func (s *Server) Handler() http.Handler {
 }
 
 // withServerAuth wraps inner with a header check that constant-time
-// compares X-Fsend-Auth against the configured password. /v1/health
+// compares X-Fsend-Auth against the configured password. /health
 // passes through unconditionally.
 func (s *Server) withServerAuth(inner http.Handler) http.Handler {
 	want := []byte(s.cfg.ServerPassword)
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/health" {
+		if r.URL.Path == "/health" || r.URL.Path == "/" {
 			inner.ServeHTTP(w, r)
 			return
 		}
@@ -436,6 +439,13 @@ func (s *Server) evict(now time.Time) {
 	}
 }
 
+// root is a human-friendly liveness banner for browsers hitting "/".
+// Machine clients use /health; this stays plain text and version-free.
+func (s *Server) root(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	_, _ = io.WriteString(w, "fsend server is up and running\n")
+}
+
 func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
 	status, code := "ok", http.StatusOK
 	// If a relay is wired and its read loop has died, report the degradation
@@ -444,11 +454,7 @@ func (s *Server) health(w http.ResponseWriter, _ *http.Request) {
 	if h, ok := s.relayAllocator.(interface{ Healthy() bool }); ok && !h.Healthy() {
 		status, code = "degraded", http.StatusServiceUnavailable
 	}
-	writeJSON(w, code, HealthResponse{
-		Status:        status,
-		Version:       s.cfg.ServerVersion,
-		UptimeSeconds: int64(time.Since(s.started).Seconds()),
-	})
+	writeJSON(w, code, HealthResponse{Status: status})
 }
 
 func (s *Server) createSession(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -304,7 +305,7 @@ func TestWaitRateLimit_PollCadenceStaysUnderBudget(t *testing.T) {
 
 func TestHealth(t *testing.T) {
 	srv := newTestServer(t)
-	resp, err := http.Get(srv.URL + "/v1/health")
+	resp, err := http.Get(srv.URL + "/health")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -312,10 +313,46 @@ func TestHealth(t *testing.T) {
 	if resp.StatusCode != 200 {
 		t.Errorf("health status = %d", resp.StatusCode)
 	}
-	var h HealthResponse
-	_ = json.NewDecoder(resp.Body).Decode(&h)
-	if h.Status != "ok" {
-		t.Errorf("status = %q", h.Status)
+	// Decode into a raw map: /health must expose status only — no version
+	// or uptime, so an unauthenticated caller can't fingerprint the build.
+	var raw map[string]any
+	if err := json.NewDecoder(resp.Body).Decode(&raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw["status"] != "ok" {
+		t.Errorf("status = %q", raw["status"])
+	}
+	for _, leaked := range []string{"version", "uptime_seconds"} {
+		if _, ok := raw[leaked]; ok {
+			t.Errorf("/health leaked %q: %v", leaked, raw)
+		}
+	}
+}
+
+func TestRoot(t *testing.T) {
+	srv := newTestServer(t)
+
+	resp, err := http.Get(srv.URL + "/")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != 200 {
+		t.Errorf("root status = %d", resp.StatusCode)
+	}
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "up and running") {
+		t.Errorf("root body = %q", body)
+	}
+
+	// {$} must not turn into a catch-all: unknown paths still 404.
+	resp404, err := http.Get(srv.URL + "/nope")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = resp404.Body.Close() }()
+	if resp404.StatusCode != 404 {
+		t.Errorf("unknown path status = %d, want 404", resp404.StatusCode)
 	}
 }
 
@@ -463,7 +500,7 @@ func TestDeleteSession(t *testing.T) {
 
 // TestServerPassword_Gate verifies that the password-gated handler
 // rejects unauthenticated requests with 401, accepts the configured
-// password, and always leaves /v1/health open so monitoring works
+// password, and always leaves /health open so monitoring works
 // without the secret.
 func TestServerPassword_Gate(t *testing.T) {
 	s := New(Config{
@@ -502,8 +539,8 @@ func TestServerPassword_Gate(t *testing.T) {
 		t.Errorf("correct password: status = %d, want 200", got)
 	}
 
-	// /v1/health is always open — monitoring must not need the secret.
-	resp, err := http.Get(srv.URL + "/v1/health")
+	// /health is always open — monitoring must not need the secret.
+	resp, err := http.Get(srv.URL + "/health")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -553,7 +590,7 @@ func (f *fakeRelay) Metrics() relay.Metrics {
 	return relay.Metrics{Forwarding: !f.noForward, Healthy: !f.dead}
 }
 
-// /v1/health must flip to 503/degraded once the relay read loop has died,
+// /health must flip to 503/degraded once the relay read loop has died,
 // so an orchestrator restarts the container instead of trusting a zombie.
 func TestHealth_DegradedWhenRelayDead(t *testing.T) {
 	s := New(Config{ServerVersion: "0.0.0-test"})
@@ -561,7 +598,7 @@ func TestHealth_DegradedWhenRelayDead(t *testing.T) {
 	srv := httptest.NewServer(s.Handler())
 	t.Cleanup(srv.Close)
 
-	resp, err := http.Get(srv.URL + "/v1/health")
+	resp, err := http.Get(srv.URL + "/health")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/server/types.go
+++ b/internal/server/types.go
@@ -109,11 +109,12 @@ type RelayAllocateResponse struct {
 	BudgetExhausted    bool   `json:"budget_exhausted,omitempty"`
 }
 
-// HealthResponse is the body of GET /v1/health.
+// HealthResponse is the body of GET /health. Deliberately minimal: a
+// pure liveness signal (plus the 200/503 status code) with no version or
+// uptime, so an unauthenticated caller learns nothing about the build.
+// Version and uptime live on the gated /metrics for operators who need them.
 type HealthResponse struct {
-	Status        string `json:"status"`
-	Version       string `json:"version"`
-	UptimeSeconds int64  `json:"uptime_seconds"`
+	Status string `json:"status"`
 }
 
 // RelayStatusResponse is the body of GET /v1/relay/status.


### PR DESCRIPTION
## Summary

Three related changes to the signaling server's HTTP surface:

- **Root banner.** `GET /` returned a bare `404`. It now serves a plain-text `fsend server is up and running` (version-free). The route is `{$}`-anchored so unknown paths still `404` — a bare `GET /` in Go's mux would swallow every unmatched path.
- **Unversion the ops endpoints.** `/v1/health` → `/health`, `/v1/metrics` → `/metrics`. Liveness/metrics are unversioned by convention (Prometheus, k8s probes) and aren't part of the client wire-protocol contract. The eight `/v1/session/*` and `/v1/relay/*` routes **keep `/v1`** — they're a shipped client/server protocol where a future breaking change needs side-by-side v1/v2 migration (clients ship as installed binaries and don't auto-update).
- **Slim `/health`.** Reduced to a pure liveness signal — `{"status":"ok"}` (or `"degraded"` + `503`), no `version`/`uptime_seconds` — so an unauthenticated caller can't fingerprint the build. Both fields remain on the gated `/metrics`. `/` and `/health` stay auth-exempt when `FSEND_SERVER_PASSWORD` is set, so monitoring never needs the secret.

Docs, the README status badge, and the `--health-check` probe follow the new paths.

## Verification

- `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- New `TestRoot` asserts `GET /` → 200 banner and `GET /nope` → 404 (guards the `{$}` catch-all regression); `TestHealth` now asserts `version`/`uptime_seconds` are **absent** from the body.
- Verified end-to-end against the running binary:
  - `GET /` → 200 banner, `POST /` → 405, `GET /nope` → 404
  - `GET /health` → `{"status":"ok"}`; `GET /metrics` → full JSON incl. version
  - `GET /v1/health` / `/v1/metrics` → 404 (old paths gone)
  - Full protocol round-trip works: create → join → candidate exchange (token-routed) → relay allocate/status → delete
  - With `FSEND_SERVER_PASSWORD` set: `/` + `/health` open (200); `/metrics`, `/v1/*`, unknown paths → 401; correct password → 200

## Note

No backward-compat shim for the old `/v1/health` / `/v1/metrics` paths — this is pre-release with no users yet, so the paths are moved outright. The public `fsend.alzina.dev` server must be redeployed alongside this, or the README status badge (which now points at `/health`) will read "down" until it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)