### PR TITLE
fix(cli): add --checksum/--manifest/--preview to the --connect conflict list

### DIFF
--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -372,7 +372,7 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	// surprised by "I asked for both --connect and --send and only the
 	// first ran."
 	if cmd.Flags().Changed("connect") {
-		for _, conflict := range []string{"send", "receive", "text", "password", "yes", "out", "overwrite", "name", "exclude", "mode", "update", "uninstall"} {
+		for _, conflict := range []string{"send", "receive", "text", "password", "yes", "out", "overwrite", "name", "exclude", "mode", "update", "uninstall", "checksum", "manifest", "preview"} {
 			if cmd.Flags().Changed(conflict) {
 				return fmt.Errorf("%w: --connect cannot be combined with --%s", fserrors.ErrUsage, conflict)
 			}

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -108,6 +108,24 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 			"--connect cannot be combined with --update",
 		},
 		{
+			// Regression: --checksum/--manifest/--preview were missing from
+			// the conflict list, so --connect persisted the server (a durable
+			// global mutation) while silently dropping them.
+			"connect_with_checksum",
+			[]string{"--connect=host:443", "--checksum"},
+			"--connect cannot be combined with --checksum",
+		},
+		{
+			"connect_with_manifest",
+			[]string{"--connect=host:443", "--manifest=m.csv"},
+			"--connect cannot be combined with --manifest",
+		},
+		{
+			"connect_with_preview",
+			[]string{"--connect=host:443", "--preview"},
+			"--connect cannot be combined with --preview",
+		},
+		{
 			"update_with_uninstall",
 			[]string{"--update", "--uninstall"},
 			"--update and --uninstall are mutually exclusive",


### PR DESCRIPTION
## Problem

The \`--connect\` guard rejects transfer flags so the user can't be surprised by "I asked for two things and only one ran" — but its conflict list predated \`--checksum\`, \`--manifest\`, and \`--preview\`. So:

\`\`\`
fsend --connect example.com --checksum
\`\`\`

**persisted \`example.com:443\` into the config** (a durable global mutation) and silently dropped \`--checksum\`. This is exactly how the review agent accidentally mutated a real user config during the CLI audit.

## Fix

Three tokens added to the existing conflict list, three rows added to the conflict-matrix test.

## Validation

- \`TestRootCmd_RejectsInvalidFlagCombinations\` extended (checksum/manifest/preview cases).
- Live on the built binary with isolated config: \`--connect example.com --checksum\` now exits 24 with a clear E024 and **no config file is written**.
- Full \`go test ./...\` (incl. e2e) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)