### PR TITLE
fix(cli): overwrite prompt re-prompts on typos instead of silently keeping

### DIFF
--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -189,22 +189,29 @@ func (ui *receiverUI) promptAccept(h wire.SenderHello, summary transfer.Classify
 
 // confirmOverwrite is the consolidated prompt for differing/conflicting
 // entries. Returns true to overwrite all, false to keep all local copies.
+// Only "n"/"no"/bare-enter take the keep default; a mistyped "yes" must
+// re-prompt, not silently count as "no" — mirroring promptAccept. EOF
+// keeps the local copies but says so.
 func (ui *receiverUI) confirmOverwrite(conflicts []transfer.Conflict) bool {
 	const preview = 5
+	fmt.Fprintln(os.Stderr)
+	fmt.Fprintf(os.Stderr, "  %s %s from your local copies:\n",
+		uxlog.CountNoun(len(conflicts), "file"), differVerb(len(conflicts)))
+	shown := min(len(conflicts), preview)
+	for _, c := range conflicts[:shown] {
+		fmt.Fprintf(os.Stderr, "    %s\n", conflictLabel(c))
+	}
+	if more := len(conflicts) - shown; more > 0 {
+		fmt.Fprintf(os.Stderr, "    %s\n", uxlog.Dim(fmt.Sprintf("… and %d more", more)))
+	}
 	for {
-		fmt.Fprintln(os.Stderr)
-		fmt.Fprintf(os.Stderr, "  %s %s from your local copies:\n",
-			uxlog.CountNoun(len(conflicts), "file"), differVerb(len(conflicts)))
-		shown := min(len(conflicts), preview)
-		for _, c := range conflicts[:shown] {
-			fmt.Fprintf(os.Stderr, "    %s\n", conflictLabel(c))
-		}
-		if more := len(conflicts) - shown; more > 0 {
-			fmt.Fprintf(os.Stderr, "    %s\n", uxlog.Dim(fmt.Sprintf("… and %d more", more)))
-		}
 		fmt.Fprint(os.Stderr, "  Overwrite all? [y / N / l = list all] ")
-		line, _, ok := readLineCtx(ui.ctx)
+		line, eof, ok := readLineCtx(ui.ctx)
 		if !ok {
+			return false
+		}
+		if eof {
+			fmt.Fprintf(os.Stderr, "\n%s No input to answer the prompt — keeping your local copies.\n", uxlog.Info())
 			return false
 		}
 		switch line {
@@ -216,14 +223,15 @@ func (ui *receiverUI) confirmOverwrite(conflicts []transfer.Conflict) bool {
 			ui.bytesHint += ui.diffBytes
 			ui.mu.Unlock()
 			return true
+		case "", "n", "no":
+			return false
 		case "l", "list":
 			for _, c := range conflicts {
 				fmt.Fprintf(os.Stderr, "    %s\n", conflictLabel(c))
 			}
 			continue
-		default:
-			return false
 		}
+		fmt.Fprintln(os.Stderr, "  Please answer y or n (or l to list all).")
 	}
 }
 

--- a/test/e2e/transfer_test.go
+++ b/test/e2e/transfer_test.go
@@ -322,6 +322,49 @@ func TestReceive_OverwriteConfirmedInteractively(t *testing.T) {
 	assertFilesEqual(t, srcFile, filepath.Join(dst, "p.bin"))
 }
 
+// A typo at the overwrite prompt must re-prompt, not silently count as
+// "keep" — a mistyped "yes" ("yws") followed by a real "y" still
+// overwrites. Regression for the prompt's old catch-all-means-no default.
+func TestReceive_OverwritePromptRepromptsOnTypo(t *testing.T) {
+	requireE2E(t)
+	src, dst := t.TempDir(), t.TempDir()
+	srcFile := filepath.Join(src, "p.bin")
+	writeRandom(t, srcFile, 16*1024)
+	if err := os.WriteFile(filepath.Join(dst, "p.bin"), []byte("PREEXISTING"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := h.runPair(t, []string{srcFile}, dst, nil, "y\nyws\ny\n")
+	r.requireSuccess(t)
+	if !strings.Contains(r.receiverErr, "Please answer y or n") {
+		t.Errorf("typo did not re-prompt:\n%s", r.receiverErr)
+	}
+	assertFilesEqual(t, srcFile, filepath.Join(dst, "p.bin"))
+}
+
+// EOF at the overwrite prompt keeps the local copies and says so — the
+// old code fell into the silent catch-all.
+func TestReceive_OverwritePromptEOFKeepsAndExplains(t *testing.T) {
+	requireE2E(t)
+	src, dst := t.TempDir(), t.TempDir()
+	srcFile := filepath.Join(src, "p.bin")
+	writeRandom(t, srcFile, 16*1024)
+	if err := os.WriteFile(filepath.Join(dst, "p.bin"), []byte("PREEXISTING"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Stdin carries only the accept answer; it closes before the
+	// overwrite prompt reads.
+	r := h.runPair(t, []string{srcFile}, dst, nil, "y\n")
+	if r.receiverExitCode != 13 {
+		t.Errorf("receiver exit = %d, want 13 (kept conflict)\nstderr:\n%s", r.receiverExitCode, r.receiverErr)
+	}
+	if !strings.Contains(r.receiverErr, "keeping your local copies") {
+		t.Errorf("EOF keep was silent:\n%s", r.receiverErr)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dst, "p.bin")); string(got) != "PREEXISTING" {
+		t.Errorf("EOF must keep the local copy, got %q", got)
+	}
+}
+
 // Interactive: receiver declines the transfer at the accept prompt. With
 // the single-prompt flow, a single-file collision is disclosed inline as
 // a chip on the artifact line — so "accept the transfer but decline the


### PR DESCRIPTION
## Problem

The consolidated overwrite prompt (`Overwrite all? [y / N / l = list all]`) treated **any** unrecognized input as "keep all": a mistyped `yes` ("yws"), a stray character, or EOF all silently resolved to "no" with zero feedback — inconsistent with the accept prompt two lines above, which re-prompts on typos and explains EOF.

## Fix

- Only `n`/`no`/bare-enter take the keep default.
- Anything else re-prompts: `Please answer y or n (or l to list all).`
- EOF keeps the local copies and says so: `No input to answer the prompt — keeping your local copies.`
- The conflict list renders once; only the question line repeats (previously `l` re-rendered the whole block).

Ctrl-C at the prompt (ctx cancellation) is unchanged.

## Validation

New e2e tests driving real stdin through the harness:
- `TestReceive_OverwritePromptRepromptsOnTypo` — `y`,`yws`,`y` still overwrites and shows the re-prompt.
- `TestReceive_OverwritePromptEOFKeepsAndExplains` — stdin closing before the prompt keeps the file (exit 13) with the explicit message.

Existing interactive-overwrite e2e unchanged and green; `go test ./cmd/fsend ./test/e2e` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)