### PR TITLE
polish(cli): six small UX fixes from the production-readiness audit

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -106,7 +106,7 @@ func TestSanitizeRemote(t *testing.T) {
 		{"only control → placeholder", "\x00\x01\x02", "peer"},
 		{"strips bidi override", "abc\u202edef", "abcdef"},
 		{"strips zero-width", "ab\u200bc\u200dd", "abcd"},
-		{"caps at 64 runes", strings.Repeat("x", 200), strings.Repeat("x", 64)},
+		{"caps at 64 runes, cut marked", strings.Repeat("x", 200), strings.Repeat("x", 47) + "…" + strings.Repeat("x", 16)},
 		{"tabs and DEL dropped", "ab\tc\x7Fd", "abcd"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
@@ -129,6 +129,27 @@ func TestIsBidi(t *testing.T) {
 		if isBidi(r) {
 			t.Errorf("isBidi(%U) = true, want false", r)
 		}
+	}
+}
+
+// Over-long peer names truncate in the middle with a visible ellipsis:
+// the name is what the accept prompt asks consent for, so a cut must be
+// marked and the extension must stay in view.
+func TestSanitizeForDisplay_TruncatesMiddleKeepingExtension(t *testing.T) {
+	long := strings.Repeat("a", 150) + ".tar.gz"
+	got := sanitizeForDisplay(long, 128)
+	if n := len([]rune(got)); n != 128 {
+		t.Errorf("truncated length = %d runes, want 128", n)
+	}
+	if !strings.Contains(got, "…") {
+		t.Errorf("truncation must be visible: %q", got)
+	}
+	if !strings.HasSuffix(got, ".tar.gz") {
+		t.Errorf("extension must survive truncation: %q", got)
+	}
+	// Short names stay byte-exact.
+	if got := sanitizeForDisplay("report.pdf", 128); got != "report.pdf" {
+		t.Errorf("short name changed: %q", got)
 	}
 }
 

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -315,11 +315,15 @@ func sanitizeForDisplay(s string, maxLen int) string {
 			continue
 		}
 		out = append(out, r)
-		if len(out) >= maxLen {
-			break
-		}
 	}
-	return string(out)
+	if len(out) <= maxLen {
+		return string(out)
+	}
+	// Truncate in the middle with a visible ellipsis: this name is what
+	// the user consents to, so a cut must not masquerade as complete, and
+	// keeping the tail leaves the real extension in view.
+	const tail = 16
+	return string(out[:maxLen-tail-1]) + "…" + string(out[len(out)-tail:])
 }
 
 // sanitizeRemote sanitizes a peer-supplied hostname for display, then

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -581,6 +581,11 @@ func applyEnvFallbacks(f *flags, cmd *cobra.Command) {
 	if !cmd.Flags().Changed("password") || bare {
 		if v := os.Getenv("FSEND_PASSWORD"); v != "" {
 			f.passArg = v
+			// The user who typed bare --password expects a prompt; say why
+			// none appears rather than silently pre-empting it.
+			if bare && !f.quiet {
+				fmt.Fprintln(os.Stderr, uxlog.Info(), "Using FSEND_PASSWORD from the environment — skipping the prompt.")
+			}
 		}
 	}
 }

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -231,6 +231,13 @@ func printSendArtifact(f *flags, c string, plan *sendPlan) *uxlog.Spinner {
 		}
 		fmt.Fprintf(os.Stderr, "  Sending %s%s  ·  %s\n",
 			name, uxlog.CountNoun(plan.totalFiles, "file"), uxlog.HumanBytes(int64(plan.totalBytes)))
+		// Directory-only sends (an empty folder) survive collectPlan's
+		// nothing-to-send guard because the dir entry itself is a source.
+		// Sending it is legitimate — but "0 files" is usually a mistake,
+		// so say what will actually happen.
+		if plan.totalFiles == 0 {
+			fmt.Fprintf(os.Stderr, "  %s No files here — only the empty directory will be created on the other side.\n", uxlog.Warn())
+		}
 		renderPreview(os.Stderr, senderPreview(plan.sources), 6)
 	}
 	fmt.Fprintln(os.Stderr)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -309,6 +309,8 @@ failure. For what to *do* about a given error, see
 | `33`  | `E033` — `fsend --update` could not complete. |
 | `34`  | `E034` — the other device is running an incompatible fsend version. |
 | `35`  | `E035` — `fsend --uninstall` could not remove the binary. |
+| `36`  | `E036` — a symlink in the send set can't be followed (missing or unreadable target, or a link cycle). |
+| `37`  | `E037` — the server's relay spent its daily byte budget; forwarding is paused until 00:00 UTC. |
 | `38`  | `E038` — files received, but the `--manifest` record could not be written. |
 | `99`  | `E099` — unexpected error. Run with `--debug` and file an issue. |
 | `130` | `E026` — cancelled by user (Ctrl-C / SIGTERM). |

--- a/internal/uxlog/format.go
+++ b/internal/uxlog/format.go
@@ -2,6 +2,7 @@ package uxlog
 
 import (
 	"fmt"
+	"strings"
 	"time"
 )
 
@@ -25,11 +26,11 @@ func HumanBytes(n int64) string {
 		exp++
 	}
 	v := float64(n) / float64(div)
-	// Round values drop the decimal: "100 MB", not "100.0 MB".
-	if v == float64(int64(v)) {
-		return fmt.Sprintf("%d %cB", int64(v), "KMGTPE"[exp])
-	}
-	return fmt.Sprintf("%.1f %cB", v, "KMGTPE"[exp])
+	// Values that *display* round drop the decimal — 300006 B must read
+	// "300 KB", not "300.0 KB" (which sat inconsistently next to an exact
+	// 300000 B rendering as "300 KB").
+	s := strings.TrimSuffix(fmt.Sprintf("%.1f", v), ".0")
+	return fmt.Sprintf("%s %cB", s, "KMGTPE"[exp])
 }
 
 // HumanDuration renders elapsed in compact form. Sub-second durations

--- a/internal/uxlog/format_test.go
+++ b/internal/uxlog/format_test.go
@@ -16,8 +16,10 @@ func TestHumanBytes(t *testing.T) {
 		{999, "999 B"},
 		{1000, "1 KB"},
 		{1500, "1.5 KB"},
-		// Decimal units, matching Finder/Explorer: 1 KiB is 1.0 KB.
-		{1024, "1.0 KB"},
+		// Decimal units, matching Finder/Explorer — and a value that only
+		// displays round drops the decimal like an exact one: 1 KiB reads
+		// "1 KB", not a lone "1.0 KB" next to 1000 B's "1 KB".
+		{1024, "1 KB"},
 		{1000 * 1000, "1 MB"},
 		{2_500_000, "2.5 MB"},
 		{100_000_000, "100 MB"},
@@ -83,5 +85,16 @@ func TestHumanDuration_HourTier(t *testing.T) {
 		if got := HumanDuration(c.d); got != c.want {
 			t.Errorf("HumanDuration(%v) = %q, want %q", c.d, got, c.want)
 		}
+	}
+}
+
+// A value that only *displays* round must drop the decimal: 300006 B is
+// "300 KB", matching an exact 300000 B — not a lone "300.0 KB".
+func TestHumanBytes_DisplayRoundDropsDecimal(t *testing.T) {
+	if got := HumanBytes(300006); got != "300 KB" {
+		t.Errorf("HumanBytes(300006) = %q, want \"300 KB\"", got)
+	}
+	if got := HumanBytes(2_400_000); got != "2.4 MB" {
+		t.Errorf("HumanBytes(2400000) = %q, want \"2.4 MB\"", got)
 	}
 }

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -155,6 +155,11 @@ func New(totalBytes int64) *Progress {
 			w: os.Stderr, total: totalBytes, lastLine: time.Now(), start: time.Now(),
 		}}
 	}
+	// The fixed width assumes ~55 columns of decorators around the bar; on
+	// narrower terminals the line would wrap and the in-place redraw only
+	// clears its last visual row, leaving stale fragments behind.
+	bw := min(barWidth, max(10, width-55))
+
 	p := &Progress{}
 	defer setActive(p)
 
@@ -251,7 +256,7 @@ func New(totalBytes int64) *Progress {
 
 	p.bar = p.mp.New(totalBytes,
 		style,
-		mpb.BarWidth(barWidth),
+		mpb.BarWidth(bw),
 		// Progress is transient: a completed bar erases itself and the
 		// summary line that follows is the permanent record. Aborted
 		// (partial) bars stay — see Done().


### PR DESCRIPTION
Batch of P2 findings, each independently small:

1. **Size formatter drift** — `HumanBytes(300006)` rendered `300.0 KB` while `HumanBytes(300000)` rendered `300 KB`, so the sender header and its own file rows disagreed. Display-round values now drop the decimal. (Side effect: `1024` reads `1 KB`, consistent with the rule; test updated.)
2. **Silent name truncation** — peer-supplied names cut at 128 runes with no marker; the accept prompt could show a "complete-looking" name hiding its real suffix. Now truncates mid-name with `…`, keeping the extension visible. Applies to hostnames (64) too.
3. **Narrow terminals** — the fixed 40-col bar plus ~55 cols of decorators wrapped below ~95 cols and the in-place redraw left stale fragments. Width now clamps to `min(40, max(10, width-55))`.
4. **`FSEND_PASSWORD` pre-empting bare `--password`** — the user asked for a prompt and got silence. Now: `[i] Using FSEND_PASSWORD from the environment — skipping the prompt.`
5. **Empty-directory send** — proceeded with `0 files · 0 B` and handed out a code. Still legitimate (creates the dir remotely) but now warns: `[!] No files here — only the empty directory will be created on the other side.`
6. **Docs** — exit-code table was missing rows `36`/`37` despite promising stable, script-matchable codes.

## Validation

Live checks for 1/4/5 (outputs in commit), new tests `TestHumanBytes_DisplayRoundDropsDecimal`, `TestSanitizeForDisplay_TruncatesMiddleKeepingExtension`, updated `TestSanitizeRemote`/`TestHumanBytes` expectations. Full `go test ./...` (incl. e2e) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)