### PR TITLE
test(e2e): surface server output when a server subprocess fails to become ready

### DIFF
--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -50,7 +50,7 @@ type harness struct {
 	withCover bool
 
 	serverCmd    *exec.Cmd
-	serverOutput bytes.Buffer
+	serverOutput safeBuffer
 }
 
 func TestMain(m *testing.M) {
@@ -124,10 +124,9 @@ func startHarness() (*harness, error) {
 	if err := hh.serverCmd.Start(); err != nil {
 		return nil, fmt.Errorf("start fsend server: %w", err)
 	}
-	if err := waitTCP("127.0.0.1:"+strconv.Itoa(hh.httpPort), 5*time.Second); err != nil {
+	if err := waitServerReady("127.0.0.1:"+strconv.Itoa(hh.httpPort), &hh.serverOutput, 5*time.Second); err != nil {
 		hh.shutdown()
-		return nil, fmt.Errorf("fsend server not ready: %w\n--- server output ---\n%s",
-			err, hh.serverOutput.String())
+		return nil, fmt.Errorf("fsend server not ready: %w", err)
 	}
 	return hh, nil
 }
@@ -212,6 +211,17 @@ func waitTCP(addr string, timeout time.Duration) error {
 		time.Sleep(50 * time.Millisecond)
 	}
 	return fmt.Errorf("no listener on %s after %s", addr, timeout)
+}
+
+// waitServerReady waits for an fsend server subprocess to accept connections
+// on addr, appending its captured output to any failure. Without this a bind
+// or config error surfaces only as a bare "no listener" timeout, which is why
+// a rare CI port collision was undiagnosable.
+func waitServerReady(addr string, output fmt.Stringer, timeout time.Duration) error {
+	if err := waitTCP(addr, timeout); err != nil {
+		return fmt.Errorf("%w\n--- server output ---\n%s", err, output.String())
+	}
+	return nil
 }
 
 // ----------------------------------------------------------------------

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -120,6 +120,9 @@ func TestServer_PasswordGate(t *testing.T) {
 		"FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MINUTE=10000",
 		"FSEND_SERVER_MAX_SESSIONS_PER_IP=1000",
 	)
+	var out safeBuffer
+	cmd.Stdout = &out
+	cmd.Stderr = &out
 	if err := cmd.Start(); err != nil {
 		t.Fatalf("start guarded server: %v", err)
 	}
@@ -127,7 +130,7 @@ func TestServer_PasswordGate(t *testing.T) {
 		_ = cmd.Process.Kill()
 		_, _ = cmd.Process.Wait()
 	})
-	if err := waitTCP("127.0.0.1:"+strconv.Itoa(httpPort), 5*time.Second); err != nil {
+	if err := waitServerReady("127.0.0.1:"+strconv.Itoa(httpPort), &out, 5*time.Second); err != nil {
 		t.Fatalf("guarded server not ready: %v", err)
 	}
 	addr := "127.0.0.1:" + strconv.Itoa(httpPort)


### PR DESCRIPTION
## Scope (read first)

This is **purely diagnostic** and test-only. It does **not** claim to eliminate the flake — it makes the *next* occurrence tell us the root cause, so we fix the right thing instead of guessing. No timeout change, no retry logic.

## Problem

`TestServer_PasswordGate` flaked once observably (on #114): `guarded server not ready: no listener on 127.0.0.1:65192 after 5s`, then passed untouched on rerun. The message is undiagnosable — the test discarded the server subprocess's stdout/stderr, so two very different causes look identical:

1. a **port race** — `freePort()` picks a port, closes the socket, and the child binds it later; on a loaded runner something can take it in between → server fails to bind and exits;
2. plain **slowness** — the child just needed >5s to bind.

We couldn't tell which, so the only response was rerun-and-ignore — which is exactly how a real failure eventually slips through a red build.

## Fix

- **`waitServerReady`** helper wraps `waitTCP` and appends the captured server output to any failure. The server prints a detailed `[E030]` on startup failure (verified — see below), so a bind/config error is now visible instead of a bare timeout.
- **`TestServer_PasswordGate`** now captures the subprocess output (it captured none) and uses the helper.
- **`serverOutput`** switches from `bytes.Buffer` to the harness's existing mutex-guarded `safeBuffer`, closing a latent data race between os/exec's writer goroutines and the failure-path `String()` read. Both server-start sites (harness init + this test) now share one safe readiness path.

Only two long-lived server starts exist in the suite; both had this gap (init captured output but not consistently; the test captured nothing). No new abstraction beyond the one small helper.

## Validation

- Full `go test ./...` green; affected e2e tests green under `-race` (confirms the `safeBuffer` swap).
- Empirically confirmed the server emits a rich diagnostic the helper now captures: pointed `fsend server` at an unusable address and it exited with a full `[E030] The server could not start` block naming the offending setting — previously all of that was thrown away.

Notably, occupying the HTTP port on macOS did **not** kill the server (it kept running), which is exactly why the true Windows cause is still unknown and why capturing the output — rather than pre-emptively adding retry/timeout guesses — is the right first move.

🤖 Generated with [Claude Code](https://claude.com/claude-code)