### PR TITLE
fix(transfer): reject Windows-unsafe receive paths (ADS, reserved names, trailing dot/space)

### DIFF
--- a/internal/transfer/fuzz_test.go
+++ b/internal/transfer/fuzz_test.go
@@ -16,6 +16,7 @@ func FuzzSanitizeRelativePath(f *testing.F) {
 		"../escape", "a/../../escape", "/abs", `\abs`,
 		`C:\windows`, `c:/windows`, `\\unc\share`, "//unc/share",
 		"föö/bär", "a\x00b", "....//", "..",
+		"notes:secret", "CON", "nul.txt", "COM1", "a/aux.c/b", "report.", "report ",
 	} {
 		f.Add(s)
 	}

--- a/internal/transfer/paths.go
+++ b/internal/transfer/paths.go
@@ -3,6 +3,7 @@ package transfer
 import (
 	"fmt"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/polius/fsend/internal/fserrors"
@@ -56,6 +57,12 @@ func (m excludeMatcher) match(rel string) bool {
 // letters, UNC paths, and empties — even when not running on Windows, since
 // the bytes still arrive over the wire.
 func SanitizeRelativePath(p string) (string, error) {
+	return sanitizeRelativePath(p, runtime.GOOS)
+}
+
+// sanitizeRelativePath is SanitizeRelativePath with the receiver OS injected,
+// so the Windows-only hazard gate can be exercised from tests on any host.
+func sanitizeRelativePath(p, goos string) (string, error) {
 	if p == "" {
 		return "", fmt.Errorf("empty path")
 	}
@@ -78,9 +85,55 @@ func SanitizeRelativePath(p string) (string, error) {
 		if part == ".." {
 			return "", fmt.Errorf("path traversal rejected: %q", p)
 		}
+		// Windows-only: ':' , reserved names, and trailing dots/spaces are
+		// legal in Unix filenames (e.g. aux.c), so gate on the receiver OS to
+		// avoid breaking Unix→Unix transfers.
+		if goos == "windows" {
+			if reason := windowsPathHazard(part); reason != "" {
+				return "", fmt.Errorf("windows-unsafe path (%s) rejected: %q", reason, p)
+			}
+		}
 	}
 	if filepath.VolumeName(clean) != "" {
 		return "", fmt.Errorf("volume name rejected: %q", p)
 	}
 	return clean, nil
+}
+
+// windowsPathHazard reports why a path component is unsafe to create on
+// Windows, or "" if it's fine. Each hazard makes the file that lands differ
+// from the name the receiver consented to (none is a traversal).
+func windowsPathHazard(component string) string {
+	if strings.ContainsRune(component, ':') {
+		// "notes:secret" writes the alternate data stream "secret" on "notes".
+		return "alternate data stream ':'"
+	}
+	if isReservedWindowsName(component) {
+		// CON/NUL/COM1 resolve to devices, not files.
+		return "reserved device name"
+	}
+	if n := len(component); n > 0 && (component[n-1] == '.' || component[n-1] == ' ') {
+		// Windows strips a trailing dot/space, so "report." collides with "report".
+		return "trailing dot or space"
+	}
+	return ""
+}
+
+// isReservedWindowsName reports whether a component maps to a Windows reserved
+// device (CON, PRN, AUX, NUL, COM1-9, LPT1-9), case-insensitively and ignoring
+// any extension ("NUL.txt" is still the NUL device).
+func isReservedWindowsName(component string) bool {
+	stem := component
+	if i := strings.IndexByte(stem, '.'); i >= 0 {
+		stem = stem[:i]
+	}
+	up := strings.ToUpper(stem)
+	switch up {
+	case "CON", "PRN", "AUX", "NUL":
+		return true
+	}
+	if len(up) == 4 && (strings.HasPrefix(up, "COM") || strings.HasPrefix(up, "LPT")) {
+		return up[3] >= '1' && up[3] <= '9'
+	}
+	return false
 }

--- a/internal/transfer/paths_test.go
+++ b/internal/transfer/paths_test.go
@@ -1,0 +1,59 @@
+package transfer
+
+import "testing"
+
+// windowsPathHazard is the pure predicate behind the Windows-receiver gate in
+// SanitizeRelativePath. Tested directly (not through SanitizeRelativePath) so
+// the Windows-only logic is exercised on every OS, including the darwin/linux
+// dev and CI runners where runtime.GOOS != "windows".
+func TestWindowsPathHazard(t *testing.T) {
+	unsafe := []string{
+		"notes:secret",   // alternate data stream
+		"file.txt:$DATA", // ADS variant
+		"CON", "con",     // reserved, any case
+		"NUL.txt",      // reserved + extension still resolves to the device
+		"COM1", "LPT9", // reserved serial/printer devices
+		"aux.c",   // reserved stem with a legit-looking extension
+		"report.", // trailing dot (stripped by Windows → collision)
+		"report ", // trailing space (stripped by Windows)
+	}
+	for _, c := range unsafe {
+		if windowsPathHazard(c) == "" {
+			t.Errorf("windowsPathHazard(%q) = safe, want a hazard", c)
+		}
+	}
+
+	safe := []string{
+		"report.pdf", "my-notes.txt", "föö", "a_b.c",
+		"CONtext.md", // only a prefix of a reserved name — fine
+		"COM10",      // COM1-9 only; COM10 isn't reserved
+		"scores.csv",
+	}
+	for _, c := range safe {
+		if r := windowsPathHazard(c); r != "" {
+			t.Errorf("windowsPathHazard(%q) = %q, want safe", c, r)
+		}
+	}
+}
+
+// The Windows hazards must be rejected only when the receiver is Windows —
+// the same names are legitimate on Unix and must pass there. Driven with the
+// OS injected so both branches run on any host.
+func TestSanitizeRelativePath_WindowsGate(t *testing.T) {
+	windowsUnsafe := []string{"notes:secret", "CON", "nul.txt", "COM1", "a/aux.c/b", "report.", "report "}
+	for _, p := range windowsUnsafe {
+		if _, err := sanitizeRelativePath(p, "windows"); err == nil {
+			t.Errorf("sanitizeRelativePath(%q, windows) accepted, want rejected", p)
+		}
+		if _, err := sanitizeRelativePath(p, "linux"); err != nil {
+			t.Errorf("sanitizeRelativePath(%q, linux) rejected (%v), want accepted", p, err)
+		}
+	}
+
+	// Traversal/absolute rejections are OS-independent — still blocked on Unix.
+	for _, p := range []string{"../escape", "/abs", `C:\x`} {
+		if _, err := sanitizeRelativePath(p, "linux"); err == nil {
+			t.Errorf("sanitizeRelativePath(%q, linux) accepted, want rejected", p)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`SanitizeRelativePath` blocked traversal (`..`, absolute, drive letters, UNC) but accepted peer-supplied names that a **Windows receiver** interprets specially — verified with a probe against the current code, all accepted:

| Name | What Windows does |
|---|---|
| `notes:secret` | writes the NTFS **alternate data stream** `secret` on file `notes` — a hidden write absent from any listing |
| `CON`, `NUL`, `COM1`, `nul.txt`, `aux.c` | resolve to **devices**: `NUL` discards the write, `CON` hits the console |
| `report.`, `report ` | Windows **strips** the trailing dot/space, so it lands as `report` — a silent collision the listing's exact-name check can't see |

In every case the file that lands differs from the name the receiver saw and consented to. Same class as the #104 symlink traversal and #110 stream-overwrite fixes, on the Windows side.

## Fix

Per-component rejection of these three hazards, **gated on the receiver being Windows** (`runtime.GOOS`). The gate is essential, not defensive: `:` , reserved stems, and trailing dots/spaces are all **legal Unix filenames** — `aux.c`/`aux.h` are everyday C files, colons appear in timestamps — so rejecting them universally would break legitimate Unix→Unix transfers. On a Windows receiver those names can't be created as intended anyway, so a clear rejection beats a silent ADS/device write.

Both `SanitizeRelativePath` call sites are receiver-side (file listing + stream name), so the gate is on the correct axis.

## Validation

The OS is injected into an unexported `sanitizeRelativePath(p, goos)` so both branches run on the darwin/linux dev + CI hosts:

- `TestSanitizeRelativePath_WindowsGate` — every hazard **rejected** under `windows`, **accepted** under `linux` (no Unix regression); traversal/absolute stay rejected on both.
- `TestWindowsPathHazard` — direct predicate table (ADS, reserved with/without extension, `COM10`≠reserved, `CONtext.md` safe).
- Fuzz corpus seeded with the hazards; `-fuzztime` run found nothing new, no panics.
- Full `go test ./...` green; `go vet` + `gofmt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)