### PR TITLE
fix(transfer): reject peer symlink entries to close a receive path traversal

### DIFF
--- a/internal/transfer/classify.go
+++ b/internal/transfer/classify.go
@@ -82,6 +82,13 @@ type Conflict struct {
 func classify(entries []wire.ListingEntry, targetDir string, checksum bool) ([]entryPlan, error) {
 	plans := make([]entryPlan, 0, len(entries))
 	for _, e := range entries {
+		// Reject peer symlinks: the honest sender dereferences them and never
+		// emits one (walk.go), so a symlink on the wire is a malicious sender
+		// planting a link that a later write traverses to escape targetDir —
+		// which the lexical path checks here can't see through.
+		if e.Type == wire.EntrySymlink {
+			return nil, fmt.Errorf("%w: peer sent a symlink (%q); fsend does not accept symlink entries", fserrors.ErrPathTraversal, e.RelativePath)
+		}
 		rel, err := SanitizeRelativePath(e.RelativePath)
 		if err != nil {
 			return nil, fmt.Errorf("%w: %v", fserrors.ErrPathTraversal, err)

--- a/internal/transfer/engine_security_test.go
+++ b/internal/transfer/engine_security_test.go
@@ -74,6 +74,87 @@ func mkChunk(index uint32, payload []byte, eof bool) *wire.Chunk {
 	return &wire.Chunk{ChunkHash: blakeHash32(payload), Segments: []wire.Segment{seg}, Payload: payload}
 }
 
+// A malicious sender must not escape the receive dir via symlink indirection:
+// two symlinks that look in-bounds to a lexical check but, once materialized,
+// redirect a later file write one level ABOVE the receive dir.
+//
+//	p        -> .           (real path: <dst>)
+//	p/q      -> ../outside  (real path: <base>/outside, above <dst>)
+//	p/q/evil (regular file)  lexically <dst>/p/q/evil, really <base>/outside/evil
+//
+// Pre-fix, materialize created the links and openRecvFile followed them,
+// writing attacker content into <base>/outside. The honest sender never emits
+// symlinks, so the receiver now rejects any symlink entry outright.
+func TestHostile_SymlinkListingRejected(t *testing.T) {
+	base := t.TempDir()
+	dst := filepath.Join(base, "target")
+	outside := filepath.Join(base, "outside") // where a successful escape would land
+	for _, d := range []string{dst, outside} {
+		if err := os.Mkdir(d, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	ctrlA, ctrlB := net.Pipe()
+	dataA, dataB := net.Pipe()
+	sender := &Streams{Control: ctrlA, Data: dataA}
+	receiver := &Streams{Control: ctrlB, Data: dataB}
+
+	recvErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+		recvErr <- Recv(ctx, receiver, RecvOptions{TargetDir: dst})
+		receiver.Close()
+	}()
+	// Drain the receiver's replies so its ack write and teardown decline can
+	// complete over the synchronous pipe (writes are a separate direction).
+	go func() { _, _ = io.Copy(io.Discard, sender.Control) }()
+	go func() { _, _ = io.Copy(io.Discard, sender.Data) }()
+
+	if err := wire.WriteControl(sender.Control, wire.TypeHello, &wire.SenderHello{
+		ProtocolVersion: wire.ProtocolVersion, Mode: wire.ModeFiles, Hostname: "evil",
+	}); err != nil {
+		t.Fatalf("hello: %v", err)
+	}
+	entries := []wire.ListingEntry{
+		{Index: 0, RelativePath: "p", Type: wire.EntrySymlink, SymlinkTarget: "."},
+		{Index: 1, RelativePath: "p/q", Type: wire.EntrySymlink, SymlinkTarget: "../outside"},
+		{Index: 2, RelativePath: "p/q/evil", Size: 4, Type: wire.EntryFile},
+	}
+	if err := wire.WriteControl(sender.Control, wire.TypeListingBatch, entries); err != nil {
+		t.Fatalf("listing: %v", err)
+	}
+	if err := wire.WriteControl(sender.Control, wire.TypeListingEnd, nil); err != nil {
+		t.Fatalf("listing-end: %v", err)
+	}
+	// Best-effort payload for the escaping file: a fixed receiver rejects at
+	// classify before the data phase (the drain discards this); a vulnerable one
+	// would materialize the links and write it into <base>/outside.
+	go func() { _ = wire.WriteChunk(sender.Data, mkChunk(2, []byte("PWND"), true)) }()
+
+	select {
+	case err := <-recvErr:
+		if err == nil {
+			t.Fatal("receiver accepted a peer-supplied symlink listing")
+		}
+		if !errors.Is(err, fserrors.ErrPathTraversal) {
+			t.Fatalf("want ErrPathTraversal, got %v", err)
+		}
+	case <-time.After(15 * time.Second):
+		t.Fatal("receiver did not reject the symlink listing")
+	}
+
+	// No file escaped, and no symlink was planted inside the receive dir.
+	if _, err := os.Lstat(filepath.Join(outside, "evil")); !os.IsNotExist(err) {
+		t.Fatalf("file escaped the receive dir into %s", filepath.Join(outside, "evil"))
+	}
+	if _, err := os.Lstat(filepath.Join(dst, "p")); !os.IsNotExist(err) {
+		t.Fatal("receiver planted a peer-supplied symlink")
+	}
+	sender.Close()
+}
+
 // A chunk for a file the receiver chose to keep (a differing file, no
 // --overwrite) must be rejected — never written over the protected local copy.
 func TestHostile_ChunkForKeptFile(t *testing.T) {

--- a/internal/transfer/fuzz_test.go
+++ b/internal/transfer/fuzz_test.go
@@ -2,7 +2,6 @@ package transfer
 
 import (
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -75,34 +74,5 @@ func TestPathIsUnder(t *testing.T) {
 		if got := pathIsUnder(tc.child, root); got != tc.want {
 			t.Errorf("pathIsUnder(%q, %q) = %v, want %v", tc.child, root, got, tc.want)
 		}
-	}
-}
-
-// TestSymlinkEscapes pins the guard that stops a malicious sender from planting
-// a symlink that resolves outside the target dir — a classic transfer RCE
-// vector with no negative coverage before this.
-func TestSymlinkEscapes(t *testing.T) {
-	absTarget := "/etc/passwd"
-	if runtime.GOOS == "windows" {
-		absTarget = `C:\Windows\System32\drivers\etc\hosts`
-	}
-	cases := []struct {
-		name, relPath, linkTarget string
-		want                      bool
-	}{
-		{"absolute target", "link", absTarget, true},
-		{"climbs above root", "link", "../../../etc", true},
-		{"deep climb", "a/b/link", "../../../../etc", true},
-		{"in-bounds sibling", "a/b/link", "../c", false},
-		{"in-bounds same dir", "a/link", "c", false},
-		{"in-bounds nested", "link", "sub/file", false},
-	}
-	for _, tc := range cases {
-		t.Run(tc.name, func(t *testing.T) {
-			if got := symlinkEscapes("/target", tc.relPath, tc.linkTarget); got != tc.want {
-				t.Fatalf("symlinkEscapes(/target, %q, %q) = %v, want %v",
-					tc.relPath, tc.linkTarget, got, tc.want)
-			}
-		})
 	}
 }

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"runtime"
 	"syscall"
 	"time"
 
@@ -170,7 +169,7 @@ func recvFiles(ctx context.Context, s *Streams, hello *wire.SenderHello, opts Re
 			expected++
 			continue
 		}
-		if err := materialize(s, p, opts.TargetDir, approveOverwrite); err != nil {
+		if err := materialize(s, p, approveOverwrite); err != nil {
 			return err
 		}
 	}
@@ -570,7 +569,7 @@ func (rf *recvFile) finalize(s *Streams, root [32]byte, opts RecvOptions) error 
 }
 
 // materialize creates a structural entry (dir / symlink / empty file).
-func materialize(s *Streams, p *entryPlan, targetDir string, approveOverwrite bool) error {
+func materialize(s *Streams, p *entryPlan, approveOverwrite bool) error {
 	target := p.target
 	if p.needsConsent() && approveOverwrite {
 		_ = os.RemoveAll(target) // clear the slot (approved)
@@ -583,19 +582,11 @@ func materialize(s *Streams, p *entryPlan, targetDir string, approveOverwrite bo
 		}
 		return nil
 	case wire.EntrySymlink:
-		if symlinkEscapes(targetDir, p.entry.RelativePath, p.entry.SymlinkTarget) {
-			declineTransfer(s, wire.ErrCodeProtocolError, "symlink escapes target dir")
-			return fserrors.ErrPathTraversal
-		}
-		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
-			declineTransfer(s, wire.ErrCodeWriteFailed, "mkdir parent")
-			return fmt.Errorf("%w: mkdir parent: %v", fserrors.ErrWriteFailed, err)
-		}
-		_ = os.Remove(target)
-		if err := os.Symlink(p.entry.SymlinkTarget, target); err != nil && runtime.GOOS != "windows" {
-			return fmt.Errorf("%w: symlink: %v", fserrors.ErrWriteFailed, err)
-		}
-		return nil
+		// Defense in depth: classify already rejects peer symlinks. Never
+		// create one from peer input — a planted link lets a later write
+		// traverse out of the receive dir. Fail closed.
+		declineTransfer(s, wire.ErrCodeProtocolError, "symlink entries are not accepted")
+		return fmt.Errorf("%w: symlink entry %q", fserrors.ErrPathTraversal, p.entry.RelativePath)
 	default: // empty regular file
 		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
 			declineTransfer(s, wire.ErrCodeWriteFailed, "mkdir parent")

--- a/internal/transfer/util.go
+++ b/internal/transfer/util.go
@@ -56,28 +56,3 @@ func pathIsUnder(child, parent string) bool {
 	}
 	return !filepath.IsAbs(rel)
 }
-
-// symlinkEscapes reports whether placing a symlink at <targetDir>/<relPath>
-// pointing at <linkTarget> would resolve outside targetDir. Used by Recv
-// to reject hostile peer-supplied symlinks before any subsequent file
-// write can traverse through them.
-//
-// Two rejection paths:
-//   - linkTarget is absolute → always rejected (no useful absolute symlink
-//     could land safely inside a receiver's TargetDir).
-//   - linkTarget is relative → resolved from the symlink's parent dir,
-//     then checked against targetDir lexically. A relative symlink that
-//     stays inside the tree (e.g. "../sister" within a nested dir) is
-//     accepted.
-func symlinkEscapes(targetDir, relPath, linkTarget string) bool {
-	if filepath.IsAbs(linkTarget) {
-		return true
-	}
-	absTarget, err := filepath.Abs(targetDir)
-	if err != nil {
-		return true // can't verify → safest to reject
-	}
-	symlinkDir := filepath.Join(absTarget, filepath.Dir(relPath))
-	resolved := filepath.Clean(filepath.Join(symlinkDir, linkTarget))
-	return !pathIsUnder(resolved, absTarget)
-}


### PR DESCRIPTION
## Summary

Closes a **remotely triggered arbitrary file write** on the receive path.

A malicious (or hand-rolled) sender could include symlink entries that pass the receiver's *lexical* path checks but, once materialized on disk, redirect a later file write **outside the target directory**. The classic escape:

```
p        -> .            (real path: <dst>)
p/q      -> ../outside   (real path: <base>/outside, above <dst>)
p/q/evil (regular file)  lexically <dst>/p/q/evil, really <base>/outside/evil
```

The guards in `classify` and `materialize` were purely lexical (`filepath.Clean`/`Abs`) and could not see through an intermediate symlink, while `MkdirAll`/`OpenFile` happily *followed* the planted links. Receiving into `~/Downloads` could let a sender overwrite `~/.ssh/authorized_keys`, `~/.bashrc`, etc. — silently under `--yes`.

## Fix

The honest sender **always dereferences symlinks** and never emits an `EntrySymlink` (see `walk.go` / `TestWalk_FollowsSymlinkToFile`), so no legitimate transfer creates symlinks on the receiver. Therefore:

- **`classify`** now rejects any peer `EntrySymlink` outright → the transfer declines with `ErrPathTraversal` before anything touches disk (primary guard).
- **`materialize`** drops the `os.Symlink` primitive entirely and fails closed (defense in depth).
- Removed the now-dead lexical `symlinkEscapes` helper + its unit test, the unused `targetDir` param, and the `runtime` import.

This is invisible to real transfers (you never received symlinks anyway); it's purely a protection layer against a hostile sender.

## Testing

- Added `TestHostile_SymlinkListingRejected`, which drives a real `Recv` with the exact escape above and asserts the transfer is rejected with `ErrPathTraversal` and nothing is written outside the receive dir.
- Verified it's a genuine regression test: it **fails** against the pre-fix code (receiver proceeds instead of rejecting) and **passes** with the fix.
- Full `go test ./...` passes; `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)