### PR TITLE
fix(transfer): refuse to overwrite an existing file on stream receive

### DIFF
--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -183,16 +183,22 @@ func receiverPasswordPrompt(ctx context.Context, f *flags) func() (string, error
 // renderArtifact prints the indented artifact line and the classification
 // breakdown. The breakdown is how the user learns, before consenting, that
 // most files are already up to date and only a few will move.
-func renderArtifact(w io.Writer, h wire.SenderHello, summary transfer.ClassifySummary) {
+func renderArtifact(w io.Writer, h wire.SenderHello, summary transfer.ClassifySummary, sink bool) {
 	pwChip := ""
 	if h.HasPassword {
 		pwChip = "  " + uxlog.PasswordChip()
 	}
 	if h.Mode == wire.ModeStream {
-		if h.IsText {
+		switch {
+		case h.IsText:
 			_, _ = fmt.Fprintf(w, "      text%s\n", pwChip)
-		} else {
+		case sink:
 			_, _ = fmt.Fprintf(w, "      stdin stream  ·  size unknown%s\n", pwChip)
+		default:
+			// The name is peer-supplied; show exactly what will land on disk
+			// (same derivation as the engine) so consent covers the filename.
+			name := sanitizeForDisplay(transfer.StreamFileName(h.DisplayName), 128)
+			_, _ = fmt.Fprintf(w, "      stdin stream  ·  saves as %s  ·  size unknown%s\n", name, pwChip)
 		}
 		return
 	}

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -146,7 +146,7 @@ func (ui *receiverUI) promptAccept(h wire.SenderHello, summary transfer.Classify
 	fmt.Fprintln(os.Stderr)
 	fmt.Fprintf(os.Stderr, "  Incoming from %s%s\n", peer, pathChip)
 	fmt.Fprintln(os.Stderr)
-	renderArtifact(os.Stderr, h, summary)
+	renderArtifact(os.Stderr, h, summary, ui.sink)
 	fmt.Fprintln(os.Stderr)
 
 	if f.yes {

--- a/internal/transfer/engine_security_test.go
+++ b/internal/transfer/engine_security_test.go
@@ -1,6 +1,7 @@
 package transfer
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
@@ -330,5 +331,59 @@ func TestSenderNegotiate_RejectsExcessDecisions(t *testing.T) {
 		}
 	case <-time.After(5 * time.Second):
 		t.Fatal("senderNegotiate did not reject excess decisions")
+	}
+}
+
+func TestEngine_StreamRefusesExistingTarget(t *testing.T) {
+	dst := t.TempDir()
+	precious := []byte("precious local content")
+	writeFile(t, filepath.Join(dst, ".bashrc"), precious)
+
+	// A crafted DisplayName pointing at an existing file must be declined,
+	// not silently truncated and renamed over.
+	se, re := runTransfer(t,
+		SendOptions{Mode: wire.ModeStream, Stream: bytes.NewReader([]byte("evil")), DisplayName: ".bashrc"},
+		RecvOptions{TargetDir: dst},
+	)
+	if !errors.Is(re, fserrors.ErrTargetExists) {
+		t.Fatalf("recv: want ErrTargetExists, got %v", re)
+	}
+	if !errors.Is(se, fserrors.ErrTargetExists) {
+		t.Fatalf("send: want ErrTargetExists, got %v", se)
+	}
+	if got := mustRead(t, filepath.Join(dst, ".bashrc")); !bytes.Equal(got, precious) {
+		t.Fatalf("existing file was modified: %q", got)
+	}
+}
+
+func TestEngine_StreamOverwriteReplacesExisting(t *testing.T) {
+	dst := t.TempDir()
+	writeFile(t, filepath.Join(dst, "out.txt"), []byte("old"))
+
+	se, re := runTransfer(t,
+		SendOptions{Mode: wire.ModeStream, Stream: bytes.NewReader([]byte("new")), DisplayName: "out.txt"},
+		RecvOptions{TargetDir: dst, Overwrite: true},
+	)
+	if se != nil || re != nil {
+		t.Fatalf("send=%v recv=%v", se, re)
+	}
+	if got := mustRead(t, filepath.Join(dst, "out.txt")); string(got) != "new" {
+		t.Fatalf("want overwritten content, got %q", got)
+	}
+}
+
+func TestStreamFileName(t *testing.T) {
+	cases := map[string]string{
+		"msg.txt":       "msg.txt",
+		"dir/inner.txt": "inner.txt",
+		"":              "fsend-received",
+		".":             "fsend-received",
+		"../../.bashrc": "fsend-received",
+		"/etc/passwd":   "fsend-received",
+	}
+	for in, want := range cases {
+		if got := StreamFileName(in); got != want {
+			t.Errorf("StreamFileName(%q) = %q, want %q", in, got, want)
+		}
 	}
 }

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -638,6 +638,22 @@ func planToDecision(p *entryPlan, approveOverwrite bool, opts RecvOptions) wire.
 	return d
 }
 
+// StreamFileName is the filename a ModeStream payload lands under: the
+// sanitized base of the peer-supplied display name, or a fixed fallback.
+// Exported so the CLI accept prompt can show the exact name recvStream
+// will write.
+func StreamFileName(displayName string) string {
+	name, err := SanitizeRelativePath(displayName)
+	if err != nil {
+		return "fsend-received"
+	}
+	base := filepath.Base(name)
+	if base == "." || base == string(filepath.Separator) {
+		return "fsend-received"
+	}
+	return base
+}
+
 // recvStream receives one ModeStream payload (stdin/--text) to a sink or a
 // single file under TargetDir.
 func recvStream(ctx context.Context, s *Streams, hello *wire.SenderHello, opts RecvOptions) error {
@@ -657,11 +673,18 @@ func recvStream(ctx context.Context, s *Streams, hello *wire.SenderHello, opts R
 	var target string
 	var f *os.File
 	if w == nil {
-		name, err := SanitizeRelativePath(hello.DisplayName)
-		if err != nil || name == "" {
-			name = "fsend-received"
+		base := StreamFileName(hello.DisplayName)
+		target = filepath.Join(opts.TargetDir, base)
+		// An honest sender names streams with a random suffix, so an existing
+		// target means a crafted DisplayName (or a freak collision) — refuse
+		// to clobber it unless the user opted in with --overwrite.
+		if !opts.Overwrite {
+			if _, lerr := os.Lstat(target); lerr == nil {
+				declineTransfer(s, wire.ErrCodeTargetExists, base)
+				return fmt.Errorf("%w: %s (use --overwrite to replace it)", fserrors.ErrTargetExists, base)
+			}
 		}
-		target = filepath.Join(opts.TargetDir, filepath.Base(name))
+		var err error
 		f, err = os.OpenFile(target+partialSuffix, os.O_CREATE|os.O_TRUNC|os.O_WRONLY, 0o600)
 		if err != nil {
 			declineTransfer(s, wire.ErrCodeWriteFailed, "create: "+err.Error())

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -345,11 +345,14 @@ func sendStream(ctx context.Context, s *Streams, opts SendOptions) error {
 	}
 	var r [32]byte
 	copy(r[:], root.Sum(nil))
+	// endFile/flush are where a short stream's write actually hits the wire,
+	// so a receiver decline (e.g. target exists) surfaces here — check for
+	// its posted reason like appendBytes does.
 	if err := packer.endFile(0, r); err != nil {
-		return err
+		return sendChunkErr(s, err)
 	}
 	if err := packer.flush(); err != nil {
-		return err
+		return sendChunkErr(s, err)
 	}
 	if opts.OnStreamingEOF != nil {
 		opts.OnStreamingEOF(0, sent)


### PR DESCRIPTION
## Problem

A \`ModeStream\` sender controls \`DisplayName\`, and \`recvStream\` renamed the payload over whatever file that name pointed at — silently, and the accept prompt showed only "stdin stream · size unknown", never the filename. A malicious sender could set \`DisplayName: ".bashrc"\` and replace it on any receiver that accepted (including under \`--yes\`). Same class as the symlink traversal closed in #104.

Telling detail: \`wire.ErrCodeTargetExists\` (E013) existed and was mapped in \`mapPeerError\`, but nothing ever emitted it — the guard was designed and never wired.

## Fix

- \`recvStream\` declines with \`ErrCodeTargetExists\` when the target already exists, unless the receiver passed \`--overwrite\`. Honest senders name streams with a random suffix (\`fsend-stdin-<rand>\`), so a collision is adversarial or a freak accident; behavior for normal transfers is unchanged.
- The accept prompt now shows the exact filename the stream will land as ("stdin stream · saves as <name> · size unknown"), derived by the same \`transfer.StreamFileName\` the engine uses, sanitized for display. Sink mode (\`--out -\`) keeps the old line.
- \`sendStream\` wraps \`endFile\`/\`flush\` in the existing \`sendChunkErr\`, so the sender reports the receiver's E013 instead of a misleading "network" error — for short streams the decline surfaces exactly at those writes.

Text receives (\`--text\`) route through the same path and are covered too.

## Tests

- \`TestEngine_StreamRefusesExistingTarget\` — crafted name over an existing file: both sides get \`ErrTargetExists\`, local content untouched.
- \`TestEngine_StreamOverwriteReplacesExisting\` — \`--overwrite\` still replaces.
- \`TestStreamFileName\` — name derivation table (traversal/absolute names fall back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)