### PR TITLE
fix(cli): explain what Ctrl-C does — force-quit hint and partial-kept notice

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -875,6 +875,27 @@ func TestPrintTextPayload_BreaksLineForPipedStdout(t *testing.T) {
 	}
 }
 
+// The cancel hint fires only when bytes actually landed — a Ctrl-C at
+// the accept prompt has no partial to speak of — and stays out of --quiet.
+func TestPrintCancelKeptHint(t *testing.T) {
+	moved := newReceiverUI(context.Background(), &flags{}, "/tmp", false, mustLANInfo())
+	moved.total = 1024
+	if got := captureStderr(t, func() { printCancelKeptHint(moved.f, moved) }); !strings.Contains(got, "Partial data kept") {
+		t.Errorf("expected resume hint after moved bytes, got %q", got)
+	}
+
+	idle := newReceiverUI(context.Background(), &flags{}, "/tmp", false, mustLANInfo())
+	if got := captureStderr(t, func() { printCancelKeptHint(idle.f, idle) }); got != "" {
+		t.Errorf("no bytes moved must print nothing, got %q", got)
+	}
+
+	quiet := newReceiverUI(context.Background(), &flags{quiet: true}, "/tmp", false, mustLANInfo())
+	quiet.total = 1024
+	if got := captureStderr(t, func() { printCancelKeptHint(quiet.f, quiet) }); got != "" {
+		t.Errorf("--quiet must suppress the hint, got %q", got)
+	}
+}
+
 func TestSummaryParts_ResumeShowsMovedAndHonestRate(t *testing.T) {
 	// 200 MB total, 50 MB moved in 1s → size annotated with the moved
 	// clause and the rate computed from moved, not total.

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -437,6 +437,7 @@ func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code 
 		// A Ctrl-C at an interactive prompt cancels ctx but surfaces as a
 		// decline/target-exists error; report it as a cancellation (E026).
 		if ctx.Err() != nil {
+			printCancelKeptHint(f, ui)
 			return ctx.Err()
 		}
 		return err

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -54,7 +54,7 @@ func runReceive(f *flags, c string) error {
 	// resolvePassword reads with echo off, and a default-disposition
 	// SIGINT inside that read would kill the process without restoring
 	// the terminal.
-	ctx, cancel := signalContext()
+	ctx, cancel := signalContext(f.quiet)
 	defer cancel()
 
 	// Bare --password: hidden no-echo prompt. We're not the password's
@@ -149,6 +149,7 @@ func runReceive(f *flags, c string) error {
 		// decline/target-exists error from the engine; report it as a
 		// cancellation (E026) rather than that incidental error.
 		if ctx.Err() != nil {
+			printCancelKeptHint(f, ui)
 			return ctx.Err()
 		}
 		return err

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -315,6 +315,18 @@ func (ui *receiverUI) bytes() (total, moved int64) {
 	return ui.total + ui.skipped, ui.total
 }
 
+// printCancelKeptHint tells a Ctrl-C'd receiver that its partial data
+// survives and how the transfer resumes. E026 itself is context-free
+// ("Cancelled.") — only the UI knows whether bytes had already landed.
+func printCancelKeptHint(f *flags, ui *receiverUI) {
+	if f.quiet {
+		return
+	}
+	if _, moved := ui.bytes(); moved > 0 {
+		fmt.Fprintf(os.Stderr, "%s Partial data kept — when the sender runs fsend again, the transfer resumes here.\n", uxlog.Info())
+	}
+}
+
 func (ui *receiverUI) close() {
 	ui.closeOnce.Do(func() {
 		ui.mu.Lock()

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -58,7 +58,7 @@ func runSend(f *flags, paths []string) error {
 		}
 	}
 
-	ctx, cancel := signalContext()
+	ctx, cancel := signalContext(f.quiet)
 	defer cancel()
 
 	if err := resolvePassword(ctx, f, true); err != nil {
@@ -393,14 +393,19 @@ func displayPath(p string) string {
 }
 
 // signalContext wires Ctrl-C / SIGTERM to ctx cancellation; a second signal
-// reverts to the default disposition and terminates outright.
-func signalContext() (context.Context, context.CancelFunc) {
+// reverts to the default disposition and terminates outright. Teardown
+// (session delete, QUIC close) can take a few seconds, so the first
+// signal says so — otherwise the pause reads as a hang.
+func signalContext(quiet bool) (context.Context, context.CancelFunc) {
 	ctx, cancel := context.WithCancel(context.Background())
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-ch
 		cancel()
+		if !quiet {
+			fmt.Fprintf(os.Stderr, "\n%s Cancelling — press Ctrl-C again to force quit.\n", uxlog.Info())
+		}
 		signal.Stop(ch)
 	}()
 	return ctx, cancel

--- a/test/e2e/signal_test.go
+++ b/test/e2e/signal_test.go
@@ -292,6 +292,15 @@ func TestSignal_ReceiverSIGINTRerunSameCode(t *testing.T) {
 	}
 	_ = r1.Wait()
 
+	// The interrupt must explain itself: the force-quit escape hatch and
+	// the fact that the partial survives for the resume exercised below.
+	if !strings.Contains(r1Err.String(), "press Ctrl-C again to force quit") {
+		t.Errorf("no force-quit hint on first SIGINT\n--- recv1 stderr ---\n%s", r1Err.String())
+	}
+	if !strings.Contains(r1Err.String(), "Partial data kept") {
+		t.Errorf("no partial-kept resume hint after mid-transfer SIGINT\n--- recv1 stderr ---\n%s", r1Err.String())
+	}
+
 	// The sender must go back to waiting rather than exit.
 	if !waitForStderr(s, "Receiver disconnected", 15*time.Second) {
 		t.Fatalf("sender never re-entered pairing\n--- sender stderr ---\n%s", s.stderr.String())


### PR DESCRIPTION
## Problem

Ctrl-C rendered a bare `[i] [E026] Cancelled.` The user never learned that (a) the up-to-3s teardown pause is expected (it reads as a hang), (b) a second Ctrl-C force-quits, or (c) the receiver's `.fsend-partial` survives and re-running the sender resumes the transfer. Interrupts are a trust moment; this one was a dead end.

## Fix

```
^C
[i] Cancelling — press Ctrl-C again to force quit.
[i] Partial data kept — when the sender runs fsend again, the transfer resumes here.
[i] [E026] Cancelled.
```

- The force-quit line prints on first SIGINT/SIGTERM in both roles (suppressed under `--quiet`); the second-signal force-quit behavior itself is unchanged.
- The partial-kept line prints only on the receiver, only when bytes actually landed — a Ctrl-C at the accept prompt stays silent about partials it doesn't have. Wired at both cancel-return sites (LAN and internet paths).

## Validation

- Live sender SIGINT while waiting (output above); receiver mid-transfer SIGINT exercised end-to-end by the extended e2e.
- `TestSignal_ReceiverSIGINTRerunSameCode` now asserts both hints on the interrupted receiver, then proves the promise by resuming on the same code.
- New unit test `TestPrintCancelKeptHint` (fires with bytes moved; silent with none; silent under `--quiet`).
- Full `go test ./cmd/fsend ./test/e2e` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)