### PR TITLE
docs: add SECURITY.md with a private vulnerability-reporting policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,31 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do **not** open a public issue for security problems — that
+publishes the bug before users can update.
+
+Report it privately instead: **[Security and quality tab → Report a
+vulnerability](https://github.com/polius/fsend/security/advisories/new)**.
+The report opens a private advisory thread visible only to you and the
+maintainer.
+
+Include what you can: the affected command or component, reproduction
+steps, and impact. You'll get an acknowledgment within 72 hours.
+Reporters are credited in the release notes unless they prefer
+otherwise. There is no bug bounty.
+
+## Supported versions
+
+Only the latest release is supported. fsend is a single self-updating
+binary — update with `fsend --update`.
+
+## Scope
+
+In scope: the fsend CLI, the wire protocol, the pairing server and
+relay, and the install scripts. Out of scope: vulnerabilities in
+third-party dependencies (report those upstream) and denial of service
+against your own self-hosted instance.
+
+For the threat model and cryptographic design, see
+[docs/security.md](docs/security.md).


### PR DESCRIPTION
## Why

The repo had no answer to "I found a vulnerability — what do I do?". \`docs/security.md\` is the threat-model/architecture doc and contains no disclosure instructions, so a researcher's only visible option was a public issue — a published 0-day for a security-marketed tool.

## What

Root \`SECURITY.md\` only: private reporting via the repo's **Security and quality** tab (private vulnerability reporting was enabled on the repo today), what to include, a 72-hour acknowledgment commitment, credit policy, no-bounty statement, supported-versions (latest release only — self-updating binary), and scope. No email address — GitHub is the only channel.

No README change: GitHub already surfaces the policy where reporters look — the Security and quality tab, and the new-issue chooser's automatic "Report a security vulnerability" link.

## Behavior of the Security policy page

GitHub currently renders \`docs/security.md\` as the repo's security policy (it matches case-insensitively in \`docs/\`). A root \`SECURITY.md\` takes precedence, so on merge the policy page switches to this file automatically. \`docs/security.md\` remains linked from the new file as the threat-model reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)