### PR TITLE
fix(cli): give a --manifest write failure its own error (E038)

### DIFF
--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -119,7 +119,8 @@ func renderError(err error, debug bool) int {
 		errors.Is(err, fserrors.ErrRelayIdleTimeout) ||
 		errors.Is(err, fserrors.ErrServerStartup) ||
 		errors.Is(err, fserrors.ErrUpdateFailed) ||
-		errors.Is(err, fserrors.ErrUninstallFailed)) {
+		errors.Is(err, fserrors.ErrUninstallFailed) ||
+		errors.Is(err, fserrors.ErrManifestWriteFailed)) {
 		if extra := extractDetail(err.Error()); extra != "" {
 			detail = extra
 		}

--- a/cmd/fsend/preview_test.go
+++ b/cmd/fsend/preview_test.go
@@ -151,12 +151,18 @@ func TestOnManifest_WritesCSV(t *testing.T) {
 }
 
 func TestOnManifest_WriteError(t *testing.T) {
-	// Parent directory doesn't exist → os.Create fails.
+	// Parent directory doesn't exist → os.Create fails. The error must be
+	// E038 (manifest-specific: the transfer itself succeeded — E009's "try
+	// --out" advice would point at the wrong path) and must carry the
+	// manifest path so the user knows which file failed.
 	path := filepath.Join(t.TempDir(), "no-such-dir", "m.csv")
 	ui := &receiverUI{f: &flags{manifest: path}}
 	ui.onManifest([]transfer.ManifestEntry{{RelativePath: "a", Size: 1, Status: "new"}})
-	if !errors.Is(ui.manifestErr, fserrors.ErrWriteFailed) {
-		t.Errorf("manifestErr = %v, want wrapping ErrWriteFailed", ui.manifestErr)
+	if !errors.Is(ui.manifestErr, fserrors.ErrManifestWriteFailed) {
+		t.Errorf("manifestErr = %v, want wrapping ErrManifestWriteFailed", ui.manifestErr)
+	}
+	if ui.manifestErr == nil || !strings.Contains(ui.manifestErr.Error(), path) {
+		t.Errorf("manifestErr should name the manifest path: %v", ui.manifestErr)
 	}
 }
 

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -273,7 +273,7 @@ func (ui *receiverUI) onConflictKept(string) {
 func (ui *receiverUI) onManifest(entries []transfer.ManifestEntry) {
 	f, err := os.Create(ui.f.manifest)
 	if err != nil {
-		ui.manifestErr = fmt.Errorf("%w: --manifest %s: %v", fserrors.ErrWriteFailed, ui.f.manifest, err)
+		ui.manifestErr = fmt.Errorf("%w: %v", fserrors.ErrManifestWriteFailed, err)
 		return
 	}
 	defer func() { _ = f.Close() }()
@@ -284,7 +284,7 @@ func (ui *receiverUI) onManifest(entries []transfer.ManifestEntry) {
 	}
 	cw.Flush()
 	if err := cw.Error(); err != nil {
-		ui.manifestErr = fmt.Errorf("%w: --manifest %s: %v", fserrors.ErrWriteFailed, ui.f.manifest, err)
+		ui.manifestErr = fmt.Errorf("%w: %s: %v", fserrors.ErrManifestWriteFailed, ui.f.manifest, err)
 	}
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -309,6 +309,7 @@ failure. For what to *do* about a given error, see
 | `33`  | `E033` — `fsend --update` could not complete. |
 | `34`  | `E034` — the other device is running an incompatible fsend version. |
 | `35`  | `E035` — `fsend --uninstall` could not remove the binary. |
+| `38`  | `E038` — files received, but the `--manifest` record could not be written. |
 | `99`  | `E099` — unexpected error. Run with `--debug` and file an issue. |
 | `130` | `E026` — cancelled by user (Ctrl-C / SIGTERM). |
 

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -128,6 +128,11 @@ var (
 	// pointed-to content, so an unresolvable link is a hard stop (with the
 	// path, so the user can fix or --exclude it).
 	ErrUnsendableSymlink = errors.New("unsendable symlink")
+	// E038 — the transfer succeeded but the --manifest record could not be
+	// written. Distinct from E009 (a failed *file* write): the data landed,
+	// only the sidecar CSV is missing, so the fix is the manifest path —
+	// not --out.
+	ErrManifestWriteFailed = errors.New("manifest write failed")
 )
 
 // Entry is one row of the user-facing error catalog.
@@ -428,6 +433,11 @@ var catalog = map[error]Entry{
 		Code: "E036", Exit: 36,
 		Message: "Cannot send a symlink",
 		Action:  "Fix the link, or skip it with --exclude.",
+	},
+	ErrManifestWriteFailed: {
+		Code: "E038", Exit: 38,
+		Message: "Files received, but the --manifest record could not be written.",
+		Action:  "Check that the --manifest path is writable.",
 	},
 }
 

--- a/internal/fserrors/fserrors_test.go
+++ b/internal/fserrors/fserrors_test.go
@@ -118,6 +118,7 @@ func TestNewSentinels_LookupAndExit(t *testing.T) {
 		{ErrUserCancelled, "E026", 130},
 		{ErrRelayIdleTimeout, "E029", 29},
 		{ErrRelayBudgetExhausted, "E037", 37},
+		{ErrManifestWriteFailed, "E038", 38},
 	}
 	for _, c := range cases {
 		entry, ok := Lookup(c.err)


### PR DESCRIPTION
## Problem

When the transfer succeeded but the `--manifest` CSV couldn't be written:

```
[FAIL] [E009] Could not write to the target file.
  Try --out <dir> to save somewhere writable.
```

Three things wrong: the received files landed fine (the message implies they didn't), `--out` is the wrong knob (the manifest path is the problem), and the `--manifest <path>` context was silently dropped (`ErrWriteFailed` isn't in `renderError`'s detail allow-list).

## Fix

New catalog entry **E038** (exit 38), in the allow-list so the cause line surfaces:

```
[FAIL] [E038] Files received, but the --manifest record could not be written.
  open /no-such-dir/m.csv: no such file or directory
  Check that the --manifest path is writable.
```

Exit-code table row added to docs/usage.md. E009 keeps its meaning for real target-file write failures.

## Validation

- Live repro before/after (above), exit code 38.
- Updated `TestOnManifest_WriteError` (sentinel + path in message), `TestNewSentinels_LookupAndExit` (+E038 row); the catalog's unique-code test covers the new entry.
- `go test ./internal/fserrors ./cmd/fsend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)