### PR TITLE
fix(server): health-check probe failure exits 1, not the E099 catchall

### DIFF
--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -50,7 +50,14 @@ func serverCmd() *cobra.Command {
 		RunE: func(_ *cobra.Command, _ []string) error {
 			if healthCheckFlag {
 				// Used as a Docker HEALTHCHECK probe — see deploy/compose/.
-				return healthCheck()
+				// An unreachable server is the routine result a probe exists
+				// to detect, not an fsend bug: one line, exit 1 as documented
+				// — never the E099 "file an issue" catchall (exit 99).
+				if err := healthCheck(); err != nil {
+					fmt.Fprintln(os.Stderr, uxlog.Cross(), err)
+					os.Exit(1)
+				}
+				return nil
 			}
 			return runServer()
 		},
@@ -447,8 +454,8 @@ func envBytes(name string, def uint64) (uint64, error) {
 }
 
 // healthCheck pings the local server's /v1/health on the configured
-// HTTP address. Exits 0 on healthy, 1 on anything else. Designed for
-// Docker HEALTHCHECK.
+// HTTP address. Returns an error when unhealthy; the caller reports it
+// and exits 1 (the Docker HEALTHCHECK contract).
 func healthCheck() error {
 	addr := envOr(envServerAddr, defaultServerAddr)
 	if strings.HasPrefix(addr, ":") {

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -1,6 +1,8 @@
 package e2e
 
 import (
+	"errors"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -88,6 +90,33 @@ func TestServer_HealthCheck(t *testing.T) {
 	cmd.Env = append(os.Environ(), "FSEND_SERVER_ADDR=:"+strconv.Itoa(h.httpPort))
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("--health-check exit: %v", err)
+	}
+}
+
+// An unreachable server is the routine result a health probe exists to
+// detect: exit 1 (the documented Docker HEALTHCHECK contract) with a
+// one-line reason — never the E099 "file an issue" catchall (exit 99).
+func TestServer_HealthCheckUnreachableExitsOne(t *testing.T) {
+	requireE2E(t)
+	cmd := exec.Command(h.fsendBin, "server", "--health-check")
+	// A port nothing listens on: bind+close to reserve a known-free one.
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	_ = l.Close()
+	cmd.Env = append(os.Environ(), "FSEND_SERVER_ADDR=127.0.0.1:"+strconv.Itoa(port))
+	out, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("expected a nonzero exit, got err=%v\n%s", err, out)
+	}
+	if code := exitErr.ExitCode(); code != 1 {
+		t.Errorf("exit = %d, want 1\n%s", code, out)
+	}
+	if strings.Contains(string(out), "E099") || strings.Contains(string(out), "issue") {
+		t.Errorf("routine probe failure must not route to the E099 catchall:\n%s", out)
 	}
 }
 


### PR DESCRIPTION
## Problem

`fsend server --health-check` against a server that isn't up (exactly what a Docker HEALTHCHECK probes for) told the operator to file a GitHub bug and exited 99:

```
[FAIL] [E099] Unexpected error: health: dial tcp 127.0.0.1:8080: connection refused
  Re-run with --debug and include the output when filing the issue: …
```

…while `healthCheck`'s own doc comment promised "exits 0 on healthy, 1 on anything else". Docker only checks nonzero, so it *worked*, but both the messaging and the documented exit code were wrong.

## Fix

The probe failure is reported in one line and exits 1, per the documented contract:

```
[FAIL] health: Get "http://127.0.0.1:19999/v1/health": dial tcp …: connection refused
(exit 1)
```

Doc comment updated to match.

## Validation

- Live: dead port → one line, exit 1; healthy server → silent, exit 0.
- New e2e `TestServer_HealthCheckUnreachableExitsOne` (exit code 1, no "E099"/"issue" text); existing healthy-path and stub-status unit tests unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)