### PR TITLE
fix(cli): say what the ~15s code-not-found retry window is doing

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -190,10 +190,16 @@ func classifyRelayDrop(ctx context.Context, client *signaling.Client, sessionID,
 // E003), not E017 — a mistyped code must not surface as "too many
 // attempts".
 func joinWithRetry(ctx context.Context, client *signaling.Client, code string, f *flags, existing *uxlog.Spinner) (*server.JoinSessionResponse, error) {
+	// The retry window can run the full budget (~15 s); a spinner stuck on
+	// the caller's "Connecting" for that long reads as a network problem.
+	// Say what we're actually doing — holding for the sender's Create.
+	const waitMsg = "Waiting for the sender to publish this code"
+
 	deadline := time.Now().Add(joinRetryBudget)
 	delay := 500 * time.Millisecond
 	var lastRetryable error
 	var spin *uxlog.Spinner
+	retitled := false
 	// Close over the variable so a spinner started inside the loop is
 	// still Stopped on return — a plain `defer spin.Stop()` would only
 	// stop the nil pointer captured at defer-time.
@@ -201,6 +207,11 @@ func joinWithRetry(ctx context.Context, client *signaling.Client, code string, f
 	for {
 		joined, err := client.Join(ctx, code)
 		if err == nil {
+			if retitled {
+				// The caller's spinner keeps running through ICE/relay setup;
+				// hand it back with its original label.
+				existing.SetMessage("Connecting")
+			}
 			return joined, nil
 		}
 		if lastRetryable != nil && errors.Is(err, fserrors.ErrRateLimited) {
@@ -211,12 +222,17 @@ func joinWithRetry(ctx context.Context, client *signaling.Client, code string, f
 			return nil, err
 		}
 		lastRetryable = err
-		// Animate a single line for the duration of the wait so the
-		// user knows we're holding for the sender rather than stuck.
-		// If the caller already gave us a running spinner, leave it
-		// alone — two spinners would fight each other on stderr.
-		if spin == nil && existing == nil && !f.quiet {
-			spin = uxlog.StartSpinner("Waiting for sender")
+		// Animate a single line for the duration of the wait so the user
+		// knows we're holding for the sender rather than stuck. A caller-
+		// owned spinner is retitled in place — starting a second one would
+		// fight it on stderr.
+		if !retitled && !f.quiet {
+			if existing != nil {
+				existing.SetMessage(waitMsg)
+			} else if spin == nil {
+				spin = uxlog.StartSpinner(waitMsg)
+			}
+			retitled = existing != nil
 		}
 		select {
 		case <-ctx.Done():

--- a/cmd/fsend/internet_test.go
+++ b/cmd/fsend/internet_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/polius/fsend/internal/fserrors"
 	"github.com/polius/fsend/internal/server"
 	"github.com/polius/fsend/internal/signaling"
+	"github.com/polius/fsend/internal/uxlog"
 )
 
 // joinWithRetry must succeed when the sender Creates after the receiver
@@ -332,5 +333,49 @@ func TestJoinWithRetry_GivesUpOnClaimedAfterBudget(t *testing.T) {
 	_, err := joinWithRetry(ctx, signaling.New(baseURL, "test"), code, &flags{quiet: true}, nil)
 	if !errors.Is(err, fserrors.ErrCodeAlreadyClaimed) {
 		t.Errorf("expected ErrCodeAlreadyClaimed after budget, got %v", err)
+	}
+}
+
+// During the retry window the caller's "Connecting" spinner must be
+// retitled to say we're holding for the sender — 15 s of "Connecting"
+// reads as a network problem — and restored once the join succeeds.
+func TestJoinWithRetry_RetitlesCallerSpinner(t *testing.T) {
+	srv, baseURL := newSignalingTestServer(t)
+	_ = srv
+	senderClient := signaling.New(baseURL, "test")
+	receiverClient := signaling.New(baseURL, "test")
+	code := "abc-defg-jkm"
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	stderr := captureStderr(t, func() {
+		spin := uxlog.StartSpinner("Connecting")
+		defer spin.Stop()
+
+		var wg sync.WaitGroup
+		var joinErr error
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, joinErr = joinWithRetry(ctx, receiverClient, code, &flags{}, spin)
+		}()
+		time.Sleep(700 * time.Millisecond) // give the retry loop a cycle
+		if _, err := senderClient.Create(ctx, code); err != nil {
+			t.Errorf("Create: %v", err)
+		}
+		wg.Wait()
+		if joinErr != nil {
+			t.Errorf("join should succeed once sender Created, got %v", joinErr)
+		}
+	})
+
+	// Non-TTY spinner: each message shows up as its own static line.
+	waitIdx := strings.Index(stderr, "Waiting for the sender to publish this code")
+	if waitIdx < 0 {
+		t.Fatalf("spinner never retitled during retry window:\n%s", stderr)
+	}
+	if restored := strings.LastIndex(stderr, "Connecting"); restored < waitIdx {
+		t.Errorf("spinner not restored to Connecting after join:\n%s", stderr)
 	}
 }

--- a/internal/uxlog/spinner.go
+++ b/internal/uxlog/spinner.go
@@ -26,6 +26,7 @@ import (
 // Stop clears the spinner line so the next stderr write starts at column 0.
 // On non-TTY the static line stays in place — Stop is a no-op visually.
 type Spinner struct {
+	mu   sync.Mutex
 	msg  string
 	w    io.Writer
 	tty  bool
@@ -95,12 +96,32 @@ func (s *Spinner) run() {
 // glyphs; on a dark background it reads as "active wait" without
 // shouting like a yellow warn would.
 func (s *Spinner) draw(frame string) {
+	s.mu.Lock()
+	msg := s.msg
+	s.mu.Unlock()
 	// Stderr write failures inside the UX layer are non-actionable —
 	// the caller has bigger problems than an unrendered spinner.
 	if colorEnabled() {
-		_, _ = fmt.Fprintf(s.w, "\r\x1b[2K%s%s%s %s", colorCyan, frame, colorReset, s.msg)
+		_, _ = fmt.Fprintf(s.w, "\r\x1b[2K%s%s%s %s", colorCyan, frame, colorReset, msg)
 	} else {
-		_, _ = fmt.Fprintf(s.w, "\r\x1b[2K%s %s", frame, s.msg)
+		_, _ = fmt.Fprintf(s.w, "\r\x1b[2K%s %s", frame, msg)
+	}
+}
+
+// SetMessage swaps the spinner text; the next frame draws it. On non-TTY,
+// where the original message was already printed as a static line, the new
+// message is printed the same way so log readers see the state change.
+// Safe on a nil receiver.
+func (s *Spinner) SetMessage(msg string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	changed := msg != s.msg
+	s.msg = msg
+	s.mu.Unlock()
+	if !s.tty && changed {
+		_, _ = fmt.Fprintln(s.w, Marker(gSpin), msg)
 	}
 }
 

--- a/internal/uxlog/spinner_test.go
+++ b/internal/uxlog/spinner_test.go
@@ -64,3 +64,30 @@ func TestSpinner_DrawFormatIncludesEraseLine(t *testing.T) {
 		t.Fatalf("draw output missing message: %q", out)
 	}
 }
+
+func TestSpinner_SetMessage(t *testing.T) {
+	// Nil-safe, like Stop.
+	var nilSpin *Spinner
+	nilSpin.SetMessage("x")
+
+	// Non-TTY: the new message is printed as a fresh static line so log
+	// readers see the state change; a same-message call prints nothing.
+	var buf bytes.Buffer
+	s := &Spinner{msg: "first", w: &buf}
+	s.SetMessage("second")
+	if got := buf.String(); !strings.Contains(got, "second") {
+		t.Errorf("non-TTY SetMessage should print the new line, got %q", got)
+	}
+	before := buf.Len()
+	s.SetMessage("second")
+	if buf.Len() != before {
+		t.Errorf("unchanged message must not reprint: %q", buf.String())
+	}
+
+	// The next draw uses the new message.
+	buf.Reset()
+	s.draw("⠋")
+	if got := buf.String(); !strings.Contains(got, "second") || strings.Contains(got, "first") {
+		t.Errorf("draw after SetMessage = %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

A wrong (or not-yet-created) code takes ~15 s to fail — deliberate (it papers over the receiver-beats-sender race and keeps the join schedule sparse against code probing). But the whole time the user stares at:

```
[*] Connecting          ← for 15 seconds
[FAIL] [E002] That code was not found.
```

which reads as a network problem. `joinWithRetry` already had a better message, but only when it started its own spinner — the receive path always passes its "Connecting" spinner in, so the honest message never showed.

## Fix

- `uxlog.Spinner.SetMessage` (new, mutex-guarded, nil-safe; on non-TTY prints the new message as a static line so logs record the state change).
- `joinWithRetry` retitles the caller's spinner during the retry window and restores "Connecting" once the join succeeds (the spinner keeps running through ICE/relay setup).

```
[*] Connecting
[*] Waiting for the sender to publish this code
[FAIL] [E002] That code was not found.
```

No change to the retry schedule or budget.

## Validation

- Live: unknown code shows the wait message during the window (output above); late-arriving sender restores "Connecting".
- New tests: `TestSpinner_SetMessage` (uxlog, incl. -race), `TestJoinWithRetry_RetitlesCallerSpinner` (retitle + restore against the signaling test server).
- `go test ./cmd/fsend ./internal/uxlog` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)