### PR TITLE
fix(transfer): propagate a permission-only change on an identical re-send

### DIFF
--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -9,6 +9,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
@@ -312,6 +313,9 @@ func TestEngine_SkipIdenticalOnResend(t *testing.T) {
 // untouched, so the file still classifies identical — but the new mode must
 // still land on the receiver's copy instead of being silently lost.
 func TestEngine_PermissionChangePropagatesOnIdenticalResend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows has no Unix permission bits; the exec bit is meaningless there")
+	}
 	src, dst := t.TempDir(), t.TempDir()
 	sp := filepath.Join(src, "deploy.sh")
 	writeFile(t, sp, []byte("#!/bin/sh\necho hi\n"))

--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -308,6 +308,47 @@ func TestEngine_SkipIdenticalOnResend(t *testing.T) {
 	}
 }
 
+// A permission-only change (chmod +x) leaves content, size and mtime
+// untouched, so the file still classifies identical — but the new mode must
+// still land on the receiver's copy instead of being silently lost.
+func TestEngine_PermissionChangePropagatesOnIdenticalResend(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+	sp := filepath.Join(src, "deploy.sh")
+	writeFile(t, sp, []byte("#!/bin/sh\necho hi\n"))
+	if err := os.Chmod(sp, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First transfer lands it non-executable.
+	if se, re := fileTransfer(t, []string{sp}, dst, nil); se != nil || re != nil {
+		t.Fatalf("seed send=%v recv=%v", se, re)
+	}
+	dp := filepath.Join(dst, "deploy.sh")
+	if st, _ := os.Stat(dp); st.Mode()&0o111 != 0 {
+		t.Fatal("precondition: dst should start non-executable")
+	}
+
+	// chmod +x on the source (content/size/mtime unchanged), re-send.
+	st, _ := os.Stat(sp)
+	if err := os.Chmod(sp, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	_ = os.Chtimes(sp, st.ModTime(), st.ModTime())
+
+	var skipped int
+	if se, re := fileTransfer(t, []string{sp}, dst, func(o *RecvOptions) {
+		o.OnSkip = func(uint32) { skipped++ }
+	}); se != nil || re != nil {
+		t.Fatalf("resend send=%v recv=%v", se, re)
+	}
+	if skipped != 1 {
+		t.Errorf("expected the file to skip the data transfer, got skipped=%d", skipped)
+	}
+	if st, _ := os.Stat(dp); st.Mode()&os.ModePerm != 0o755 {
+		t.Errorf("mode not propagated: dst is %o, want 0755", st.Mode()&os.ModePerm)
+	}
+}
+
 func TestEngine_DifferingFileProtectedWithoutOverwrite(t *testing.T) {
 	src, dst := t.TempDir(), t.TempDir()
 	writeFile(t, filepath.Join(src, "x.txt"), []byte("NEW CONTENT"))

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -166,6 +166,12 @@ func recvFiles(ctx context.Context, s *Streams, hello *wire.SenderHello, opts Re
 		p := &plans[i]
 		byIndex[p.entry.Index] = p
 		if decisions[i].Action == wire.DecisionSkip {
+			// An identical file skips the data transfer, but a permission-only
+			// change (chmod +x) leaves size+mtime untouched — repair the mode
+			// locally or it never propagates. Kept conflicts stay as-is.
+			if p.disp == dispIdentical {
+				repairIdenticalMode(p)
+			}
 			continue
 		}
 		if p.entry.Type == wire.EntryFile && p.entry.Size > 0 {
@@ -610,6 +616,20 @@ func materialize(s *Streams, p *entryPlan, approveOverwrite bool) error {
 }
 
 // planToDecision maps a plan to its wire decision and fires receiver-side
+// repairIdenticalMode propagates a permission-only change onto an
+// already-identical regular file, whose unchanged size+mtime (or content
+// hash under --checksum) would otherwise skip it and never pick up the new
+// mode. Best-effort; a chmod failure isn't worth failing the transfer.
+func repairIdenticalMode(p *entryPlan) {
+	if p.entry.Type != wire.EntryFile {
+		return
+	}
+	want := os.FileMode(p.entry.Mode) & os.ModePerm
+	if st, err := os.Stat(p.target); err == nil && st.Mode()&os.ModePerm != want {
+		_ = os.Chmod(p.target, want)
+	}
+}
+
 // notifications (skip / conflict-kept).
 func planToDecision(p *entryPlan, approveOverwrite bool, opts RecvOptions) wire.Decision {
 	d := wire.Decision{Index: p.entry.Index}


### PR DESCRIPTION
## Problem

Send a script, `chmod +x` the source, re-send → the receiver says "already up to date" and its copy stays `-rw-r--r--` **forever**. `chmod` changes ctime, not mtime, so size+mtime still match → the file classifies identical and skips — but the mode was never compared or applied. `--checksum` can't fix it either (content identical → skip).

This is the canonical "sent my script, lost +x" complaint. fsend already preserves the exec bit correctly for *fresh* files; only the identical-re-send path missed it.

## Fix

When a file skips as identical, repair its mode locally to match the sender (zero bytes transferred, rsync `-p` style). Applied post-consent in the decision loop and gated to `dispIdentical` — a *kept conflict* (differs, no `--overwrite`) is deliberately left untouched. Works for both the mtime-identical and `--checksum`-identical paths since both reach the same loop.

## After

```
after 1st send:            -rw-r--r--
after chmod +x, re-send:   -rwxr-xr-x   ("Already up to date · 1 file unchanged")
```

## Validation

- Live before/after for both the default and `--checksum` paths (both now land `0755`).
- New `TestEngine_PermissionChangePropagatesOnIdenticalResend`: seeds `0644`, chmod +x source (size+mtime preserved), asserts the file skips the data transfer yet lands `0755`.
- `go test ./internal/transfer ./cmd/fsend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)