### PR TITLE
fix(cli): let --receive tolerate capitalized or whitespace-wrapped codes

### DIFF
--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -594,6 +594,12 @@ func startReceive(f *flags, c string) error {
 	if f.preview {
 		return fmt.Errorf("%w: --preview is a send-side flag and has no effect when receiving", fserrors.ErrUsage)
 	}
+	// An explicit --receive deserves the same tolerance auto-detect has
+	// for chat-app mangling (auto-capitalized first letter, copied
+	// whitespace) — the more explicit user must not get the worse E004.
+	if t := strings.ToLower(strings.TrimSpace(c)); t != c && code.IsCode(t) {
+		c = t
+	}
 	return runReceive(f, c)
 }
 

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -322,3 +322,25 @@ func TestHelpTemplate_ListsEveryFlag(t *testing.T) {
 		}
 	})
 }
+
+// An explicit --receive must tolerate the same chat-app mangling
+// (auto-capitalized first letter, wrapped whitespace) that auto-detect
+// already fixes up — not fail E004 where the implicit path would work.
+// The probe uses --quiet without --yes: a code that survives validation
+// hits that usage guard (E024) before any network work, so E004-vs-E024
+// distinguishes "rejected by format" from "normalized and accepted".
+func TestStartReceive_NormalizesMangledCodes(t *testing.T) {
+	for _, mangled := range []string{"Abc-Defg-Jkm", "ABC-DEFG-JKM", " abc-defg-jkm\n"} {
+		err := startReceive(&flags{quiet: true}, mangled)
+		if errors.Is(err, fserrors.ErrInvalidCodeFormat) {
+			t.Errorf("startReceive(%q) rejected a normalizable code: %v", mangled, err)
+		}
+		if !errors.Is(err, fserrors.ErrUsage) {
+			t.Errorf("startReceive(%q) = %v, want the quiet-without-yes usage guard", mangled, err)
+		}
+	}
+	// Genuinely invalid stays E004.
+	if err := startReceive(&flags{quiet: true}, "Not-A-Code-At-All"); !errors.Is(err, fserrors.ErrInvalidCodeFormat) {
+		t.Errorf("invalid code should stay E004, got %v", err)
+	}
+}


### PR DESCRIPTION
## Problem

`fsend Abc-Defg-Jkm` (auto-detect) fixes up chat-app capitalization and stray whitespace and receives fine — but `fsend --receive Abc-Defg-Jkm` failed with E004 "Invalid code format". The more explicit invocation got the worse behavior.

## Fix

`startReceive` applies the same normalization rule auto-detect uses: lowercase + trim, only when the result is a valid code. Genuinely invalid input stays E004.

## Validation

- Live: `--receive Ezh-jjpj-dym` (capitalized) now completes the transfer.
- New unit test `TestStartReceive_NormalizesMangledCodes` — uses the `--quiet`-without-`--yes` guard as a network-free probe to distinguish "rejected by format" (E004) from "normalized and accepted" (E024), plus an invalid-stays-E004 case.
- `go test ./cmd/fsend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)