### PR TITLE
fix(cli): make the receive summary honest when files are kept back

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/polius/fsend/internal/connpath"
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/transfer"
+	"github.com/polius/fsend/internal/uxlog"
 	"github.com/polius/fsend/internal/wire"
 )
 
@@ -740,7 +741,7 @@ func TestPromptAccept_HeadlineReconcilesOfferedAndNet(t *testing.T) {
 			},
 		})
 	})
-	for _, want := range []string{"307 MB of 1.2 GB", "1 differ"} {
+	for _, want := range []string{"307 MB of 1.2 GB", "1 differs"} {
 		if !strings.Contains(got, want) {
 			t.Errorf("headline missing %q:\n%s", want, got)
 		}
@@ -748,6 +749,36 @@ func TestPromptAccept_HeadlineReconcilesOfferedAndNet(t *testing.T) {
 	// The old stacked breakdown line must be gone.
 	if strings.Contains(got, "3 new") || strings.Contains(got, "6 up to date") {
 		t.Errorf("stacked breakdown line should be removed:\n%s", got)
+	}
+}
+
+// A summary with kept-back files must not read as an unqualified success:
+// warn glyph, and the headline counts what was written, not what was offered.
+func TestFinishReceive_KeptFilesGetHonestSummary(t *testing.T) {
+	ui := newReceiverUI(context.Background(), &flags{}, "/tmp", false, mustLANInfo())
+	h := wire.SenderHello{Mode: wire.ModeFiles, DisplayName: "2 files"}
+	ui.hello = &h
+	ui.kept = 1
+	ui.skippedSame = 1
+	got := captureStderr(t, func() {
+		if err := finishReceive(ui.f, ui, time.Second); !errors.Is(err, fserrors.ErrTargetExists) {
+			t.Errorf("finishReceive error = %v, want ErrTargetExists", err)
+		}
+	})
+	if want := uxlog.Warn() + " Saved 0 of 2 files to /tmp"; !strings.Contains(got, want) {
+		t.Errorf("summary missing %q:\n%s", want, got)
+	}
+	if strings.Contains(got, uxlog.Check()) {
+		t.Errorf("kept-back summary must not carry the success glyph:\n%s", got)
+	}
+}
+
+func TestDifferVerb(t *testing.T) {
+	if got := differVerb(1); got != "differs" {
+		t.Errorf("differVerb(1) = %q", got)
+	}
+	if got := differVerb(2); got != "differ" {
+		t.Errorf("differVerb(2) = %q", got)
 	}
 }
 

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -219,11 +219,20 @@ func renderArtifact(w io.Writer, h wire.SenderHello, summary transfer.ClassifySu
 	}
 	diff := ""
 	if summary.Differing > 0 {
-		diff = fmt.Sprintf("  ·  %d differ", summary.Differing)
+		diff = fmt.Sprintf("  ·  %d %s", summary.Differing, differVerb(summary.Differing))
 	}
 	_, _ = fmt.Fprintf(w, "      %s  ·  %s%s%s\n",
 		lead, receiverSizeClause(summary), diff, pwChip)
 	renderPreview(w, receiverPreview(summary.Files), 8)
+}
+
+// differVerb conjugates the "N differ(s)" clauses used by the incoming
+// header and the overwrite prompt.
+func differVerb(n int) string {
+	if n == 1 {
+		return "differs"
+	}
+	return "differ"
 }
 
 // receiverSizeClause renders the headline's size figure. The offered total

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -186,7 +186,8 @@ func (ui *receiverUI) confirmOverwrite(conflicts []transfer.Conflict) bool {
 	const preview = 5
 	for {
 		fmt.Fprintln(os.Stderr)
-		fmt.Fprintf(os.Stderr, "  %s differ from your local copies:\n", uxlog.CountNoun(len(conflicts), "file"))
+		fmt.Fprintf(os.Stderr, "  %s %s from your local copies:\n",
+			uxlog.CountNoun(len(conflicts), "file"), differVerb(len(conflicts)))
 		shown := min(len(conflicts), preview)
 		for _, c := range conflicts[:shown] {
 			fmt.Fprintf(os.Stderr, "    %s\n", conflictLabel(c))
@@ -345,7 +346,14 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 		return nil
 	}
 	total, moved := ui.bytes()
-	printRecvSummary(f, ui.headline(h, files), total, moved, kept, skippedSame, elapsed, ui.pathInfo)
+	headline := ui.headline(h, files)
+	// With kept-back files the peer-supplied display name ("2 files") would
+	// overcount what actually landed — say how many of the offer were written.
+	if kept > 0 && !ui.sink {
+		headline = fmt.Sprintf("Saved %d of %s to %s",
+			len(files), uxlog.CountNoun(len(files)+skippedSame+kept, "file"), displayPath(ui.outDir))
+	}
+	printRecvSummary(f, headline, total, moved, kept, skippedSame, elapsed, ui.pathInfo)
 	// manifestErr is set by onManifest, which runs on this goroutine before we
 	// return, so no lock is needed. The transfer succeeded; the failure is only
 	// that --manifest couldn't be written.
@@ -398,10 +406,15 @@ func (ui *receiverUI) headline(h *wire.SenderHello, files []string) string {
 	return "Saved " + name + " to " + dest
 }
 
-// printRecvSummary renders the post-transfer success line.
+// printRecvSummary renders the post-transfer outcome line. Kept-back files
+// make it a partial success: warn glyph, matching the E013 exit that follows.
 func printRecvSummary(f *flags, headline string, total, moved int64, kept, skippedSame int, elapsed time.Duration, path connpath.Info) {
 	if f.quiet {
 		return
+	}
+	glyph := uxlog.Check()
+	if kept > 0 {
+		glyph = uxlog.Warn()
 	}
 	if headline == "" {
 		headline = "Received"
@@ -422,6 +435,6 @@ func printRecvSummary(f *flags, headline string, total, moved int64, kept, skipp
 	if kept > 0 {
 		parts = append(parts, fmt.Sprintf("%s kept (use --overwrite)", uxlog.CountNoun(kept, "file")))
 	}
-	fmt.Fprintf(os.Stderr, "%s %s  ·  %s\n", uxlog.Check(), headline, strings.Join(parts, "  ·  "))
+	fmt.Fprintf(os.Stderr, "%s %s  ·  %s\n", glyph, headline, strings.Join(parts, "  ·  "))
 	printUpdateNotice(f)
 }

--- a/test/e2e/transfer_test.go
+++ b/test/e2e/transfer_test.go
@@ -368,6 +368,14 @@ func TestReceive_DifferingFileKept_ReceiverSeesE013(t *testing.T) {
 		t.Errorf("receiver exit = %d, want 13 (E013, conflict kept)\nstderr:\n%s",
 			r.receiverExitCode, r.receiverErr)
 	}
+	// The summary must agree with the exit code: warn glyph and a headline
+	// counting what was written, not a green "Saved 1 file" for a kept file.
+	if !strings.Contains(r.receiverErr, "Saved 0 of 1 file") {
+		t.Errorf("summary should say nothing was written:\nstderr:\n%s", r.receiverErr)
+	}
+	if strings.Contains(r.receiverErr, "[OK] Saved") {
+		t.Errorf("kept conflict must not render a success summary:\nstderr:\n%s", r.receiverErr)
+	}
 	if r.senderExitCode != 0 {
 		t.Errorf("sender exit = %d, want 0 (transfer completes; file skipped)\nstderr:\n%s",
 			r.senderExitCode, r.senderErr)


### PR DESCRIPTION
## Problem

Receiving a transfer where a local file differs (no `--overwrite`) printed a green success line followed by a hard failure:

```
[OK] Saved 2 files to …rdir  ·  0 B  ·  2ms  ·  …  ·  1 file kept (use --overwrite)
[FAIL] [E013] Target file exists and --overwrite was not given.
```

Zero bytes were written, yet the summary claimed "Saved 2 files" with the success glyph — the count came from the peer's display name, not from what landed. Humans read the ✓, scripts read exit 13; they disagreed. The header/prompt also read "1 differ" / "1 file differ" at n=1.

## Fix

- When files are kept back, the summary leads with the warn glyph and counts what was actually written: `[!] Saved 1 of 2 files to … · 1 file kept (use --overwrite)` — glyph, counts, and E013 exit now agree.
- `differVerb` conjugates the "N differ(s)" clauses (incoming header + overwrite prompt).

## After

```
      2 files  ·  300 KB of 300.0 KB  ·  1 differs
[!] Saved 1 of 2 files to …rdir  ·  300 KB  ·  8ms  ·  Direct on local network  ·  1 file kept (use --overwrite)
[FAIL] [E013] Target file exists and --overwrite was not given.
```

## Validation

- Live repro against a local pairing server (before/after above).
- New unit tests: `TestFinishReceive_KeptFilesGetHonestSummary`, `TestDifferVerb`.
- Extended e2e `TestReceive_DifferingFileKept_ReceiverSeesE013` to assert the warn-glyph summary and reject `[OK] Saved`.
- `go test ./cmd/fsend ./test/e2e` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)