### PR TITLE
fix(landisc): bound the sender's mDNS teardown so a wedged Close can't hang the send

### DIFF
--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -97,7 +97,9 @@ func pairOverLAN(ctx context.Context, code string) (*lanSenderPairing, error) {
 		return nil, fmt.Errorf("%w: mDNS announce: %v", fserrors.ErrLANListenerFailed, err)
 	}
 	var stopMDNSOnce sync.Once
-	stopMDNS := func() { stopMDNSOnce.Do(func() { _ = mdnsConn.Close() }) }
+	// Bounded: a synchronous Close could wedge, hanging pairOverLAN and the
+	// coordinator draining lanCh. See landisc.StopAnnounce.
+	stopMDNS := func() { stopMDNSOnce.Do(func() { landisc.StopAnnounce(mdnsConn) }) }
 
 	// Keep accepting until the real receiver completes the handshake or the
 	// pairing window closes. A malicious LAN host can reach the deterministic

--- a/internal/landisc/landisc.go
+++ b/internal/landisc/landisc.go
@@ -21,6 +21,7 @@ import (
 	"encoding/binary"
 	"encoding/hex"
 	"fmt"
+	"io"
 	"net"
 	"net/netip"
 	"sync"
@@ -93,6 +94,22 @@ func Announce(code string, ip net.IP) (*mdns.Conn, error) {
 		return nil, fmt.Errorf("landisc: mdns server: %w", err)
 	}
 	return conn, nil
+}
+
+// StopAnnounce closes an announcement conn, but never blocks past
+// watchdogGrace: pion/mdns's Close has been observed to wedge forever. Past
+// the grace we abandon it, leaking the goroutine until process exit — the
+// same tradeoff Query makes.
+func StopAnnounce(conn io.Closer) {
+	if conn == nil {
+		return
+	}
+	done := make(chan struct{})
+	go func() { _ = conn.Close(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(watchdogGrace):
+	}
 }
 
 // QueryResult bundles the discovered peer's address + port.

--- a/internal/landisc/landisc_test.go
+++ b/internal/landisc/landisc_test.go
@@ -52,6 +52,40 @@ func TestPortForCode_Deterministic(t *testing.T) {
 	}
 }
 
+// TestStopAnnounce_BoundedOnWedgedClose pins the watchdog: a Close that
+// never returns (a wedged pion/mdns) must not hang the caller past the grace.
+func TestStopAnnounce_BoundedOnWedgedClose(t *testing.T) {
+	unblock := make(chan struct{})
+	t.Cleanup(func() { close(unblock) }) // release the abandoned goroutine
+	start := time.Now()
+	StopAnnounce(blockingCloser{unblock})
+	elapsed := time.Since(start)
+	if elapsed < watchdogGrace {
+		t.Errorf("returned in %v, before the %v grace — watchdog skipped?", elapsed, watchdogGrace)
+	}
+	if limit := watchdogGrace + 2*time.Second; elapsed > limit {
+		t.Errorf("took %v, want < %v", elapsed, limit)
+	}
+}
+
+// TestStopAnnounce_FastPath: a Close that returns promptly must not wait out
+// the grace (the common case — the watchdog is only for a wedge).
+func TestStopAnnounce_FastPath(t *testing.T) {
+	start := time.Now()
+	StopAnnounce(nopCloser{})
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Errorf("blocked %v on a fast Close, want < 1s", elapsed)
+	}
+}
+
+type blockingCloser struct{ ch chan struct{} }
+
+func (b blockingCloser) Close() error { <-b.ch; return nil }
+
+type nopCloser struct{}
+
+func (nopCloser) Close() error { return nil }
+
 // TestPortForCode_InRange guards the 50000–50999 window the package
 // promises: the lower bound stays clear of the OS ephemeral range on
 // most systems, and the upper bound stops the hash from wrapping into


### PR DESCRIPTION
## Summary

Closes a **sender-side hang**: a wedged `pion/mdns` `Close()` could hang the entire `fsend` send, surviving Ctrl-C.

`pion/mdns`'s `Close()` waits on read loops that only exit on `net.ErrClosed` (`conn.go`: `readLoop` `continue`s on any other error; `Close` blocks on `<-c.closed`), and has been **observed to block forever** — the reason the receiver's `Query` already has a watchdog (`landisc.go`).

The sender didn't have that protection: `pairOverLAN`'s `stopMDNS` closed the announcement **synchronously**. If `Close` wedged:
- `pairOverLAN` never returned, so the LAN goroutine never sent its outcome on `lanCh`;
- the coordinator's blocking drain (`drainLoser`/`drainBoth`, `res := <-lanCh`) hung forever;
- the whole send stalled, **surviving Ctrl-C** (context cancellation can't unwedge a stuck `Close`).

This fires on both the loser path (internet won, LAN teardown wedges) and the winning LAN path (success still calls `stopMDNS` before returning).

## Fix

Add `landisc.StopAnnounce`, which runs `Close()` on a goroutine and abandons it past `watchdogGrace` — leaking the goroutine until process exit, the same tradeoff `Query` already makes. The sender's `stopMDNS` uses it.

Deliberately minimal:
- **No socket exposure to force-close** (as `Query` does): pion closes its sockets *before* it blocks on `<-c.closed`, so there's nothing left to force-close — bounding the wait is the only mechanism that helps.
- **`Query` untouched**: its `Close` already runs in the background after delivering the result, so it can't hang the caller.
- **No `lanCh` drain timeout**: fixing the actual blocking call is right-sized; a drain timeout would change semantics (drop a late pairing).

No effect on the common path, where `Close` returns immediately.

## Testing

- `TestStopAnnounce_BoundedOnWedgedClose` — a `Close` that never returns must not hang past the grace (lands at ~2s = `watchdogGrace`).
- `TestStopAnnounce_FastPath` — a prompt `Close` must not wait out the grace.
- Full `go test ./...` passes (incl. e2e); `go vet` and `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)