### PR TITLE
fix(cli): report a dead receiver honestly, with rounded retry waits

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -61,6 +61,24 @@ func TestShortErr_TruncatesAndStripsNewlines(t *testing.T) {
 	}
 }
 
+// The retry notice rounds the jittered wait — "618.167744ms" is
+// debugging noise on a user-facing line.
+func TestRetryNoticeFor_RoundsWait(t *testing.T) {
+	notice := retryNoticeFor(&flags{})
+	got := captureStderr(t, func() {
+		notice(2, 618167744*time.Nanosecond, errors.New("idle timeout"))
+	})
+	if !strings.Contains(got, "retrying in 600ms (attempt 2/3)") {
+		t.Errorf("wait not rounded: %q", got)
+	}
+	got = captureStderr(t, func() {
+		notice(3, 2822002555*time.Nanosecond, errors.New("idle timeout"))
+	})
+	if !strings.Contains(got, "retrying in 2.8s (attempt 3/3)") {
+		t.Errorf("wait not rounded: %q", got)
+	}
+}
+
 func TestHostnameOrDefault(t *testing.T) {
 	if got := hostnameOrDefault("override"); got != "override" {
 		t.Errorf("override ignored: %q", got)

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -467,6 +467,9 @@ func retryNoticeFor(f *flags) func(attempt int, wait time.Duration, lastErr erro
 	// uxlog.Println coordinates with a live progress bar so the notice
 	// prints above it instead of colliding with the in-place redraw.
 	return func(attempt int, wait time.Duration, lastErr error) {
+		// The raw jittered duration ("618.167744ms") is debugging noise
+		// on a user-facing line.
+		wait = wait.Round(100 * time.Millisecond)
 		if f.debug {
 			uxlog.Println(fmt.Sprintf("  %s Connection interrupted (%s) — retrying in %s (attempt %d/%d)",
 				uxlog.Retry(), shortErr(lastErr), wait, attempt, retry.DefaultAttempts))

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -446,7 +446,16 @@ func runSendParallel(ctx context.Context, f *flags, plan *sendPlan, code string,
 			return err
 		}
 		if !f.quiet {
-			fmt.Fprintf(os.Stderr, "%s Receiver disconnected — waiting for them to reconnect.\n", uxlog.Info())
+			// A deliberate close (Ctrl-C, clean exit) may genuinely re-run
+			// and reconnect. A death (kill, crash, network gone) surfaces
+			// as exhausted retries — that process is never coming back, so
+			// "reconnect" would misdirect the user; what's true is that the
+			// code still works for a fresh `fsend <code>`.
+			msg := "Receiver disconnected — waiting for them to reconnect."
+			if !isReceiverClose(err) {
+				msg = "Lost contact with the receiver — waiting for a new connection on the same code."
+			}
+			fmt.Fprintf(os.Stderr, "%s %s\n", uxlog.Info(), msg)
 		}
 		waitSpin = startWaitSpinner(f, "Waiting for receiver")
 	}

--- a/internal/quicconn/quicconn.go
+++ b/internal/quicconn/quicconn.go
@@ -120,10 +120,22 @@ func ReceiverTLSConfig() *tls.Config {
 
 // QuicConfig returns the shared quic-go config.
 func QuicConfig() *quic.Config {
+	idle := 30 * time.Second
+	// Undocumented test knob: peer-death detection latency equals the
+	// idle timeout, and the e2e suite can't wait 30 s per scenario.
+	if v := os.Getenv("FSEND_QUIC_IDLE_TIMEOUT"); v != "" {
+		if d, err := time.ParseDuration(v); err == nil && d > 0 {
+			idle = d
+		}
+	}
+	keepAlive := 10 * time.Second
+	if keepAlive > idle/2 {
+		keepAlive = idle / 2
+	}
 	return &quic.Config{
 		HandshakeIdleTimeout:           HandshakeTimeout,
-		MaxIdleTimeout:                 30 * time.Second,
-		KeepAlivePeriod:                10 * time.Second,
+		MaxIdleTimeout:                 idle,
+		KeepAlivePeriod:                keepAlive,
 		InitialStreamReceiveWindow:     512 * 1024,
 		MaxStreamReceiveWindow:         6 * 1024 * 1024,
 		InitialConnectionReceiveWindow: 1024 * 1024,

--- a/test/e2e/signal_test.go
+++ b/test/e2e/signal_test.go
@@ -6,6 +6,7 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"syscall"
 	"testing"
@@ -341,3 +342,76 @@ func waitForStderr(s *senderProc, substr string, budget time.Duration) bool {
 	}
 	return false
 }
+
+// A receiver that dies uncleanly (SIGKILL — crash, power loss, network
+// gone) must not strand the sender: after the QUIC idle timeout and the
+// bounded re-accept retries, the sender reports the lost contact
+// honestly (no "reconnect" from a dead process) and returns to waiting —
+// and the same code must still complete a transfer with a fresh
+// receiver. FSEND_QUIC_IDLE_TIMEOUT shrinks the 30 s death-detection
+// window so the test doesn't wait a minute per run.
+func TestSignal_ReceiverKilledCodeStaysLive(t *testing.T) {
+	requireE2E(t)
+	src, dst := t.TempDir(), t.TempDir()
+	srcFile := filepath.Join(src, "p.bin")
+	writeRandom(t, srcFile, 256*1024)
+
+	xdg := h.newXDG(t)
+	s := &senderProc{cmd: h.fsendCmd(xdg, srcFile), stdout: &safeBuffer{}, stderr: &safeBuffer{}}
+	s.cmd.Env = append(s.cmd.Env, "FSEND_QUIC_IDLE_TIMEOUT=2s")
+	s.cmd.Stdout, s.cmd.Stderr = s.stdout, s.stderr
+	if err := s.cmd.Start(); err != nil {
+		t.Fatalf("start sender: %v", err)
+	}
+	t.Cleanup(func() { _ = s.cmd.Process.Kill() })
+	code := s.waitForCode(t, 5*time.Second)
+
+	// Receiver 1 pairs (no --yes: it parks at the accept prompt, held
+	// open by a pipe we never write to) and is then hard-killed. An
+	// os.Pipe passes the fd straight through, so Wait doesn't hang on
+	// an exec stdin-copy goroutine after the Kill.
+	pr, pw, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = pr.Close(); _ = pw.Close() }()
+	r1 := h.fsendCmd(xdg, code)
+	r1.Dir = dst
+	r1.Stdin = pr
+	var r1Err bytes.Buffer
+	r1.Stderr = &r1Err
+	if err := r1.Start(); err != nil {
+		t.Fatalf("start recv1: %v", err)
+	}
+	if !waitForStderr(s, "Receiver connected", 10*time.Second) {
+		t.Fatalf("receiver never paired\n--- sender stderr ---\n%s", s.stderr.String())
+	}
+	if err := r1.Process.Kill(); err != nil {
+		t.Fatalf("kill recv1: %v", err)
+	}
+	_ = r1.Wait()
+
+	// Idle timeout (2 s) + two bounded re-accepts (15 s each) + backoff.
+	if !waitForStderr(s, "Lost contact with the receiver", 60*time.Second) {
+		t.Fatalf("sender never reported the lost receiver\n--- sender stderr ---\n%s", s.stderr.String())
+	}
+	// The user-facing retry notice must carry a rounded wait, not the raw
+	// jittered duration ("618.167744ms").
+	if rawDuration.MatchString(s.stderr.String()) {
+		t.Errorf("retry notice leaked a raw duration\n--- sender stderr ---\n%s", s.stderr.String())
+	}
+
+	// The code is still live: a fresh receiver completes the transfer.
+	rOut, rErr, exit := h.runFsendIn(t, xdg, dst, "--yes", code)
+	if exit != 0 {
+		t.Fatalf("fresh receiver exit %d\n%s\n%s\n--- sender stderr ---\n%s", exit, rOut, rErr, s.stderr.String())
+	}
+	if got := s.wait(t, 10*time.Second); got != 0 {
+		t.Fatalf("sender exit = %d\n--- sender stderr ---\n%s", got, s.stderr.String())
+	}
+	assertFilesEqual(t, srcFile, filepath.Join(dst, "p.bin"))
+}
+
+// rawDuration matches Go's un-rounded Duration rendering (5+ decimals),
+// e.g. "618.167744ms" — what the retry notice must never show.
+var rawDuration = regexp.MustCompile(`[0-9]+\.[0-9]{5,}m?s`)


### PR DESCRIPTION
## Problem

Hard-killing a receiver at the accept prompt (crash, power loss, network gone) left the sender telling this story:

```
[*] Waiting for them to accept          ← ~30 s of silence (QUIC idle timeout)
  [~] Connection interrupted — retrying in 618.167744ms (attempt 2/3)
  [~] Connection interrupted — retrying in 2.822002555s (attempt 3/3)
[i] Receiver disconnected — waiting for them to reconnect.
```

Two lies and one leak: raw jittered `time.Duration`s on a user-facing line, and "waiting for them to reconnect" about a process that is never coming back. (Investigation note: the audit's suspected *endless* retry loop did not reproduce — the mechanics were already sound, returning to a stable wait with the code live, per the agreed design. The repeated-cycle appearance came from overlapping log tails.)

## Fix

- Retry notices round the wait to 100 ms: `retrying in 600ms (attempt 2/3)`.
- The re-pair line distinguishes what happened:
  - deliberate close (Ctrl-C/clean exit): `Receiver disconnected — waiting for them to reconnect.` (unchanged — that receiver may re-run)
  - exhausted retries (death): `Lost contact with the receiver — waiting for a new connection on the same code.`
- `FSEND_QUIC_IDLE_TIMEOUT` (undocumented test knob) makes the 30 s detection window shrinkable; keep-alive scales to stay under half of it. Production default unchanged.

## Validation

- Live: receiver SIGKILL with default timeouts → silence, rounded notices, honest line, stable return to "Waiting for receiver".
- New e2e `TestSignal_ReceiverKilledCodeStaysLive` (35 s): hard-kills a paired receiver, asserts the rounded notices (regex rejects 5+-decimal durations), the lost-contact line, **and that a fresh receiver then completes the transfer on the same code** with sender exit 0.
- New unit test `TestRetryNoticeFor_RoundsWait`.
- Full `go test ./...` green, including the existing clean-close e2e (`TestSignal_ReceiverSIGINTRerunSameCode`) which pins the unchanged "Receiver disconnected" wording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)