### PR TITLE
fix(cli): keep the text summary off the payload line on shared sinks

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -822,6 +822,41 @@ func TestPromptAccept_YesWarnsAboutKeptDiffers(t *testing.T) {
 	}
 }
 
+// A text payload with no trailing newline must not let the stderr summary
+// butt against it when both streams share a sink (2>&1, CI logs) — the line
+// break goes to stderr, keeping the piped stdout bytes exact.
+func TestPrintTextPayload_BreaksLineForPipedStdout(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "payload")
+	if err := os.WriteFile(path, []byte("no-newline"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	var stdout string
+	stderr := captureStderr(t, func() {
+		stdout = captureStdout(t, func() {
+			if err := printTextPayload([]string{path}); err != nil {
+				t.Errorf("printTextPayload: %v", err)
+			}
+		})
+	})
+	if stdout != "no-newline" {
+		t.Errorf("piped stdout must carry the exact bytes, got %q", stdout)
+	}
+	if stderr != "\n" {
+		t.Errorf("expected a line break on stderr, got %q", stderr)
+	}
+
+	// A newline-terminated payload needs no break.
+	if err := os.WriteFile(path, []byte("clean\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	stderr = captureStderr(t, func() {
+		_ = captureStdout(t, func() { _ = printTextPayload([]string{path}) })
+	})
+	if stderr != "" {
+		t.Errorf("newline-terminated payload must not emit a break, got %q", stderr)
+	}
+}
+
 func TestSummaryParts_ResumeShowsMovedAndHonestRate(t *testing.T) {
 	// 200 MB total, 50 MB moved in 1s → size annotated with the moved
 	// clause and the rate computed from moved, not total.

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -385,8 +385,15 @@ func printTextPayload(files []string) error {
 	if _, err := os.Stdout.Write(b); err != nil {
 		return err
 	}
-	if len(b) > 0 && b[len(b)-1] != '\n' && term.IsTerminal(int(os.Stdout.Fd())) {
-		fmt.Println()
+	if len(b) > 0 && b[len(b)-1] != '\n' {
+		if term.IsTerminal(int(os.Stdout.Fd())) {
+			fmt.Println()
+		} else {
+			// stdout is piped, so its bytes must stay exact — but when
+			// stderr shares the sink (2>&1, CI logs) the summary line would
+			// butt against the payload. Break the line on stderr instead.
+			fmt.Fprintln(os.Stderr)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

Receiving `--text` whose payload lacks a trailing newline, with stdout and stderr going to the same sink (`2>&1`, CI logs):

```
wifi: hunter2[OK] Received text  ·  13 B  ·  7ms  ·  Direct on local network
```

On a real TTY this was already handled (a cosmetic newline is printed to stdout when it's a terminal); the piped case wasn't.

## Fix

When stdout is **not** a TTY and the payload lacks a trailing newline, emit the line break on **stderr** — the piped stdout bytes stay exact (`fsend <code> > note.txt` is unchanged), and a shared log renders:

```
no-trailing-newline
[OK] Received text  ·  19 B  ·  8ms  ·  Direct on local network
```

Cost: at most one blank stderr line when the streams don't share a sink.

## Validation

- Live shared-sink repro before/after (above); TTY behavior verified unchanged via `script(1)`.
- New unit test `TestPrintTextPayload_BreaksLineForPipedStdout` (exact stdout bytes + stderr break; no break when newline-terminated).
- `go test ./cmd/fsend` green (incl. `TestSend_TextLiteral` e2e stdout-exactness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)