### PR TITLE
fix(transfer): tell the receiver when the sender's source is unreadable

### DIFF
--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -223,6 +223,7 @@ var terminalSentinels = []error{
 	fserrors.ErrPasswordRequired,   // receiver has no password to offer; retrying won't conjure one
 	fserrors.ErrCodeAlreadyClaimed, // sender already paired; no retry will recover
 	fserrors.ErrWriteFailed,        // peer's (or our) disk problem; retrying won't fix it
+	fserrors.ErrReadFailed,         // peer's (or our) source unreadable; retrying won't fix it
 	fserrors.ErrDiskFull,
 	fserrors.ErrPeerCancelled,       // peer hit Ctrl-C; it isn't coming back
 	fserrors.ErrIncompatibleVersion, // version mismatch; only an update fixes it

--- a/internal/transfer/ctxstream.go
+++ b/internal/transfer/ctxstream.go
@@ -18,7 +18,7 @@ import (
 // directions) and the control read side, unblocking the parked call with a
 // deadline error; the returned ctxConn then reports it as ctx.Err() so the
 // loops surface a clean cancellation. The control *write* side is left alone
-// so the sender's best-effort cancel notification (notifyCancel) still
+// so the sender's best-effort terminal notification (notifyPeer) still
 // reaches the peer.
 //
 // Streams that don't expose deadlines (the io.Pipe pair used in tests) are

--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/rand"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -13,6 +14,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/polius/fsend/internal/fserrors"
+	"github.com/polius/fsend/internal/retry"
 	"github.com/polius/fsend/internal/wire"
 )
 
@@ -459,5 +462,36 @@ func TestManifestStatus(t *testing.T) {
 		if got := manifestStatus(tc.disp, tc.act); got != tc.want {
 			t.Errorf("manifestStatus(%v, %v) = %q, want %q", tc.disp, tc.act, got, tc.want)
 		}
+	}
+}
+
+// A sender whose source vanishes between walk and send must tell the
+// receiver why. Without the ERROR frame the receiver saw only a bare
+// stream close, classified it transient, and burned retries on a
+// misleading "network" error.
+func TestEngine_SenderReadFailureReachesReceiver(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+	p := filepath.Join(src, "gone.bin")
+	writeFile(t, p, randBytes(1024))
+	sources, err := Walk([]string{p}, nil)
+	if err != nil {
+		t.Fatalf("Walk: %v", err)
+	}
+	if err := os.Remove(p); err != nil {
+		t.Fatal(err)
+	}
+
+	se, re := runTransfer(t,
+		SendOptions{Mode: wire.ModeFiles, Sources: sources},
+		RecvOptions{TargetDir: dst},
+	)
+	if !errors.Is(se, fserrors.ErrReadFailed) {
+		t.Fatalf("send: want ErrReadFailed, got %v", se)
+	}
+	if !errors.Is(re, fserrors.ErrReadFailed) {
+		t.Fatalf("recv: want the sender's ErrReadFailed, got %v", re)
+	}
+	if retry.IsTransient(re) {
+		t.Fatalf("receiver error must be terminal (no retry), got transient: %v", re)
 	}
 }

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -839,6 +839,8 @@ func mapPeerError(ef wire.ErrorFrame) error {
 		return fserrors.ErrReceiverDeclined
 	case wire.ErrCodeWriteFailed:
 		return fmt.Errorf("%w: receiver: %s", fserrors.ErrWriteFailed, ef.Message)
+	case wire.ErrCodeReadFailed:
+		return fmt.Errorf("%w: sender: %s", fserrors.ErrReadFailed, ef.Message)
 	case wire.ErrCodeCancelled:
 		return fserrors.ErrPeerCancelled
 	default:

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -45,15 +45,21 @@ type SendOptions struct {
 // Send executes the full sender-side protocol over the supplied streams.
 func Send(ctx context.Context, s *Streams, opts SendOptions) error {
 	err := send(ctx, s, opts)
-	if errors.Is(err, context.Canceled) {
-		notifyCancel(s)
+	switch {
+	case errors.Is(err, context.Canceled):
+		notifyPeer(s, wire.ErrCodeCancelled, "sender cancelled")
+	case errors.Is(err, fserrors.ErrReadFailed):
+		// A local source failure (unreadable, vanished, shrunk) otherwise
+		// surfaces on the receiver as a bare stream close — a "network"
+		// error it would burn retries on. Post the real reason instead.
+		notifyPeer(s, wire.ErrCodeReadFailed, err.Error())
 	}
 	return err
 }
 
 func send(ctx context.Context, s *Streams, opts SendOptions) error {
 	// Bind the streams to ctx so a Ctrl-C parked in a blocked QUIC write
-	// unblocks promptly instead of waiting out the idle timeout. notifyCancel
+	// unblocks promptly instead of waiting out the idle timeout. notifyPeer
 	// (called by the outer Send with the raw, unwrapped streams) is unaffected.
 	s, stop := bindCtx(ctx, s)
 	defer stop()
@@ -375,14 +381,16 @@ func sendStream(ctx context.Context, s *Streams, opts SendOptions) error {
 	return nil
 }
 
-// notifyCancel posts a cancel ERROR so the peer can tell a deliberate Ctrl-C
-// from a network drop. Bounded so a wedged peer can't hold the cancel hostage.
-func notifyCancel(s *Streams) {
+// notifyPeer posts a terminal ERROR so the peer can tell the real cause
+// (cancel, unreadable source, …) from a network drop. Data closes first so
+// a receiver blocked mid-chunk unblocks and reads the reason. Bounded so a
+// wedged peer can't hold the sender hostage.
+func notifyPeer(s *Streams, code wire.ErrorCode, msg string) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
 		_ = s.Data.Close()
-		declineTransfer(s, wire.ErrCodeCancelled, "sender cancelled")
+		declineTransfer(s, code, msg)
 	}()
 	select {
 	case <-done:

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -127,6 +127,10 @@ const (
 	// ErrCodeDeclined — the receiver declined at the accept prompt (after the
 	// listing, so it can't ride on HELLO_ACK like the stream-mode decline).
 	ErrCodeDeclined ErrorCode = 17
+	// ErrCodeReadFailed — sender hit a local filesystem error reading the
+	// source (open, read, hash). Terminal for the receiver: retrying won't
+	// fix the sender's disk. Mirror of ErrCodeWriteFailed.
+	ErrCodeReadFailed ErrorCode = 18
 )
 
 // Chunk-frame flag bits (frame-level).


### PR DESCRIPTION
## Problem

When the sender hit a local failure mid-transfer (source file deleted, unreadable, or shrunk between walk and send), it returned without posting any ERROR frame. The receiver saw a bare stream close, classified it transient, burned 3 re-dials on "Connection interrupted — retrying", and ended with a misleading E020 "network" error — masking the real cause entirely.

## Fix

- New \`wire.ErrCodeReadFailed\` (18) — the exact mirror of the existing \`ErrCodeWriteFailed\` (receiver-disk) code.
- \`Send()\` now posts it whenever the transfer fails with \`fserrors.ErrReadFailed\`, using \`notifyPeer\` — \`notifyCancel\` generalized to take a code/message, keeping its 1s bound and its close-data-first ordering (so a receiver blocked mid-chunk unblocks and reads the reason).
- \`mapPeerError\` maps it to \`ErrReadFailed\` with a \`sender:\` prefix, and \`ErrReadFailed\` joins \`retry.terminalSentinels\` so neither side retries a disk problem (matching \`ErrWriteFailed\`, which was already listed).

Older receivers seeing the unknown code fall into \`mapPeerError\`'s default branch — a protocol-error message that still carries the sender's reason text, and is already terminal.

## Validation

- \`TestEngine_SenderReadFailureReachesReceiver\`: real engines over pipes; source removed between walk and send; both sides get \`ErrReadFailed\` and the receiver's error is asserted non-transient.
- Live with real binaries + local server: deleted the file while the sender waited; receiver now prints \`[E010] Could not read the source file\` immediately, exit 10, **zero** retry notices (previously: 3 retries → E020).
- Full \`go test ./...\` (incl. e2e) green.

Note: the receiver reuses E010's catalog text, whose "check the file permissions" hint reads slightly sender-directed; kept as-is to avoid a new error-catalog entry for a message that names the culprit (\`sender: ...\`) in the detail line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)