### PR TITLE
fix(transfer): resume must not rename over an existing target without consent

### DIFF
--- a/internal/transfer/classify.go
+++ b/internal/transfer/classify.go
@@ -179,11 +179,17 @@ func classifyOne(e wire.ListingEntry, target, targetDir string, checksum bool) e
 				return p
 			}
 		}
-		if off, imo, ok := resumeCandidate(target+partialSuffix, e.Size); ok {
-			p.disp = dispResume
-			p.resumeOffset = off
-			p.imohash = imo
-			return p
+		// Resume only when the target is absent. An existing non-identical
+		// target is the user's file — resuming would rename over it with no
+		// consent, so fall through to differs/conflict (an approved
+		// overwrite re-sends fresh, truncating the stale partial).
+		if !exists {
+			if off, imo, ok := resumeCandidate(target+partialSuffix, e.Size); ok {
+				p.disp = dispResume
+				p.resumeOffset = off
+				p.imohash = imo
+				return p
+			}
 		}
 		switch {
 		case exists && (st.IsDir() || st.Mode()&os.ModeSymlink != 0):

--- a/internal/transfer/engine_resume_test.go
+++ b/internal/transfer/engine_resume_test.go
@@ -54,6 +54,48 @@ func TestEngine_ResumePartialMismatch(t *testing.T) {
 	}
 }
 
+// A stale partial next to an existing, differing target must not let resume
+// rename over the user's file without consent. Without --overwrite the file
+// is kept (conflict); with it, the fresh content lands.
+func TestEngine_ResumeDoesNotClobberExistingTarget(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+	data := randBytes(3 * wire.MaxChunkSize)
+	writeFile(t, filepath.Join(src, "report.pdf"), data)
+
+	// A leftover partial from a crashed transfer...
+	writeFile(t, filepath.Join(dst, "report.pdf"+partialSuffix), data[:2*wire.MaxChunkSize])
+	// ...and the user's own, unrelated file at the same name.
+	userFile := []byte("MY OWN FILE")
+	writeFile(t, filepath.Join(dst, "report.pdf"), userFile)
+
+	// No overwrite: the user's file is kept and the conflict is signalled
+	// (the engine skips it; the E013 exit is the CLI layer's job).
+	var kept []string
+	_, re := fileTransfer(t, []string{filepath.Join(src, "report.pdf")}, dst, func(o *RecvOptions) {
+		o.OnConflictKept = func(rel string) { kept = append(kept, rel) }
+	})
+	if re != nil {
+		t.Fatalf("recv = %v, want nil (conflict kept, not an error)", re)
+	}
+	if len(kept) != 1 {
+		t.Fatalf("expected 1 kept conflict, got %v", kept)
+	}
+	if got := mustRead(t, filepath.Join(dst, "report.pdf")); !bytes.Equal(got, userFile) {
+		t.Fatalf("user's file was clobbered: %q", got)
+	}
+
+	// With overwrite: the transferred content lands (fresh, not resumed junk).
+	_, re = fileTransfer(t, []string{filepath.Join(src, "report.pdf")}, dst, func(o *RecvOptions) {
+		o.Overwrite = true
+	})
+	if re != nil {
+		t.Fatalf("overwrite recv = %v", re)
+	}
+	if got := mustRead(t, filepath.Join(dst, "report.pdf")); !bytes.Equal(got, data) {
+		t.Fatal("overwrite did not land the sent content")
+	}
+}
+
 func TestEngine_StreamToSink(t *testing.T) {
 	data := randBytes(3*wire.MaxChunkSize + 123)
 	var sink bytes.Buffer


### PR DESCRIPTION
## Problem (data loss)

`classify` checked for a `.fsend-partial` resume candidate **before** checking whether the final target already existed and differed. A stale partial from a crashed transfer made a re-send classify as `dispResume` and rename the completed download over the user's own same-named file — silently, no overwrite prompt, reporting success.

**Reproduced end-to-end:**
1. A transfer of `report.pdf` is interrupted → `report.pdf.fsend-partial` left on disk, no `report.pdf`.
2. User later saves *their own* `report.pdf` at that path.
3. Re-send → `Resuming from 2 MB` → the user's file is renamed over and gone. Exit 0, "✓ Saved".

The partial and the final target are two different files; the partial's presence was acting as a skeleton key past the consent gate that fsend's whole classify system exists to enforce.

## Fix

Resume applies **only when the target is absent**. An existing, non-identical target routes through the normal differs/conflict consent path; an approved overwrite re-sends fresh (the stale partial is truncated on open, in openRecvFile). Unchanged: resume after a clean interruption (no target yet), and identical-skip.

~10 lines in `classify.go`.

## After (same repro, `--yes` no `--overwrite`)

```
recv exit=13
… 1 file kept (use --overwrite)
USER FILE PRESERVED ✓
```

With `--overwrite` the sent content lands fresh (not resumed junk).

## Validation

- Live before/after (above).
- New `TestEngine_ResumeDoesNotClobberExistingTarget`: stale partial + differing user file → kept + user file intact without overwrite; fresh content lands with it.
- Existing resume tests (`TestEngine_ResumeLargeFile`, `TestEngine_ResumePartialMismatch`) unchanged — they plant only the partial (target absent), so normal resume is preserved.
- `go test ./internal/transfer ./cmd/fsend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
