### PR TITLE
refactor(cli)!: rename --pass to --password (and FSEND_PASS to FSEND_PASSWORD)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ fsend is a **command-line tool** that lets any two computers transfer files and 
 - **Send anything** — files, folders, multiple at once, stdin streams, or literal text
 - **Resumable** — a dropped transfer continues where it left off on the next send (with a fresh code), instead of starting over
 - **Skips what's already there** — re-send a folder and only the new or changed files transfer
-- **Password-protected** — gate any transfer with `--pass`; receiver supplies it to unlock
+- **Password-protected** — gate any transfer with `--password`; receiver supplies it to unlock
 - **Post-quantum** — X25519 + ML-KEM-768 (NIST); designed so future quantum computers can't decrypt today's transfers
 - **Self-hostable** — deploy your own pairing server + relay with Docker compose
 - **Runs anywhere** — single static binary on Linux, macOS, FreeBSD, Windows; x86 and ARM
@@ -97,7 +97,7 @@ fsend ./project                    # a whole folder
 fsend a.txt b.txt c.txt            # several at once
 pg_dump mydb | fsend               # a stream from stdin
 fsend --text "wifi: hunter2"       # a literal string
-fsend report.pdf --pass            # gated behind a password
+fsend report.pdf --password            # gated behind a password
 ```
 
 …and to receive:

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -441,18 +441,18 @@ func TestDebugRequested(t *testing.T) {
 // root.go applyEnvFallbacks
 // ---------------------------------------------------------------------------
 
-func TestApplyEnvFallbacks_FSEND_PASS(t *testing.T) {
-	saved, had := os.LookupEnv("FSEND_PASS")
+func TestApplyEnvFallbacks_FSEND_PASSWORD(t *testing.T) {
+	saved, had := os.LookupEnv("FSEND_PASSWORD")
 	t.Cleanup(func() {
 		if had {
-			_ = os.Setenv("FSEND_PASS", saved)
+			_ = os.Setenv("FSEND_PASSWORD", saved)
 		} else {
-			_ = os.Unsetenv("FSEND_PASS")
+			_ = os.Unsetenv("FSEND_PASSWORD")
 		}
 	})
 
 	c := rootCmd()
-	_ = os.Setenv("FSEND_PASS", "from-env")
+	_ = os.Setenv("FSEND_PASSWORD", "from-env")
 	f := &flags{}
 	applyEnvFallbacks(f, c)
 	if f.passArg != "from-env" {
@@ -460,9 +460,9 @@ func TestApplyEnvFallbacks_FSEND_PASS(t *testing.T) {
 	}
 
 	// When the flag is already "changed", env is ignored — sender's
-	// explicit --pass must win.
+	// explicit --password must win.
 	c2 := rootCmd()
-	if err := c2.Flags().Set("pass", "from-flag"); err != nil {
+	if err := c2.Flags().Set("password", "from-flag"); err != nil {
 		t.Fatal(err)
 	}
 	f2 := &flags{passArg: "from-flag"}

--- a/cmd/fsend/password.go
+++ b/cmd/fsend/password.go
@@ -80,8 +80,8 @@ func readPasswordHiddenCtx(ctx context.Context, prompt string) (string, error) {
 	}
 }
 
-// resolvePassword expands the bare --pass sentinel into a concrete
-// password. No-op when --pass wasn't given bare.
+// resolvePassword expands the bare --password sentinel into a concrete
+// password. No-op when --password wasn't given bare.
 //
 // Sender side: shows a freshly-generated 16-char suggestion the user can
 // accept with <enter> (or override by typing one). The suggestion is
@@ -100,13 +100,13 @@ func resolvePassword(ctx context.Context, f *flags, sender bool) error {
 	if f.passArg != passPromptSentinel {
 		return nil
 	}
-	// Bare --pass needs a TTY: the sender prompt echoes a suggestion the
+	// Bare --password needs a TTY: the sender prompt echoes a suggestion the
 	// user accepts with Enter; the receiver prompt reads no-echo. Either
 	// way, doing it on a piped stdin reads the file's first line as the
-	// password and breaks the transfer. FSEND_PASS is the documented
+	// password and breaks the transfer. FSEND_PASSWORD is the documented
 	// non-interactive path.
 	if !stdinIsTTY() {
-		return fmt.Errorf("%w: bare --pass needs a terminal; use --pass=<value> or FSEND_PASS", fserrors.ErrUsage)
+		return fmt.Errorf("%w: bare --password needs a terminal; use --password=<value> or FSEND_PASSWORD", fserrors.ErrUsage)
 	}
 	if sender {
 		pw, err := promptPasswordWithSuggestionCtx(ctx)

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -57,7 +57,7 @@ func runReceive(f *flags, c string) error {
 	ctx, cancel := signalContext()
 	defer cancel()
 
-	// Bare --pass: hidden no-echo prompt. We're not the password's
+	// Bare --password: hidden no-echo prompt. We're not the password's
 	// author — we have to type what the sender configured — so there's
 	// no point offering a random default here.
 	if err := resolvePassword(ctx, f, false); err != nil {
@@ -158,13 +158,13 @@ func runReceive(f *flags, c string) error {
 }
 
 // receiverPasswordPrompt returns a callback that reads a password from
-// stdin when the sender requires --pass but the receiver didn't supply
-// one via --pass / FSEND_PASS. Returns nil under --quiet so the transfer
+// stdin when the sender requires --password but the receiver didn't supply
+// one via --password / FSEND_PASSWORD. Returns nil under --quiet so the transfer
 // engine immediately fails with ErrWrongPassword instead of blocking on
 // a prompt that nobody will see.
 //
 // Input is read with no echo when stdin is a TTY (golang.org/x/term).
-// Non-interactive callers should pass --pass or FSEND_PASS so the
+// Non-interactive callers should pass --password or FSEND_PASSWORD so the
 // prompt never fires.
 //
 // Timing: the progress bar is constructed lazily on first byte (see

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -105,12 +105,12 @@ Examples:
 
 	// Transfer behavior
 	c.Flags().StringVar(&f.textArg, "text", "", "send a literal string instead of a file")
-	c.Flags().StringVar(&f.passArg, "pass", "",
-		"password gate. Bare --pass prompts (sender: suggests a random default); inline: --pass=SECRET. Env: FSEND_PASS")
-	// Bare --pass (no value) collapses to this sentinel; the dispatch
+	c.Flags().StringVar(&f.passArg, "password", "",
+		"password gate. Bare --password prompts (sender: suggests a random default); inline: --password=SECRET. Env: FSEND_PASSWORD")
+	// Bare --password (no value) collapses to this sentinel; the dispatch
 	// layer treats it as "ask interactively, with input hidden." We
 	// blank DefValue so cobra's --help doesn't print the sentinel.
-	passFlag := c.Flags().Lookup("pass")
+	passFlag := c.Flags().Lookup("password")
 	passFlag.NoOptDefVal = passPromptSentinel
 	passFlag.DefValue = ""
 	c.Flags().BoolVar(&f.yes, "yes", false, "auto-accept incoming transfers")
@@ -129,7 +129,7 @@ Examples:
 	c.Flags().BoolVar(&f.forceReceive, "receive", false, "force receive mode (skip auto-detect)")
 
 	// Server selection. Bare --connect (no value) means "show current
-	// server" — same NoOptDefVal trick as --pass. The dispatcher
+	// server" — same NoOptDefVal trick as --password. The dispatcher
 	// recognises the sentinel and treats it as "no args".
 	c.Flags().StringSliceVar(&f.connectArgsRaw, "connect", nil, "set the server: <host[:port]>[,<password>] | 'default'")
 	connectFlag := c.Flags().Lookup("connect")
@@ -245,15 +245,15 @@ EXAMPLES
   Send a whole folder:
     fsend ./myproject
   Send with extra password protection:
-    fsend report.pdf --pass="shared-secret"
+    fsend report.pdf --password="shared-secret"
   Use a different server:
     fsend --connect relay.mycompany.com:443
 
 SENDING
-  --pass[=<password>]    Require the receiver to enter a password.
-                         Bare --pass prompts interactively — sender side
+  --password[=<password>]    Require the receiver to enter a password.
+                         Bare --password prompts interactively — sender side
                          suggests a fresh random default (press Enter to
-                         accept). Inline: --pass=SECRET. Env: FSEND_PASS.
+                         accept). Inline: --password=SECRET. Env: FSEND_PASSWORD.
   --exclude <glob,…>     Skip entries matching these globs in a directory
   --text "<string>"      Send a literal string instead of a file
                          (the receiver prints it — nothing is saved;
@@ -267,8 +267,8 @@ RECEIVING
   --out <dir>            Receive into this directory (default: current)
   --out -                Receive to stdout (single file, text, or piped
                          stream — pipe-friendly: fsend <code> --out - | …)
-  --pass[=<value>]       Supply the sender's password up front as --pass=VALUE,
-                         skipping the prompt (bare --pass prompts). Env: FSEND_PASS
+  --password[=<value>]       Supply the sender's password up front as --password=VALUE,
+                         skipping the prompt (bare --password prompts). Env: FSEND_PASSWORD
   --overwrite            Replace existing files that differ (identical files
                          are always skipped)
   --checksum             Decide identical files by content hash, not
@@ -331,10 +331,10 @@ func isHelpHeader(line string) bool {
 }
 
 // passPromptSentinel is the value cobra hands us when the user passes
-// bare --pass with no argument. The dispatch layer translates this into
+// bare --password with no argument. The dispatch layer translates this into
 // an interactive no-echo prompt before any send/receive work begins.
 //
-// Note: a user who explicitly passes --pass=":prompt:" gets the same
+// Note: a user who explicitly passes --password=":prompt:" gets the same
 // hidden prompt — surprising-but-fine, since they typed the literal
 // sentinel themselves.
 const passPromptSentinel = ":prompt:"
@@ -354,7 +354,7 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	// surprised by "I asked for both --connect and --send and only the
 	// first ran."
 	if cmd.Flags().Changed("connect") {
-		for _, conflict := range []string{"send", "receive", "text", "pass", "yes", "out", "overwrite", "name", "exclude", "mode", "update", "uninstall"} {
+		for _, conflict := range []string{"send", "receive", "text", "password", "yes", "out", "overwrite", "name", "exclude", "mode", "update", "uninstall"} {
 			if cmd.Flags().Changed(conflict) {
 				return fmt.Errorf("%w: --connect cannot be combined with --%s", fserrors.ErrUsage, conflict)
 			}
@@ -403,38 +403,38 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 		}
 	}
 
-	// `--pass=` (explicitly empty): the user asked for a password gate but
+	// `--password=` (explicitly empty): the user asked for a password gate but
 	// supplied none — proceeding would run the transfer unprotected.
-	if cmd.Flags().Changed("pass") && f.passArg == "" {
-		return fmt.Errorf("%w: --pass requires a non-empty password (bare --pass prompts interactively)",
+	if cmd.Flags().Changed("password") && f.passArg == "" {
+		return fmt.Errorf("%w: --password requires a non-empty password (bare --password prompts interactively)",
 			fserrors.ErrUsage)
 	}
 
-	// An inline password now rides the flag as `--pass=secret`, so a bare
-	// --pass followed by a non-file, non-code word is very likely a misplaced
-	// inline password (`fsend --pass secret file`). Point at the = form rather
+	// An inline password now rides the flag as `--password=secret`, so a bare
+	// --password followed by a non-file, non-code word is very likely a misplaced
+	// inline password (`fsend --password secret file`). Point at the = form rather
 	// than failing later with a bare "no such file".
-	if cmd.Flags().Changed("pass") && f.passArg == passPromptSentinel &&
+	if cmd.Flags().Changed("password") && f.passArg == passPromptSentinel &&
 		!cmd.Flags().Changed("text") && !f.forceReceive {
 		for _, a := range f.posArgs {
 			if a == "-" || code.IsCode(a) || code.LooksLikeCode(a) {
 				continue
 			}
 			if _, err := os.Stat(a); os.IsNotExist(err) {
-				return fmt.Errorf("%w: %q is not a file; if it's the password, use --pass=%s (bare --pass prompts)",
+				return fmt.Errorf("%w: %q is not a file; if it's the password, use --password=%s (bare --password prompts)",
 					fserrors.ErrUsage, a, a)
 			}
 		}
 	}
 
-	// Env-var fallback for the password (FSEND_PASS). Passing a secret via
+	// Env-var fallback for the password (FSEND_PASSWORD). Passing a secret via
 	// flag leaks it through /proc/<pid>/cmdline and `ps -ef`; the env var
 	// lets users keep it out of argv. We only consult it when the flag
 	// wasn't explicitly given, so scripts that set both keep the flag's
 	// value (matching every other CLI's override convention).
 	applyEnvFallbacks(f, cmd)
 
-	// Bare --pass (no value) is resolved inside runSend / runReceive so
+	// Bare --password (no value) is resolved inside runSend / runReceive so
 	// each role can show the right prompt: the sender gets a random
 	// 16-char suggestion, the receiver gets a hidden no-echo prompt.
 
@@ -543,15 +543,15 @@ func wrappedCode(arg string) (string, bool) {
 // user did not pass the corresponding flag. Used for secrets we'd
 // rather not see on argv.
 //
-// Bare --pass (collapsed to passPromptSentinel) counts as "the user said
+// Bare --password (collapsed to passPromptSentinel) counts as "the user said
 // they want a password, but didn't supply one" — so we still consult
-// FSEND_PASS. Doing it the other way around (env wins only when the
-// flag is absent entirely) silently ignored FSEND_PASS for users who
-// typed `--pass` to opt in.
+// FSEND_PASSWORD. Doing it the other way around (env wins only when the
+// flag is absent entirely) silently ignored FSEND_PASSWORD for users who
+// typed `--password` to opt in.
 func applyEnvFallbacks(f *flags, cmd *cobra.Command) {
 	bare := f.passArg == passPromptSentinel
-	if !cmd.Flags().Changed("pass") || bare {
-		if v := os.Getenv("FSEND_PASS"); v != "" {
+	if !cmd.Flags().Changed("password") || bare {
+		if v := os.Getenv("FSEND_PASSWORD"); v != "" {
 			f.passArg = v
 		}
 	}

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -75,18 +75,18 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 			"--connect default takes no password",
 		},
 		{
-			// Regression: `--pass=` skipped every password path, so the
+			// Regression: `--password=` skipped every password path, so the
 			// user believed the transfer was gated when it wasn't.
 			"pass_empty_value",
-			[]string{"--pass="},
-			"--pass requires a non-empty password",
+			[]string{"--password="},
+			"--password requires a non-empty password",
 		},
 		{
-			// A bare --pass followed by a non-file, non-code word is very
+			// A bare --password followed by a non-file, non-code word is very
 			// likely a misplaced inline password — point at the = form.
 			"pass_bare_then_nonfile",
-			[]string{"--pass", "secret", "report.pdf"},
-			"if it's the password, use --pass=secret",
+			[]string{"--password", "secret", "report.pdf"},
+			"if it's the password, use --password=secret",
 		},
 		{
 			// Same trap on --connect: the code would be persisted as the

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -60,7 +60,7 @@ no accounts, end-to-end encrypted, self-hostable. The differences are in
 | Post-quantum forward secrecy      | **✓ X25519 + ML-KEM-768**                  | ✗                                     | ✗                                           |
 | Default code entropy              | **~45 bits**                               | **~45 bits**                          | 16 bits (adjustable)                        |
 | Online-guess protection           | **Rate-limited 30/min + bounded TTL**      | None server-side                      | None (acknowledged in docs)                 |
-| Password on top of the code       | **✓ `--pass`**                             | ✗ (code is the secret)                | ✗ (code is the secret)                      |
+| Password on top of the code       | **✓ `--password`**                             | ✗ (code is the secret)                | ✗ (code is the secret)                      |
 | Choose your own code phrase       | ✗                                          | **✓ `--code`**                        | **✓ `--code`**                              |
 | Resume after interruption         | **✓ (BLAKE3 chunk-verified)**              | **✓ (chunk-based)**                   | ✗ (classic transit restarts)               |
 | Skip unchanged files on re-send   | **✓ (size+mtime; `--checksum` to hash)**   | **✓ (always hashes)**                 | ✗                                           |
@@ -245,7 +245,7 @@ own code phrase, while fsend always picks it for you.
 | Skip unchanged files on re-send | **✓ (size+mtime; `--checksum`)** | **✓ (always hashes)** | ✗ |
 | Preview what you'd send | **✓ `--preview`** — list every file + size as CSV, locally, without sending | ✗ | ✗ |
 | Record of what was received | **✓ `--manifest`** — CSV of each file with its outcome (new / identical / overwritten / kept / resumed) | ✗ | ✗ |
-| Password on top of the code | **✓ `--pass`** | code phrase doubles as secret | ✗ (the code is the secret) |
+| Password on top of the code | **✓ `--password`** | code phrase doubles as secret | ✗ (the code is the secret) |
 | Exclude paths in a directory | **✓ `--exclude`** | **✓ `--exclude` (+ `--git`)** | ✗ |
 | Custom output dir / name | `--out` | `--out` | `--output-file` |
 | Compression | zstd (automatic; skips chunks it can't shrink) | DEFLATE (`--no-compress` to disable) | DEFLATE (folders only) |
@@ -313,7 +313,7 @@ it; or Python is already your path of least resistance.
   lengthen anything;
 - you want **defense-in-depth** (SPAKE2 *over* TLS 1.3) and
   **post-quantum** forward secrecy — neither of the others has either;
-- you want **resume**, a separate **`--pass`** secret, a **`--preview`**
+- you want **resume**, a separate **`--password`** secret, a **`--preview`**
   of what you'd send, **multi-file** transfers, or **binary stdin/stdout**
   streaming;
 - you'd rather deploy **one static binary** than a Python environment.

--- a/docs/security.md
+++ b/docs/security.md
@@ -118,7 +118,7 @@ What makes a short code safe to use as the whole secret:
   authenticates the peer; it never feeds the encryption key and never
   crosses the wire in the clear.
 - **Chosen for you.** fsend generates the code; it isn't user-selectable.
-  To add a second secret on top, send with `--pass`.
+  To add a second secret on top, send with `--password`.
 
 ## Release integrity
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -73,11 +73,11 @@ stopped.
 
 | Code | Situation | Fix |
 |---|---|---|
-| `E021` | Wrong **transfer** password | Re-enter the sender's `--pass` value, or set `FSEND_PASS`. |
-| `E031` | The transfer needs a password you didn't supply | The sender used `--pass`; receive with `--pass` (or `FSEND_PASS`). |
+| `E021` | Wrong **transfer** password | Re-enter the sender's `--password` value, or set `FSEND_PASSWORD`. |
+| `E031` | The transfer needs a password you didn't supply | The sender used `--password`; receive with `--password` (or `FSEND_PASSWORD`). |
 | `E028` | The **server** needs a password | Connect with `fsend --connect host:443,<password>`. See [Self-hosting](self-hosting.md#require-a-password-optional). |
 
-Note the two are different: `--pass` protects a *transfer*; the server
+Note the two are different: `--password` protects a *transfer*; the server
 password gates a *self-hosted server*.
 
 ## Files

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -66,7 +66,7 @@ without a positional argument.
 | Flag | Purpose |
 |---|---|
 | `--text <string>` | Send a literal string instead of a file. The receiver prints it to stdout; nothing is saved to disk. To keep it: `fsend <code> > note.txt`. |
-| `--pass[=<password>]` | Require the receiver to supply this password. Bare `--pass` prompts interactively with a random default; supply it inline as `--pass=<password>`. Also `FSEND_PASS`. |
+| `--password[=<password>]` | Require the receiver to supply this password. Bare `--password` prompts interactively with a random default; supply it inline as `--password=<password>`. Also `FSEND_PASSWORD`. |
 | `--exclude <glob,…>` | Skip entries when bundling a directory. |
 | `--name <hostname>` | Override the hostname shown to the peer. |
 | `--preview` | List what would be sent as CSV (`path,size`) and exit — no code, no transfer. Redirect with `> files.csv` to inspect. |
@@ -76,7 +76,7 @@ fsend report.pdf
 fsend ./project --exclude 'node_modules,*.log,.git'
 tar c ./build | fsend
 fsend --text "the wifi password is hunter2"
-fsend ./secret.tar.gz --pass         # prompts with a random default
+fsend ./secret.tar.gz --password         # prompts with a random default
 ```
 
 ### Symlinks
@@ -114,13 +114,13 @@ sending, then confirms. Pass `--yes` to skip.
 | `--overwrite` | Replace existing files whose contents **differ**. Without it they're kept and the receiver exits `E013`. (Identical files are skipped either way.) |
 | `--manifest <file>` | After receiving, write a CSV record (`path,size,status`) to `<file>` — what fsend did with each file (`new` / `identical` / `overwritten` / `kept` / `resumed`). |
 | `--checksum` | Decide what's already present by hashing **contents** (BLAKE3) instead of comparing size + mtime — like rsync's `-c`. See [below](#when-a-file-already-exists). |
-| `--pass[=<password>]` | Supply the sender's password non-interactively as `--pass=<password>`. Also `FSEND_PASS`. |
+| `--password[=<password>]` | Supply the sender's password non-interactively as `--password=<password>`. Also `FSEND_PASSWORD`. |
 
 ```sh
 fsend abc-defg-jkm
 fsend --yes --out ~/Downloads abc-defg-jkm
 fsend --yes --out - abc-defg-jkm > dump.sql   # pipe-to-pipe with the sender's `… | fsend`
-FSEND_PASS=swordfish fsend --yes abc-defg-jkm
+FSEND_PASSWORD=swordfish fsend --yes abc-defg-jkm
 ```
 
 ### When a file already exists
@@ -170,10 +170,10 @@ fsend file1.txt --quiet > code.txt    # prints the code, then waits
 ```
 
 On receive, pair `--quiet` with `--yes` (nothing else can answer the
-prompt) and pass any password via `FSEND_PASS`:
+prompt) and pass any password via `FSEND_PASSWORD`:
 
 ```sh
-FSEND_PASS=swordfish fsend "$(cat code.txt)" --quiet --yes --out ~/incoming
+FSEND_PASSWORD=swordfish fsend "$(cat code.txt)" --quiet --yes --out ~/incoming
 ```
 
 ## Chaining through a middle machine
@@ -228,7 +228,7 @@ Config is at `~/.config/fsend/config.json` (Linux),
 
 | Variable | Equivalent flag | Purpose |
 |---|---|---|
-| `FSEND_PASS` | `--pass` | Supply the transfer password out-of-band. |
+| `FSEND_PASSWORD` | `--password` | Supply the transfer password out-of-band. |
 | `FSEND_DEBUG` | `--debug` | Set to `1` (any value except `0`/`false`) for verbose stderr logging. |
 | `FSEND_NO_UPDATE_CHECK` | — | Set to `1` (any value except `0`/`false`) to disable the once-a-day check for a newer release. |
 
@@ -304,7 +304,7 @@ failure. For what to *do* about a given error, see
 | `28`  | `E028` — pairing server requires a password (missing or wrong). |
 | `29`  | `E029` — server closed the connection because no data was flowing. |
 | `30`  | `E030` — `fsend server` could not start (port in use or no permission to bind). |
-| `31`  | `E031` — transfer requires a password the receiver didn't have (`--pass` / `FSEND_PASS`). |
+| `31`  | `E031` — transfer requires a password the receiver didn't have (`--password` / `FSEND_PASSWORD`). |
 | `32`  | `E032` — the other side cancelled the transfer. |
 | `33`  | `E033` — `fsend --update` could not complete. |
 | `34`  | `E034` — the other device is running an incompatible fsend version. |
@@ -321,6 +321,6 @@ Codes look like `abc-defg-jkm` — three groups (3-4-3) from a 23-letter
 alphabet (`i`, `l`, `o` are excluded for legibility). One-shot,
 system-generated, server-side TTL.
 
-To require a password before the receiver can download, add `--pass`
+To require a password before the receiver can download, add `--password`
 when sending. For the full model — entropy, TTL, rate-limiting, channel
 binding — see [Security → Share codes](security.md#share-codes).

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -63,7 +63,7 @@ var (
 	// E020 — transfer was interrupted but is recoverable; surfaced when
 	// retries are exhausted.
 	ErrTransientFailure = errors.New("transient transfer failure")
-	// E021 — receiver did not match the sender's --pass challenge.
+	// E021 — receiver did not match the sender's --password challenge.
 	ErrWrongPassword = errors.New("wrong password")
 	// E022 — peers did not agree on the short code (or someone in the
 	// middle tried to MITM): SPAKE2-derived key + TLS exporter mismatch.
@@ -104,7 +104,7 @@ var (
 	// not route through the E099 "file an issue" catchall.
 	ErrServerStartup = errors.New("server failed to start")
 	// E031 — the sender requires a password and the receiver had none to
-	// offer (--quiet with no --pass / FSEND_PASS), so the challenge was
+	// offer (--quiet with no --password / FSEND_PASSWORD), so the challenge was
 	// never answered. Distinct from E021: no password was entered at all.
 	ErrPasswordRequired = errors.New("password required")
 	// E032 — the peer deliberately cancelled (Ctrl-C) mid-transfer.
@@ -393,10 +393,10 @@ var catalog = map[error]Entry{
 	ErrPasswordRequired: {
 		Code: "E031", Exit: 31,
 		Message:       "This transfer requires a password.",
-		Action:        "Rerun with --pass=<password> (or set FSEND_PASS).",
+		Action:        "Rerun with --password=<password> (or set FSEND_PASSWORD).",
 		SenderMessage: "The receiver couldn't supply the password.",
 		SenderAction: "Run fsend again to issue a fresh code, and ask them to rerun with\n" +
-			"  --pass=<password> (or FSEND_PASS).",
+			"  --password=<password> (or FSEND_PASSWORD).",
 	},
 	ErrPeerCancelled: {
 		Code: "E032", Exit: 32,

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -823,7 +823,7 @@ func mapPeerError(ef wire.ErrorFrame) error {
 	}
 }
 
-// receiverPasswordHandshake answers the sender's --pass challenge.
+// receiverPasswordHandshake answers the sender's --password challenge.
 func receiverPasswordHandshake(s *Streams, opts RecvOptions) error {
 	var ch wire.PasswordChallenge
 	ft, err := wire.ReadControl(s.Control, &ch)

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -394,7 +394,7 @@ func peerError(body []byte) error {
 	return mapPeerError(ef)
 }
 
-// senderPasswordHandshake runs the challenge/response that gates --pass.
+// senderPasswordHandshake runs the challenge/response that gates --password.
 func senderPasswordHandshake(s *Streams, password string) error {
 	var nonce [32]byte
 	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -114,7 +114,7 @@ const (
 	// receiver's disk.
 	ErrCodeWriteFailed ErrorCode = 13
 	// ErrCodePasswordRequired — sender demanded a password but the
-	// receiver had none to offer (--quiet with no --pass / FSEND_PASS).
+	// receiver had none to offer (--quiet with no --password / FSEND_PASSWORD).
 	// Distinct from ErrCodeWrongPassword: no attempt was ever made.
 	ErrCodePasswordRequired ErrorCode = 14
 	// ErrCodeCancelled — the peer cancelled deliberately (Ctrl-C).

--- a/test/e2e/transfer_test.go
+++ b/test/e2e/transfer_test.go
@@ -519,7 +519,7 @@ func TestDispatch_ForceReceive(t *testing.T) {
 }
 
 // TestPassword_NoBarCollisionOnPrompt drives the receiver's full
-// interactive flow when the sender used --pass and pins two related
+// interactive flow when the sender used --password and pins two related
 // UX properties:
 //
 //  1. Prompt ordering: the password prompt comes first, then the
@@ -542,7 +542,7 @@ func TestPassword_NoBarCollisionOnPrompt(t *testing.T) {
 	// Receiver stdin order matches the new prompt order: the password line
 	// first, then "Y" for the save confirmation.
 	r := h.runPair(t,
-		[]string{"--pass=swordfish", srcFile},
+		[]string{"--password=swordfish", srcFile},
 		dst,
 		nil, // no extra receiver flags — exercise the full interactive path
 		"swordfish\nY\n",


### PR DESCRIPTION
**BREAKING CHANGE.** Renames the password flag `--pass` → `--password` and the env var `FSEND_PASS` → `FSEND_PASSWORD`. The old names are removed (no alias).

## Why

`pass` reads as a verb ("to pass") and is ambiguous; `--password` is the unambiguous, conventional name (mysql, docker, wget). The tool is pre-widespread, so a clean break is preferable to a permanent two-name alias. Follows up the `--pass` ambiguity fix in #106.

## Scope

- Behavior is unchanged: bare `--password` prompts, inline is `--password=SECRET`, `FSEND_PASSWORD` is the non-interactive path.
- User-facing names only — internal Go identifiers (`passArg`, `passPromptSentinel`) are untouched.
- Updates help text, all docs (README + usage/comparison/security/troubleshooting), error messages, and tests (incl. the e2e password test).
- No `-p` short alias (the tool has zero short flags by design, `-p` collides with `--preview`, and an optional-value short flag would reintroduce the space-vs-glue ambiguity).

## Testing

- `go build`, `go vet`, `gofmt`, full `go test ./...` (incl. e2e) all clean.
- Exercised on the binary: `--password=secret` works inline, old `--pass` is rejected (`unknown flag: --pass`), and the misplaced-value hint points at `--password=`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)