### PR TITLE
fix(cli): refuse --update/--uninstall on a Homebrew-managed binary

### DIFF
--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -118,7 +118,8 @@ func renderError(err error, debug bool) int {
 		errors.Is(err, fserrors.ErrRelayCapHit) ||
 		errors.Is(err, fserrors.ErrRelayIdleTimeout) ||
 		errors.Is(err, fserrors.ErrServerStartup) ||
-		errors.Is(err, fserrors.ErrUpdateFailed)) {
+		errors.Is(err, fserrors.ErrUpdateFailed) ||
+		errors.Is(err, fserrors.ErrUninstallFailed)) {
 		if extra := extractDetail(err.Error()); extra != "" {
 			detail = extra
 		}

--- a/cmd/fsend/selfupdate.go
+++ b/cmd/fsend/selfupdate.go
@@ -24,6 +24,22 @@ func runUpdate() error {
 		return fmt.Errorf("%w: this is a dev build with no release to compare against", fserrors.ErrUpdateFailed)
 	}
 
+	binPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("%w: locating the fsend binary: %v", fserrors.ErrUpdateFailed, err)
+	}
+	// Resolve symlinks so the install lands on the real binary and an
+	// on-PATH `~/.local/bin/fsend → /opt/fsend/fsend` link keeps working.
+	if resolved, rerr := filepath.EvalSymlinks(binPath); rerr == nil && resolved != "" {
+		binPath = resolved
+	}
+	// A brew-managed binary must not be overwritten behind brew's back —
+	// the Cellar file would diverge from the formula's metadata and the
+	// next `brew upgrade` would fight it. Checked before any network work.
+	if managedByHomebrew(binPath) {
+		return fmt.Errorf("%w: this fsend was installed with Homebrew — update it with: brew upgrade fsend", fserrors.ErrUpdateFailed)
+	}
+
 	fmt.Fprintln(os.Stderr, "  Checking the latest release...")
 	latest, ok := update.Latest(context.Background())
 	if !ok {
@@ -34,19 +50,22 @@ func runUpdate() error {
 		return nil
 	}
 
-	binPath, err := os.Executable()
-	if err != nil {
-		return fmt.Errorf("%w: locating the fsend binary: %v", fserrors.ErrUpdateFailed, err)
-	}
-	// Resolve symlinks so the install lands on the real binary and an
-	// on-PATH `~/.local/bin/fsend → /opt/fsend/fsend` link keeps working.
-	if resolved, rerr := filepath.EvalSymlinks(binPath); rerr == nil && resolved != "" {
-		binPath = resolved
-	}
-
 	fmt.Fprintf(os.Stderr, "  Updating fsend %s → %s in %s\n", current, latest, filepath.Dir(binPath))
 	if err := runInstaller(binPath); err != nil {
 		return fmt.Errorf("%w: %v", fserrors.ErrUpdateFailed, err)
 	}
 	return nil
+}
+
+// managedByHomebrew reports whether the (symlink-resolved) binary lives
+// in a Homebrew prefix. Only brew is detected: its paths are unambiguous,
+// and the project ships a brew tap so it's the real-world case — the
+// curl script, go install, and hand-placed binaries stay self-managed.
+func managedByHomebrew(binPath string) bool {
+	for _, marker := range []string{"/Cellar/", "/homebrew/", "/linuxbrew/"} {
+		if strings.Contains(binPath, marker) {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/fsend/selfupdate_test.go
+++ b/cmd/fsend/selfupdate_test.go
@@ -24,3 +24,24 @@ func TestRunUpdate_DevBuildRefused(t *testing.T) {
 		t.Errorf("got %q, want a dev-build explanation", err.Error())
 	}
 }
+
+func TestManagedByHomebrew(t *testing.T) {
+	for _, managed := range []string{
+		"/opt/homebrew/Cellar/fsend/1.9.1/bin/fsend",
+		"/usr/local/Cellar/fsend/1.9.1/bin/fsend",
+		"/home/linuxbrew/.linuxbrew/bin/fsend",
+	} {
+		if !managedByHomebrew(managed) {
+			t.Errorf("managedByHomebrew(%q) = false, want true", managed)
+		}
+	}
+	for _, own := range []string{
+		"/usr/local/bin/fsend", // curl-script default
+		"/home/u/go/bin/fsend", // go install
+		"/opt/fsend/fsend",
+	} {
+		if managedByHomebrew(own) {
+			t.Errorf("managedByHomebrew(%q) = true, want false", own)
+		}
+	}
+}

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -18,6 +18,18 @@ import (
 // Config dir first because it's always writable; binary may live in a
 // privileged directory and need the user to escalate by hand.
 func runUninstall(f *flags) error {
+	// A brew-managed binary belongs to brew: deleting it strands the
+	// formula's metadata and `brew list/upgrade` keep believing it's
+	// installed. Refuse before even asking for confirmation.
+	if binPath, err := os.Executable(); err == nil {
+		if resolved, rerr := filepath.EvalSymlinks(binPath); rerr == nil && resolved != "" {
+			binPath = resolved
+		}
+		if managedByHomebrew(binPath) {
+			return fmt.Errorf("%w: this fsend was installed with Homebrew — uninstall it with: brew uninstall fsend", fserrors.ErrUninstallFailed)
+		}
+	}
+
 	if !confirmUninstall(f) {
 		fmt.Fprintln(os.Stderr, "  Uninstall cancelled.")
 		return nil


### PR DESCRIPTION
## Problem

The project ships a brew tap, but `--update`/`--uninstall` were blind to it:

- `--update` resolved `os.Executable()` and re-ran the curl installer with `PREFIX` inside the Cellar — overwriting a brew-managed file that diverges from the formula and fights the next `brew upgrade`.
- `--uninstall` deleted the Cellar binary out from under brew's metadata (`brew list` still believes it's installed), after already removing the config dir.

## Fix

`managedByHomebrew` checks the symlink-resolved binary path for the unambiguous brew markers (`/Cellar/`, `/homebrew/`, `/linuxbrew/`) — only brew is detected; curl-script, `go install`, and hand-placed binaries stay self-managed.

```
$ fsend --update      # from a Cellar path
[FAIL] [E033] Could not update fsend.
  this fsend was installed with Homebrew — update it with: brew upgrade fsend

$ fsend --uninstall
[FAIL] [E035] fsend was not fully uninstalled.
  this fsend was installed with Homebrew — uninstall it with: brew uninstall fsend
```

Update refuses **before any network work**; uninstall refuses **before the confirmation prompt and config-dir removal** (nothing is touched). `ErrUninstallFailed` joined the detail allow-list so the hint surfaces.

## Validation

- Live: binary copied into a fake `Cellar/…/bin` path → both commands refuse with exits 33/35, binary and config untouched; normal paths unaffected.
- New unit test `TestManagedByHomebrew` (3 managed + 3 self-managed paths).
- `go test ./cmd/fsend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)