### PR TITLE
feat(transfer): allow 3 password attempts before burning the code

### DIFF
--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -170,13 +170,17 @@ func runReceive(f *flags, c string) error {
 // Timing: the progress bar is constructed lazily on first byte (see
 // newReceiverProgress), so this prompt fires before any bar exists —
 // no risk of mpb rendering on top of the password input line.
-func receiverPasswordPrompt(ctx context.Context, f *flags) func() (string, error) {
+func receiverPasswordPrompt(ctx context.Context, f *flags) func(attempt int) (string, error) {
 	if f.quiet {
 		return nil
 	}
-	return func() (string, error) {
+	return func(attempt int) (string, error) {
 		fmt.Fprintln(os.Stderr)
-		return readPasswordHiddenCtx(ctx, "  Password required by sender: ")
+		if attempt > 1 {
+			return readPasswordHiddenCtx(ctx,
+				fmt.Sprintf("  Wrong password — try again (%d/%d): ", attempt, transfer.PasswordAttempts))
+		}
+		return readPasswordHiddenCtx(ctx, "  Password for this transfer: ")
 	}
 }
 

--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -498,7 +498,7 @@ func TestEngine_SenderReadFailureReachesReceiver(t *testing.T) {
 
 // passwordTransfer runs a password-gated single-file transfer with the given
 // receiver password options.
-func passwordTransfer(t *testing.T, senderPass string, mutate func(*RecvOptions)) (sendErr, recvErr error, dst string) {
+func passwordTransfer(t *testing.T, senderPass string, mutate func(*RecvOptions)) (dst string, sendErr, recvErr error) {
 	t.Helper()
 	src := t.TempDir()
 	dst = t.TempDir()
@@ -511,7 +511,7 @@ func passwordTransfer(t *testing.T, senderPass string, mutate func(*RecvOptions)
 	mutate(&recvOpts)
 	sendErr, recvErr = runTransfer(t,
 		SendOptions{Mode: wire.ModeFiles, Sources: sources, Password: senderPass}, recvOpts)
-	return sendErr, recvErr, dst
+	return dst, sendErr, recvErr
 }
 
 // A typo at the prompt gets fresh challenges: two wrong tries then the right
@@ -519,7 +519,7 @@ func passwordTransfer(t *testing.T, senderPass string, mutate func(*RecvOptions)
 func TestEngine_PasswordRetriesWithinCap(t *testing.T) {
 	tries := []string{"wrong1", "wrong2", "right"}
 	var attempts []int
-	se, re, dst := passwordTransfer(t, "right", func(o *RecvOptions) {
+	dst, se, re := passwordTransfer(t, "right", func(o *RecvOptions) {
 		o.PromptPass = func(attempt int) (string, error) {
 			attempts = append(attempts, attempt)
 			return tries[attempt-1], nil
@@ -540,7 +540,7 @@ func TestEngine_PasswordRetriesWithinCap(t *testing.T) {
 // PasswordAttempts wrong tries abort with ErrWrongPassword on both sides.
 func TestEngine_PasswordExhaustedAborts(t *testing.T) {
 	prompts := 0
-	se, re, dst := passwordTransfer(t, "right", func(o *RecvOptions) {
+	dst, se, re := passwordTransfer(t, "right", func(o *RecvOptions) {
 		o.PromptPass = func(attempt int) (string, error) {
 			prompts++
 			return "wrong", nil
@@ -560,7 +560,7 @@ func TestEngine_PasswordExhaustedAborts(t *testing.T) {
 // A fixed password (--password / FSEND_PASSWORD) can't change between tries,
 // so a mismatch aborts after one attempt on both sides.
 func TestEngine_PasswordFixedWrongSingleAttempt(t *testing.T) {
-	se, re, _ := passwordTransfer(t, "right", func(o *RecvOptions) {
+	_, se, re := passwordTransfer(t, "right", func(o *RecvOptions) {
 		o.Password = "wrong"
 	})
 	if !errors.Is(se, fserrors.ErrWrongPassword) || !errors.Is(re, fserrors.ErrWrongPassword) {

--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -495,3 +495,75 @@ func TestEngine_SenderReadFailureReachesReceiver(t *testing.T) {
 		t.Fatalf("receiver error must be terminal (no retry), got transient: %v", re)
 	}
 }
+
+// passwordTransfer runs a password-gated single-file transfer with the given
+// receiver password options.
+func passwordTransfer(t *testing.T, senderPass string, mutate func(*RecvOptions)) (sendErr, recvErr error, dst string) {
+	t.Helper()
+	src := t.TempDir()
+	dst = t.TempDir()
+	writeFile(t, filepath.Join(src, "gated.txt"), []byte("payload"))
+	sources, err := Walk([]string{filepath.Join(src, "gated.txt")}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recvOpts := RecvOptions{TargetDir: dst}
+	mutate(&recvOpts)
+	sendErr, recvErr = runTransfer(t,
+		SendOptions{Mode: wire.ModeFiles, Sources: sources, Password: senderPass}, recvOpts)
+	return sendErr, recvErr, dst
+}
+
+// A typo at the prompt gets fresh challenges: two wrong tries then the right
+// one completes the transfer on the same session, without burning the code.
+func TestEngine_PasswordRetriesWithinCap(t *testing.T) {
+	tries := []string{"wrong1", "wrong2", "right"}
+	var attempts []int
+	se, re, dst := passwordTransfer(t, "right", func(o *RecvOptions) {
+		o.PromptPass = func(attempt int) (string, error) {
+			attempts = append(attempts, attempt)
+			return tries[attempt-1], nil
+		}
+	})
+	if se != nil || re != nil {
+		t.Fatalf("send=%v recv=%v", se, re)
+	}
+	want := []int{1, 2, 3}
+	if len(attempts) != 3 || attempts[0] != want[0] || attempts[1] != want[1] || attempts[2] != want[2] {
+		t.Errorf("prompt attempts = %v, want %v", attempts, want)
+	}
+	if got := mustRead(t, filepath.Join(dst, "gated.txt")); string(got) != "payload" {
+		t.Errorf("file content = %q", got)
+	}
+}
+
+// PasswordAttempts wrong tries abort with ErrWrongPassword on both sides.
+func TestEngine_PasswordExhaustedAborts(t *testing.T) {
+	prompts := 0
+	se, re, dst := passwordTransfer(t, "right", func(o *RecvOptions) {
+		o.PromptPass = func(attempt int) (string, error) {
+			prompts++
+			return "wrong", nil
+		}
+	})
+	if !errors.Is(se, fserrors.ErrWrongPassword) || !errors.Is(re, fserrors.ErrWrongPassword) {
+		t.Fatalf("send=%v recv=%v, want ErrWrongPassword on both", se, re)
+	}
+	if prompts != PasswordAttempts {
+		t.Errorf("prompted %d times, want %d", prompts, PasswordAttempts)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "gated.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("no file must land on a failed password gate")
+	}
+}
+
+// A fixed password (--password / FSEND_PASSWORD) can't change between tries,
+// so a mismatch aborts after one attempt on both sides.
+func TestEngine_PasswordFixedWrongSingleAttempt(t *testing.T) {
+	se, re, _ := passwordTransfer(t, "right", func(o *RecvOptions) {
+		o.Password = "wrong"
+	})
+	if !errors.Is(se, fserrors.ErrWrongPassword) || !errors.Is(re, fserrors.ErrWrongPassword) {
+		t.Fatalf("send=%v recv=%v, want ErrWrongPassword on both", se, re)
+	}
+}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -34,8 +34,11 @@ type RecvOptions struct {
 	// Overwrite is false and there is a terminal to ask.
 	ConfirmOverwrite func(conflicts []Conflict) bool
 
-	Password   string
-	PromptPass func() (string, error)
+	Password string
+	// PromptPass asks the user for the sender's password. attempt starts at
+	// 1 and grows when the sender rejects a try (up to PasswordAttempts),
+	// so the prompt can say "wrong password — try again".
+	PromptPass func(attempt int) (string, error)
 
 	ProgressFn func(index uint32, bytesWritten uint64)
 	OnResume   func(index uint32, offset, total uint64)
@@ -848,47 +851,61 @@ func mapPeerError(ef wire.ErrorFrame) error {
 	}
 }
 
-// receiverPasswordHandshake answers the sender's --password challenge.
+// receiverPasswordHandshake answers the sender's --password challenge. On a
+// mismatch the sender issues a fresh challenge (up to PasswordAttempts), so
+// an interactively-prompted receiver can retry a typo without burning the
+// one-shot code. A fixed password (--password / FSEND_PASSWORD) gets one
+// try — resending the same value can't succeed.
 func receiverPasswordHandshake(s *Streams, opts RecvOptions) error {
-	var ch wire.PasswordChallenge
-	ft, err := wire.ReadControl(s.Control, &ch)
-	if err != nil {
-		return fmt.Errorf("recv: read password challenge: %w", err)
-	}
-	if ft != wire.TypePasswordChallenge {
-		return fmt.Errorf("%w: expected PASSWORD_CHALLENGE, got %v", fserrors.ErrProtocolError, ft)
-	}
-	password := opts.Password
-	if password == "" {
-		if opts.PromptPass == nil {
-			declineTransfer(s, wire.ErrCodePasswordRequired, "receiver has no password to offer")
-			return fserrors.ErrPasswordRequired
-		}
-		password, err = opts.PromptPass()
+	for attempt := 1; ; attempt++ {
+		var ch wire.PasswordChallenge
+		ft, err := wire.ReadControl(s.Control, &ch)
 		if err != nil {
-			return fmt.Errorf("recv: read password: %w", err)
+			// An old sender closes the stream after one mismatch instead of
+			// re-challenging; the honest error is still the password.
+			if attempt > 1 {
+				return fserrors.ErrWrongPassword
+			}
+			return fmt.Errorf("recv: read password challenge: %w", err)
 		}
-	}
-	mac := hmacPassword(password, ch.Nonce[:])
-	var resp wire.PasswordResponse
-	copy(resp.HMAC[:], mac)
-	if err := wire.WriteControl(s.Control, wire.TypePasswordResponse, &resp); err != nil {
-		return fmt.Errorf("recv: write password response: %w", err)
-	}
-	var ef wire.ErrorFrame
-	ft, err = wire.ReadControl(s.Control, &ef)
-	if err != nil {
-		return fmt.Errorf("recv: read password verdict: %w", err)
-	}
-	switch ft {
-	case wire.TypePasswordVerified:
-		return nil
-	case wire.TypeError:
-		if ef.Code == wire.ErrCodeWrongPassword {
+		if ft != wire.TypePasswordChallenge {
+			return fmt.Errorf("%w: expected PASSWORD_CHALLENGE, got %v", fserrors.ErrProtocolError, ft)
+		}
+		password := opts.Password
+		if password == "" {
+			if opts.PromptPass == nil {
+				declineTransfer(s, wire.ErrCodePasswordRequired, "receiver has no password to offer")
+				return fserrors.ErrPasswordRequired
+			}
+			password, err = opts.PromptPass(attempt)
+			if err != nil {
+				return fmt.Errorf("recv: read password: %w", err)
+			}
+		}
+		mac := hmacPassword(password, ch.Nonce[:])
+		var resp wire.PasswordResponse
+		copy(resp.HMAC[:], mac)
+		if err := wire.WriteControl(s.Control, wire.TypePasswordResponse, &resp); err != nil {
+			return fmt.Errorf("recv: write password response: %w", err)
+		}
+		var ef wire.ErrorFrame
+		ft, err = wire.ReadControl(s.Control, &ef)
+		if err != nil {
+			return fmt.Errorf("recv: read password verdict: %w", err)
+		}
+		switch ft {
+		case wire.TypePasswordVerified:
+			return nil
+		case wire.TypeError:
+			if ef.Code != wire.ErrCodeWrongPassword {
+				return fmt.Errorf("%w: peer reported %d: %s", fserrors.ErrProtocolError, ef.Code, ef.Message)
+			}
+			if opts.Password == "" && opts.PromptPass != nil {
+				continue // loop back for the sender's next challenge
+			}
 			return fserrors.ErrWrongPassword
+		default:
+			return fmt.Errorf("%w: expected PASSWORD_VERIFIED, got %v", fserrors.ErrProtocolError, ft)
 		}
-		return fmt.Errorf("%w: peer reported %d: %s", fserrors.ErrProtocolError, ef.Code, ef.Message)
-	default:
-		return fmt.Errorf("%w: expected PASSWORD_VERIFIED, got %v", fserrors.ErrProtocolError, ft)
 	}
 }

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -405,42 +405,61 @@ func peerError(body []byte) error {
 	return mapPeerError(ef)
 }
 
+// PasswordAttempts is how many password tries the sender allows per session
+// before aborting the transfer. A typo at the receiver's no-echo prompt
+// shouldn't burn the one-shot code.
+const PasswordAttempts = 3
+
 // senderPasswordHandshake runs the challenge/response that gates --password.
+// Each mismatch below the attempt cap answers with a WrongPassword error and
+// a fresh challenge; the final mismatch closes the stream as before.
 func senderPasswordHandshake(s *Streams, password string) error {
-	var nonce [32]byte
-	if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
-		return fmt.Errorf("send: password nonce: %w", err)
-	}
-	if err := wire.WriteControl(s.Control, wire.TypePasswordChallenge, &wire.PasswordChallenge{Nonce: nonce}); err != nil {
-		return fmt.Errorf("send: password challenge: %w", err)
-	}
-	ft, body, err := wire.ReadControlRaw(s.Control)
-	if err != nil {
-		return fmt.Errorf("send: read password response: %w", err)
-	}
-	if ft == wire.TypeError {
-		return peerError(body)
-	}
-	if ft != wire.TypePasswordResponse {
-		return fmt.Errorf("%w: expected PASSWORD_RESPONSE, got %v", fserrors.ErrProtocolError, ft)
-	}
-	var resp wire.PasswordResponse
-	if err := wire.Decode(body, &resp); err != nil {
-		return fmt.Errorf("send: decode password response: %w", err)
-	}
-	expected := hmacPassword(password, nonce[:])
-	if subtle.ConstantTimeCompare(expected, resp.HMAC[:]) != 1 {
+	for attempt := 1; ; attempt++ {
+		var nonce [32]byte
+		if _, err := io.ReadFull(rand.Reader, nonce[:]); err != nil {
+			return fmt.Errorf("send: password nonce: %w", err)
+		}
+		if err := wire.WriteControl(s.Control, wire.TypePasswordChallenge, &wire.PasswordChallenge{Nonce: nonce}); err != nil {
+			// A receiver that can't retry (fixed password, old fsend) hangs
+			// up after its mismatch; the honest error is still the password.
+			if attempt > 1 {
+				return fserrors.ErrWrongPassword
+			}
+			return fmt.Errorf("send: password challenge: %w", err)
+		}
+		ft, body, err := wire.ReadControlRaw(s.Control)
+		if err != nil {
+			if attempt > 1 {
+				return fserrors.ErrWrongPassword
+			}
+			return fmt.Errorf("send: read password response: %w", err)
+		}
+		if ft == wire.TypeError {
+			return peerError(body)
+		}
+		if ft != wire.TypePasswordResponse {
+			return fmt.Errorf("%w: expected PASSWORD_RESPONSE, got %v", fserrors.ErrProtocolError, ft)
+		}
+		var resp wire.PasswordResponse
+		if err := wire.Decode(body, &resp); err != nil {
+			return fmt.Errorf("send: decode password response: %w", err)
+		}
+		expected := hmacPassword(password, nonce[:])
+		if subtle.ConstantTimeCompare(expected, resp.HMAC[:]) == 1 {
+			if err := wire.WriteControl(s.Control, wire.TypePasswordVerified, nil); err != nil {
+				return fmt.Errorf("send: password verified: %w", err)
+			}
+			return nil
+		}
 		_ = wire.WriteControl(s.Control, wire.TypeError, &wire.ErrorFrame{
 			Code: wire.ErrCodeWrongPassword, Message: "wrong password",
 		})
-		_ = s.Control.Close()
-		_, _ = io.Copy(io.Discard, s.Control)
-		return fserrors.ErrWrongPassword
+		if attempt == PasswordAttempts {
+			_ = s.Control.Close()
+			_, _ = io.Copy(io.Discard, s.Control)
+			return fserrors.ErrWrongPassword
+		}
 	}
-	if err := wire.WriteControl(s.Control, wire.TypePasswordVerified, nil); err != nil {
-		return fmt.Errorf("send: password verified: %w", err)
-	}
-	return nil
 }
 
 // hmacPassword is the shared response tag; argon2id stretches the password

--- a/test/e2e/transfer_test.go
+++ b/test/e2e/transfer_test.go
@@ -529,7 +529,7 @@ func TestDispatch_ForceReceive(t *testing.T) {
 //  2. No progress-bar collision: the bar is materialized lazily on the
 //     first chunk, so mpb's stderr repaint can't overlap the password
 //     input line. A regression would re-introduce a garbled line like
-//     "Password required by sender:   0 % [---]   0.00 b" — what the
+//     "Password for this transfer:   0 % [---]   0.00 b" — what the
 //     original UX bug report flagged.
 func TestPassword_NoBarCollisionOnPrompt(t *testing.T) {
 	requireE2E(t)
@@ -550,7 +550,7 @@ func TestPassword_NoBarCollisionOnPrompt(t *testing.T) {
 	r.requireSuccess(t)
 
 	saveIdx := strings.Index(r.receiverErr, "Save to")
-	passwordIdx := strings.Index(r.receiverErr, "Password required by sender:")
+	passwordIdx := strings.Index(r.receiverErr, "Password for this transfer:")
 	if saveIdx < 0 {
 		t.Fatalf("save prompt not found in receiver stderr:\n%s", r.receiverErr)
 	}
@@ -566,7 +566,7 @@ func TestPassword_NoBarCollisionOnPrompt(t *testing.T) {
 	// must not also contain progress-bar tokens. "% [" is the leading
 	// fragment mpb emits ("  X % [######...").
 	for _, line := range strings.Split(r.receiverErr, "\n") {
-		if strings.Contains(line, "Password required by sender:") && strings.Contains(line, "% [") {
+		if strings.Contains(line, "Password for this transfer:") && strings.Contains(line, "% [") {
 			t.Fatalf("progress bar rendered on password prompt line: %q", line)
 		}
 	}


### PR DESCRIPTION
## Problem

The receiver's password prompt is no-echo and got exactly one attempt: a single typo aborted with E021, and — codes being one-shot — the sender had to restart and re-share a new code. `ssh`/`sudo` give 3 tries; a verbally-relayed password deserves the same.

## Fix

- Sender: on HMAC mismatch below the cap (3), answer `Error(WrongPassword)` **plus a fresh challenge** instead of closing; the final mismatch closes the stream exactly as before.
- Receiver: on a wrong-password verdict, loop back for the next challenge and re-prompt (`Wrong password — try again (2/3)`). A fixed `--password`/`FSEND_PASSWORD` value keeps the single attempt — resending the same value can't succeed.
- Prompt wording unified on `Password for this transfer:` (was `Password required by sender:` in the mid-handshake path).

## Compatibility (no protocol version bump)

- **New sender + old receiver**: old receiver exits on the first `Error`; the sender's next challenge write/read fails and is mapped back to `ErrWrongPassword` → today's single-attempt behavior.
- **Old sender + new receiver**: old sender closes after one mismatch; the receiver's next challenge read fails and is mapped back to `ErrWrongPassword` → same.
- Verified by `TestEngine_PasswordFixedWrongSingleAttempt`, which exercises exactly the hang-up-after-one-mismatch path.

## Security note

3 online guesses per code instead of 1 (agreed tradeoff). The PAKE-authenticated code still gates the connection; the sender tears down after the cap.

## Validation

- Live: `bad1`,`bad2`,`goodpass` → transfer completes on the same code; `bad1`,`bad2`,`bad3` → E021 both sides, exit 21.
- New engine tests over in-memory pipes: `TestEngine_PasswordRetriesWithinCap`, `TestEngine_PasswordExhaustedAborts`, `TestEngine_PasswordFixedWrongSingleAttempt`.
- `go test ./internal/transfer ./cmd/fsend ./test/e2e` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)