### PR TITLE
feat(cli): create the --out directory if missing (mkdir -p)

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -831,3 +831,44 @@ func TestPromptAccept_PathChipShown(t *testing.T) {
 		}
 	}
 }
+
+// resolveOutDir creates a missing --out directory (mkdir -p), accepts an
+// existing one, and rejects a path that exists but isn't a directory.
+func TestResolveOutDir(t *testing.T) {
+	base := t.TempDir()
+
+	t.Run("creates_missing_nested", func(t *testing.T) {
+		want := filepath.Join(base, "a", "b", "c")
+		dir, sink, err := resolveOutDir(&flags{outDir: want})
+		if err != nil || sink {
+			t.Fatalf("got (%q, sink=%v, %v), want created dir", dir, sink, err)
+		}
+		if st, statErr := os.Stat(want); statErr != nil || !st.IsDir() {
+			t.Fatalf("--out dir was not created: %v", statErr)
+		}
+	})
+
+	t.Run("accepts_existing", func(t *testing.T) {
+		if _, _, err := resolveOutDir(&flags{outDir: base}); err != nil {
+			t.Fatalf("existing dir rejected: %v", err)
+		}
+	})
+
+	t.Run("rejects_file", func(t *testing.T) {
+		file := filepath.Join(base, "file.txt")
+		if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		_, _, err := resolveOutDir(&flags{outDir: file})
+		if !errors.Is(err, fserrors.ErrUsage) || !strings.Contains(err.Error(), "not a directory") {
+			t.Fatalf("got %v, want ErrUsage 'not a directory'", err)
+		}
+	})
+
+	t.Run("stdout_sink", func(t *testing.T) {
+		_, sink, err := resolveOutDir(&flags{outDir: "-"})
+		if err != nil || !sink {
+			t.Fatalf("got (sink=%v, %v), want sink=true", sink, err)
+		}
+	})
+}

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -70,10 +70,16 @@ func resolveOutDir(f *flags) (dir string, sink bool, err error) {
 	if f.outDir != "" {
 		st, statErr := os.Stat(dir)
 		switch {
-		case statErr != nil:
-			return "", false, fmt.Errorf("%w: --out directory does not exist: %s", fserrors.ErrUsage, dir)
-		case !st.IsDir():
+		case statErr == nil && !st.IsDir():
 			return "", false, fmt.Errorf("%w: --out is not a directory: %s", fserrors.ErrUsage, dir)
+		case os.IsNotExist(statErr):
+			// Create it (and parents), like `mkdir -p` — failing after the
+			// one-shot code is consumed just to say "make this first" is poor UX.
+			if mkErr := os.MkdirAll(dir, 0o755); mkErr != nil {
+				return "", false, fmt.Errorf("%w: could not create --out directory %s: %v", fserrors.ErrUsage, dir, mkErr)
+			}
+		case statErr != nil:
+			return "", false, fmt.Errorf("%w: cannot access --out directory %s: %v", fserrors.ErrUsage, dir, statErr)
 		}
 	}
 	return dir, false, nil

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -264,7 +264,8 @@ SENDING
 
 RECEIVING
   --yes                  Auto-accept incoming transfers (no prompt)
-  --out <dir>            Receive into this directory (default: current)
+  --out <dir>            Receive into this directory, created if missing
+                         (default: current)
   --out -                Receive to stdout (single file, text, or piped
                          stream — pipe-friendly: fsend <code> --out - | …)
   --password[=<value>]       Supply the sender's password up front as --password=VALUE,

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -109,7 +109,7 @@ sending, then confirms. Pass `--yes` to skip.
 | Flag | Purpose |
 |---|---|
 | `--yes` | Auto-accept. |
-| `--out <dir>` | Receive into this directory (must already exist). Default: cwd. |
+| `--out <dir>` | Receive into this directory (created if missing, like `mkdir -p`). Default: cwd. |
 | `--out -` | Stream the payload to stdout instead of saving a file (single file, text, or piped stream — not directories). Retries are disabled: emitted bytes can't be rewound. |
 | `--overwrite` | Replace existing files whose contents **differ**. Without it they're kept and the receiver exits `E013`. (Identical files are skipped either way.) |
 | `--manifest <file>` | After receiving, write a CSV record (`path,size,status`) to `<file>` — what fsend did with each file (`new` / `identical` / `overwritten` / `kept` / `resumed`). |


### PR DESCRIPTION
## What

`--out <dir>` now creates the target directory (and parents) if it doesn't exist, like `mkdir -p` — instead of hard-erroring.

## Why

The old behavior failed *after* the sender's one-shot code was already consumed, so recovering meant "create the dir and start over with a fresh code." Every download tool (`scp`, `curl -O`, browsers) creates the destination. Silent-create matches that and the receive summary already prints where files landed.

## Details

- Uses `os.MkdirAll(dir, 0o755)` — cross-platform, works on Windows (drive letters/backslashes handled; mode ignored there).
- A path that **exists but isn't a directory** still errors clearly.
- Other stat errors (e.g. permission) surface a clear message.

## Testing

- New `TestResolveOutDir`: creates missing nested dir, accepts existing, rejects a file, handles `--out -` (stdout).
- Help text and `docs/usage.md` updated ("created if missing").
- `go build`/`vet`/`gofmt`/`go test ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)