### PR TITLE
fix(cli): reject syntactically impossible --connect hostnames

### DIFF
--- a/cmd/fsend/connect.go
+++ b/cmd/fsend/connect.go
@@ -178,7 +178,36 @@ func normalizeServer(s string) (string, error) {
 	if strings.TrimSpace(host) == "" {
 		return "", fmt.Errorf("host part is empty in %q", s)
 	}
+	if !validHost(host) {
+		return "", fmt.Errorf("invalid server hostname %q", host)
+	}
 	return net.JoinHostPort(host, port), nil
+}
+
+// validHost reports whether host is an IP literal or a plausible DNS name.
+// Persisting a syntactically impossible host ("not a host!") would break
+// every later transfer as E001, so it must be rejected here — unlike a
+// well-formed name that merely fails to resolve, which only warns (the
+// user may be offline or on another network).
+func validHost(host string) bool {
+	if net.ParseIP(host) != nil {
+		return true
+	}
+	host = strings.TrimSuffix(host, ".") // tolerate a FQDN's trailing dot
+	for _, label := range strings.Split(host, ".") {
+		if label == "" || label[0] == '-' || label[len(label)-1] == '-' {
+			return false
+		}
+		for _, r := range label {
+			switch {
+			case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			case r == '-', r == '_': // '_' is invalid DNS but common on LANs
+			default:
+				return false
+			}
+		}
+	}
+	return true
 }
 
 // defaultPortForHost returns the implicit port for an address where the

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -226,9 +226,20 @@ func TestNormalizeServer(t *testing.T) {
 			t.Errorf("normalizeServer(%q) = %q, want %q", tc.in, got, tc.want)
 		}
 	}
-	for _, bad := range []string{"", "   ", ":443", "host:0", "host:99999", "host:abc", "http://", "https://"} {
+	for _, bad := range []string{
+		"", "   ", ":443", "host:0", "host:99999", "host:abc", "http://", "https://",
+		// Syntactically impossible hostnames must be rejected, not
+		// persisted with a resolve warning.
+		"not a host!", "host!", "a b.example.com", "host..double", "-lead.example.com", "trail-.example.com", "héllo.example.com",
+	} {
 		if _, err := normalizeServer(bad); err == nil {
 			t.Errorf("normalizeServer(%q) accepted bad input", bad)
+		}
+	}
+	// Unusual-but-real shapes stay accepted.
+	for _, ok := range []string{"my_host", "fs.example.com.", "xn--nxasmq6b.example"} {
+		if _, err := normalizeServer(ok); err != nil {
+			t.Errorf("normalizeServer(%q) rejected valid host: %v", ok, err)
 		}
 	}
 }


### PR DESCRIPTION
## Problem

```
$ fsend --connect 'not a host!'
[OK] Server set to not a host!:443
[!] "not a host!" does not resolve from here — saved anyway.
```

A hostname with spaces and `!` can never be valid, yet it was persisted with only a resolve *warning* — and then every subsequent transfer failed with E001 until the user figured out why.

## Fix

`normalizeServer` now validates the host: IP literals pass; otherwise labels must be non-empty, not hyphen-edged, and drawn from `[a-zA-Z0-9-_]` (underscore kept — invalid DNS but common on LANs; FQDN trailing dot tolerated). Impossible hosts fail fast as E024. Well-formed names that merely don't resolve keep today's warn-but-save behavior (offline use, split-horizon DNS).

```
$ fsend --connect 'not a host!'
[FAIL] [E024] Invalid usage.
  invalid server hostname "not a host!"
```

## Validation

Live before/after above; typo'd-but-well-formed names still warn+save. Extended `TestNormalizeServer` with 7 reject cases and 3 accept cases. `go test ./cmd/fsend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)