### PR TITLE
fix(cli): show throughput for unknown-total streams, and their real size

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -872,3 +872,15 @@ func TestResolveOutDir(t *testing.T) {
 		}
 	})
 }
+
+// A stream's total is 0 until EOF; the summary must report the moved
+// bytes as the size, not "0 B".
+func TestSummaryParts_UnknownTotalUsesMoved(t *testing.T) {
+	parts := strings.Join(summaryParts(0, 15_000_000, "sent", 3*time.Second, mustLANInfo()), "  ·  ")
+	if !strings.Contains(parts, "15 MB") || strings.Contains(parts, "0 B") {
+		t.Errorf("stream summary should carry the moved size: %s", parts)
+	}
+	if strings.Contains(parts, "(") {
+		t.Errorf("no resume clause expected for a stream: %s", parts)
+	}
+}

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -361,6 +361,11 @@ func printSendSummary(f *flags, total, moved int64, skippedFiles int, elapsed ti
 // summaries. moved below total adds a "(X sent)" clause and bases the rate on
 // moved alone.
 func summaryParts(total, moved int64, verb string, elapsed time.Duration, path connpath.Info) []string {
+	// A stream's total is unknown up front (0); by summary time the moved
+	// count is the size — "Sent · 0 B" for a 15 MB pipe would be a lie.
+	if moved > total {
+		total = moved
+	}
 	size := uxlog.HumanBytes(total)
 	if moved < total {
 		size += " (" + uxlog.HumanBytes(moved) + " " + verb + ")"

--- a/internal/uxlog/progress_test.go
+++ b/internal/uxlog/progress_test.go
@@ -3,7 +3,9 @@ package uxlog
 import (
 	"bytes"
 	"os"
+	"strings"
 	"testing"
+	"time"
 )
 
 // silenceStderr redirects os.Stderr to /dev/null for the duration of the
@@ -122,5 +124,29 @@ func TestProgress_PlainModePartialSilent(t *testing.T) {
 	}
 	if len(out) != 0 {
 		t.Fatalf("partial plain progress should be silent, got %q", out)
+	}
+}
+
+// An unknown-total (stdin) stream must show throughput once past
+// HumanRate's noise floor — a bare byte counter is all a long pipe would
+// otherwise ever display.
+func TestProgress_PlainModeUnknownTotalShowsRate(t *testing.T) {
+	var buf bytes.Buffer
+	p := &plainProgress{w: &buf, start: time.Now().Add(-2 * time.Second), lastLine: time.Now().Add(-2 * time.Second)}
+	p.add(5 * 1000 * 1000) // 5 MB over ~2s → ~2.5 MB/s
+	out := buf.String()
+	if !strings.Contains(out, "5 MB") {
+		t.Errorf("missing byte counter: %q", out)
+	}
+	if !strings.Contains(out, "/s") {
+		t.Errorf("unknown-total line missing rate: %q", out)
+	}
+
+	// Below the noise floor: counter only, no misleading rate.
+	buf.Reset()
+	p2 := &plainProgress{w: &buf, start: time.Now().Add(-2 * time.Second), lastLine: time.Now().Add(-2 * time.Second)}
+	p2.add(10 * 1000)
+	if out := buf.String(); strings.Contains(out, "/s") {
+		t.Errorf("sub-floor stream must not show a rate: %q", out)
 	}
 }

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -47,6 +47,7 @@ type plainProgress struct {
 	complete bool
 	closed   bool
 	lastLine time.Time
+	start    time.Time
 }
 
 // plainInterval throttles plain-mode lines. One line per second keeps
@@ -66,7 +67,14 @@ func (p *plainProgress) add(n int64) {
 			p.current*100/p.total, HumanBytes(p.current), HumanBytes(p.total))
 		return
 	}
-	_, _ = fmt.Fprintf(p.w, "  %s\n", HumanBytes(p.current))
+	// Unknown total (stdin streams): a bare byte counter is all a long
+	// pipe would ever show — add throughput once it clears HumanRate's
+	// noise floor.
+	line := HumanBytes(p.current)
+	if r := HumanRate(p.current, time.Since(p.start)); r != "" {
+		line += "  ·  " + r
+	}
+	_, _ = fmt.Fprintf(p.w, "  %s\n", line)
 }
 
 func (p *plainProgress) setTotal(total int64, complete bool) {
@@ -144,7 +152,7 @@ func New(totalBytes int64) *Progress {
 	width, _, sizeErr := term.GetSize(int(os.Stderr.Fd()))
 	if !renderTTY(os.Stderr) || sizeErr != nil || width <= 0 {
 		return &Progress{plain: &plainProgress{
-			w: os.Stderr, total: totalBytes, lastLine: time.Now(),
+			w: os.Stderr, total: totalBytes, lastLine: time.Now(), start: time.Now(),
 		}}
 	}
 	p := &Progress{}
@@ -164,7 +172,11 @@ func New(totalBytes int64) *Progress {
 	// summary line will use for "(<rate>)".
 	start := time.Now()
 	hasTotal := totalBytes > 0
-	showRate := totalBytes >= rateThreshold
+	// Rate needs no total — a multi-GB stdin stream is exactly where the
+	// user wants throughput. HumanRate's own noise floor keeps it hidden
+	// until ~1 MB has moved, covering the small-stream case; ETA stays
+	// total-gated inside its decorator.
+	showRate := !hasTotal || totalBytes >= rateThreshold
 
 	// Percentage on the left. The completed bar is removed (see
 	// BarRemoveOnComplete below), so no terminal-state swap is needed.


### PR DESCRIPTION
## Problem

`cat huge.iso | fsend` — the longest-running kind of transfer — showed a bare byte counter with no throughput: the rate decorator was gated on `totalBytes >= threshold`, and streams have `totalBytes == 0`. The sender's final summary was worse, printing the unknown total literally:

```
[OK] Sent  ·  0 B  ·  2.9s  ·  5.1 MB/s  ·  Direct on local network   ← 15 MB moved
```

## Fix

- Rate is attached for unknown totals too — TTY bar and the plain pipe/CI renderer both. `HumanRate`'s existing 1 MB noise floor keeps small streams quiet; ETA stays total-gated (it genuinely needs one).
- `summaryParts` uses the moved count as the size when it exceeds the declared total (i.e. streams).

After, mid-transfer and summary:

```
  5.1 MB  ·  3.6 MB/s
  10.1 MB  ·  3.6 MB/s
[OK] Sent  ·  15 MB  ·  284ms  ·  52.8 MB/s  ·  Direct on local network
```

## Validation

- Live: throttled 15 MB stdin stream shows rate on both sides mid-transfer; summary carries the real size.
- New tests: `TestProgress_PlainModeUnknownTotalShowsRate` (rate above floor, silent below), `TestSummaryParts_UnknownTotalUsesMoved`.
- `go test ./internal/uxlog ./cmd/fsend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)