### PR TITLE
fix(cli): reject positionals and transfer flags with --update/--uninstall

### DIFF
--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -345,6 +345,25 @@ const passPromptSentinel = ":prompt:"
 // user.
 const connectShowSentinel = ":show:"
 
+// maintenanceGuard rejects transfer flags and positionals alongside a
+// maintenance flag (--update / --uninstall): anything else on the command
+// line would silently not run. allowYes exempts --yes, which --uninstall
+// documents as skipping its confirmation prompt.
+func maintenanceGuard(cmd *cobra.Command, f *flags, name string, allowYes bool) error {
+	for _, conflict := range []string{"send", "receive", "text", "password", "yes", "out", "overwrite", "name", "exclude", "mode", "checksum", "manifest", "preview"} {
+		if conflict == "yes" && allowYes {
+			continue
+		}
+		if cmd.Flags().Changed(conflict) {
+			return fmt.Errorf("%w: %s cannot be combined with --%s", fserrors.ErrUsage, name, conflict)
+		}
+	}
+	if len(f.posArgs) > 0 {
+		return fmt.Errorf("%w: %s cannot be combined with positional arguments (got %q)", fserrors.ErrUsage, name, f.posArgs[0])
+	}
+	return nil
+}
+
 // dispatch implements the CLI dispatch rules documented on the main.go
 // package comment.
 func dispatch(cmd *cobra.Command, f *flags) error {
@@ -377,14 +396,23 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	}
 
 	// --update / --uninstall are maintenance commands; never combine
-	// with transfer or with each other.
+	// with transfer flags, positionals, or each other. Same rationale as
+	// --connect above: `fsend report.pdf --update` would otherwise run
+	// the updater and silently drop the file the user asked to send.
 	if f.update && f.uninstall {
 		return fmt.Errorf("%w: --update and --uninstall are mutually exclusive", fserrors.ErrUsage)
 	}
 	if f.update {
+		if err := maintenanceGuard(cmd, f, "--update", false); err != nil {
+			return err
+		}
 		return runUpdate()
 	}
 	if f.uninstall {
+		// --yes stays allowed: it skips the uninstall confirmation.
+		if err := maintenanceGuard(cmd, f, "--uninstall", true); err != nil {
+			return err
+		}
 		return runUninstall(f)
 	}
 

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -113,6 +113,30 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 			"--update and --uninstall are mutually exclusive",
 		},
 		{
+			// Regression: `fsend report.pdf --update` ran the updater and
+			// silently dropped the file the user asked to send.
+			"update_with_positional",
+			[]string{"report.pdf", "--update"},
+			"--update cannot be combined with positional arguments",
+		},
+		{
+			"update_with_yes",
+			[]string{"--update", "--yes"},
+			"--update cannot be combined with --yes",
+		},
+		{
+			// Worst case of the same hole: `--uninstall --yes` in a mangled
+			// script deleted the binary when a transfer was intended.
+			"uninstall_with_positional",
+			[]string{"somefile", "--uninstall"},
+			"--uninstall cannot be combined with positional arguments",
+		},
+		{
+			"uninstall_with_out",
+			[]string{"--uninstall", "--out=/tmp"},
+			"--uninstall cannot be combined with --out",
+		},
+		{
 			// --preview is send-side; rejected when the arg is a code.
 			"preview_on_receive",
 			[]string{"--preview", "abc-defg-jkm"},
@@ -149,6 +173,18 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 				t.Errorf("got %q, want substring %q", err.Error(), c.wantSub)
 			}
 		})
+	}
+}
+
+// --uninstall --yes is documented (skip the confirmation), so the guard
+// must exempt it — unlike --update, where --yes answers nothing.
+func TestMaintenanceGuard_AllowsYesForUninstall(t *testing.T) {
+	cmd := rootCmd()
+	if err := cmd.ParseFlags([]string{"--uninstall", "--yes"}); err != nil {
+		t.Fatal(err)
+	}
+	if err := maintenanceGuard(cmd, &flags{}, "--uninstall", true); err != nil {
+		t.Fatalf("--uninstall --yes must be allowed, got %v", err)
 	}
 }
 


### PR DESCRIPTION
## Problem

\`dispatch\` handled \`--update\`/\`--uninstall\` before any positional or flag validation:

- \`fsend report.pdf --update\` ran the updater and silently dropped \`report.pdf\` (exit 0).
- \`fsend somefile --uninstall\` went straight to the uninstall prompt; worst case, \`--uninstall --yes\` in a mangled script deletes the binary and config dir when a transfer was intended.

Inconsistent with \`--connect\`, which carefully rejects both conflicting flags and positionals for exactly this "user asked for two things and only one ran" reason.

## Fix

New \`maintenanceGuard\` mirroring the \`--connect\` guard: with \`--update\` or \`--uninstall\`, any transfer flag or positional errors with E024. \`--uninstall --yes\` stays allowed (documented: skips the confirmation); \`--update --yes\` is rejected since it answers nothing.

## Tests

Four new cases in the conflict-matrix table (\`TestRootCmd_RejectsInvalidFlagCombinations\`) plus \`TestMaintenanceGuard_AllowsYesForUninstall\` for the exemption. Also exercised on the built binary: all three combinations report E024/exit 24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)