### PR TITLE
fix(cli): make --connect default actually reset a corrupt config

### DIFF
--- a/cmd/fsend/connect.go
+++ b/cmd/fsend/connect.go
@@ -28,6 +28,12 @@ func warnIfConfigCorrupted(err error, quiet bool) {
 		return
 	}
 	fmt.Fprintf(os.Stderr, "%s [%s] %s\n", uxlog.Warn(), entry.Code, entry.Message)
+	// Load wraps the sentinel with the file and cause ("<path>: not valid
+	// JSON", "open <path>: permission denied") — show it so the user knows
+	// which file to fix and why it was rejected.
+	if detail := strings.TrimPrefix(err.Error(), fserrors.ErrConfigCorrupted.Error()+": "); detail != err.Error() {
+		fmt.Fprintf(os.Stderr, "  %s\n", detail)
+	}
 	if entry.Action != "" {
 		fmt.Fprintf(os.Stderr, "  %s\n", entry.Action)
 	}
@@ -79,7 +85,11 @@ func runConnect(f *flags) error {
 		if len(args) > 1 {
 			return fmt.Errorf("%w: --connect default takes no password", fserrors.ErrUsage)
 		}
-		if cfg.IsDefault() {
+		// "Already default" short-circuits only when the file also loaded
+		// cleanly. A corrupt file loads as the zero-value (default) config,
+		// and this command is E016's suggested fix — it must rewrite the
+		// file, or the warning recurs forever.
+		if cfg.IsDefault() && loadErr == nil {
 			fmt.Fprintln(os.Stderr, uxlog.Info(), "Already on the default server:", config.DefaultServer)
 			return nil
 		}
@@ -211,6 +221,9 @@ func printCurrentServer(cfg *config.Config) {
 		fmt.Fprintln(os.Stderr)
 		fmt.Fprintln(os.Stderr, "  Revert to the default:  fsend --connect default")
 		fmt.Fprintln(os.Stderr, "  Set a new server:       fsend --connect <host[:port]>[,<password>]")
+	}
+	if p, err := config.Path(); err == nil {
+		fmt.Fprintln(os.Stderr, "  Config file:", p)
 	}
 	fmt.Fprintln(os.Stderr)
 }

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -273,6 +273,61 @@ func TestRunConnect_PersistsServerAndPassword(t *testing.T) {
 	}
 }
 
+// `--connect default` is E016's suggested fix, so it must rewrite a corrupt
+// config file — not short-circuit on "already default" (a corrupt file loads
+// as the zero-value config) and leave the warning to recur forever.
+func TestRunConnect_DefaultRewritesCorruptConfig(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.json")
+	config.SetPathForTesting(cfgPath)
+	t.Cleanup(func() { config.SetPathForTesting("") })
+	if err := os.WriteFile(cfgPath, []byte("{garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	stderr := captureStderr(t, func() {
+		if err := runConnect(&flags{connectArgsRaw: []string{"default"}}); err != nil {
+			t.Fatalf("runConnect default: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "Reverted to default server") {
+		t.Errorf("expected revert message, got:\n%s", stderr)
+	}
+	if _, err := config.Load(); err != nil {
+		t.Errorf("config still unusable after --connect default: %v", err)
+	}
+}
+
+// The show screen names the config file, and a corrupt file's warning says
+// which file was rejected and why.
+func TestRunConnect_ShowPrintsPathAndCorruptionDetail(t *testing.T) {
+	tmp := t.TempDir()
+	cfgPath := filepath.Join(tmp, "config.json")
+	config.SetPathForTesting(cfgPath)
+	t.Cleanup(func() { config.SetPathForTesting("") })
+
+	stderr := captureStderr(t, func() {
+		if err := runConnect(&flags{connectArgsRaw: []string{connectShowSentinel}}); err != nil {
+			t.Fatalf("runConnect show: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "Config file: "+cfgPath) {
+		t.Errorf("show screen missing config path:\n%s", stderr)
+	}
+
+	if err := os.WriteFile(cfgPath, []byte("{garbage"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stderr = captureStderr(t, func() {
+		if err := runConnect(&flags{connectArgsRaw: []string{connectShowSentinel}}); err != nil {
+			t.Fatalf("runConnect show: %v", err)
+		}
+	})
+	if !strings.Contains(stderr, "E016") || !strings.Contains(stderr, cfgPath+": not valid JSON") {
+		t.Errorf("corruption warning missing file/cause detail:\n%s", stderr)
+	}
+}
+
 func TestRunConnect_RejectsBadHostPort(t *testing.T) {
 	tmp := t.TempDir()
 	config.SetPathForTesting(filepath.Join(tmp, "config.json"))

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -125,16 +125,17 @@ func Load() (*Config, error) {
 		// Readable-but-denied (e.g. a chmod-000 or root-owned config)
 		// must not fall back to the public default *silently* — that
 		// would drop a user's custom server with no hint. Surface it as
-		// the same warn-and-default path corruption uses.
-		return &Config{}, fserrors.ErrConfigCorrupted
+		// the same warn-and-default path corruption uses. The wrapped
+		// cause names the file and why, so the E016 warning can show it.
+		return &Config{}, fmt.Errorf("%w: %v", fserrors.ErrConfigCorrupted, err)
 	}
 	var c Config
 	if err := json.Unmarshal(data, &c); err != nil {
-		return &Config{}, fserrors.ErrConfigCorrupted
+		return &Config{}, fmt.Errorf("%w: %s: not valid JSON", fserrors.ErrConfigCorrupted, p)
 	}
 	if c.SchemaVersion != SchemaVersion {
 		// Future schema or junk; ignore.
-		return &Config{}, fserrors.ErrConfigCorrupted
+		return &Config{}, fmt.Errorf("%w: %s: unsupported schema_version %d", fserrors.ErrConfigCorrupted, p, c.SchemaVersion)
 	}
 	return &c, nil
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/polius/fsend/internal/fserrors"
@@ -95,11 +96,35 @@ func TestLoad_CorruptedJSON(t *testing.T) {
 	if !errors.Is(err, fserrors.ErrConfigCorrupted) {
 		t.Errorf("expected ErrConfigCorrupted, got %v", err)
 	}
+	// The wrapped cause names the file so the E016 warning can show it.
+	if err == nil || !strings.Contains(err.Error(), path+": not valid JSON") {
+		t.Errorf("error should name the file and cause, got %v", err)
+	}
 	if c == nil {
 		t.Fatal("expected non-nil zero Config even on corruption")
 	}
 	if !c.IsDefault() {
 		t.Error("corrupted config should fall back to defaults")
+	}
+}
+
+func TestLoad_PermissionDenied(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root reads through file modes")
+	}
+	path := withTempXDG(t)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"schema_version": 1}`), 0o000); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Load()
+	if !errors.Is(err, fserrors.ErrConfigCorrupted) {
+		t.Errorf("expected ErrConfigCorrupted for unreadable file, got %v", err)
+	}
+	if err == nil || !strings.Contains(err.Error(), "permission denied") {
+		t.Errorf("error should carry the permission cause, got %v", err)
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -109,6 +109,9 @@ func TestLoad_CorruptedJSON(t *testing.T) {
 }
 
 func TestLoad_PermissionDenied(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("0o000 does not make a file unreadable on Windows")
+	}
 	if os.Getuid() == 0 {
 		t.Skip("root reads through file modes")
 	}

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -284,7 +284,7 @@ var catalog = map[error]Entry{
 	},
 	ErrConfigCorrupted: {
 		Code: "E016", Exit: 0, // warning, not fatal
-		Message: "Your config file is invalid. Falling back to defaults.",
+		Message: "Your config file could not be used. Falling back to defaults.",
 		Action:  "To reset:  fsend --connect default",
 	},
 	ErrRateLimited: {


### PR DESCRIPTION
## Problem

With a corrupted config file, every command warned:

```
[!] [E016] Your config file is invalid. Falling back to defaults.
  To reset:  fsend --connect default
```

But following that advice printed "Already on the default server" **without rewriting the file** — a corrupt file loads as the zero-value (default) config, so the short-circuit fired and the warning recurred forever. The user had no CLI way out, no idea which file was broken, and a permission-denied file was mislabeled "invalid". A corrupt config also silently drops a configured custom server (transfers fall back to the public server), which makes fast recovery matter.

## Fix

- `--connect default` short-circuits on "already default" only when the file also **loaded cleanly**; otherwise it rewrites clean defaults.
- `config.Load` wraps E016 with the file path and cause; the warning now reads:
  ```
  [!] [E016] Your config file could not be used. Falling back to defaults.
    /Users/x/…/fsend/config.json: not valid JSON
    To reset:  fsend --connect default
  ```
- The `--connect` show screen prints `Config file: <path>` (stderr, so the greppable stdout stays server-only).

## Validation

Live before/after: corrupt file → warning names file+cause → `--connect default` rewrites `{"schema_version": 1}` → warning gone.

New tests: `TestRunConnect_DefaultRewritesCorruptConfig`, `TestRunConnect_ShowPrintsPathAndCorruptionDetail`, `TestLoad_PermissionDenied`, plus cause-detail assertions in `TestLoad_CorruptedJSON`. `go test ./internal/config ./cmd/fsend ./internal/fserrors` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)