### PR TITLE
fix(transfer): empty file to --out - no longer hangs until the idle timeout

### DIFF
--- a/internal/transfer/engine_resume_test.go
+++ b/internal/transfer/engine_resume_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/polius/fsend/internal/wire"
 )
@@ -108,6 +109,36 @@ func TestEngine_StreamToSink(t *testing.T) {
 	}
 	if !bytes.Equal(sink.Bytes(), data) {
 		t.Fatal("sink content mismatch")
+	}
+}
+
+// A zero-byte file to a sink (--out -) must complete promptly: the sender
+// skips the data phase for empty files, so the receiver must not block waiting
+// for a chunk that never comes (it used to hang until the idle timeout).
+func TestEngine_EmptyFileToSink(t *testing.T) {
+	src := t.TempDir()
+	writeFile(t, filepath.Join(src, "empty.bin"), nil)
+	sources, err := Walk([]string{filepath.Join(src, "empty.bin")}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var sink bytes.Buffer
+	done := make(chan [2]error, 1)
+	go func() {
+		se, re := runTransfer(t, SendOptions{Mode: wire.ModeFiles, Sources: sources},
+			RecvOptions{TargetDir: t.TempDir(), Sink: &sink})
+		done <- [2]error{se, re}
+	}()
+	select {
+	case errs := <-done:
+		if errs[0] != nil || errs[1] != nil {
+			t.Fatalf("send=%v recv=%v", errs[0], errs[1])
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("empty file to sink hung (regression: deadlock waiting for a data chunk)")
+	}
+	if sink.Len() != 0 {
+		t.Errorf("empty file should yield no bytes, got %d", sink.Len())
 	}
 }
 

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -233,12 +233,16 @@ func recvFilesToSink(ctx context.Context, s *Streams, hello *wire.SenderHello, e
 	if err := sendDecisions(s.Control, []wire.Decision{{Index: 0, Action: wire.DecisionSend}}); err != nil {
 		return fmt.Errorf("recv: decisions: %w", err)
 	}
-	if err := streamPayload(ctx, s, opts.Sink, func(n uint64) {
-		if opts.ProgressFn != nil {
-			opts.ProgressFn(0, n)
+	// A zero-byte file carries no data phase (the sender skips it), so waiting
+	// on streamPayload would hang until the idle timeout. Nothing to write.
+	if entries[0].Size > 0 {
+		if err := streamPayload(ctx, s, opts.Sink, func(n uint64) {
+			if opts.ProgressFn != nil {
+				opts.ProgressFn(0, n)
+			}
+		}); err != nil {
+			return err
 		}
-	}); err != nil {
-		return err
 	}
 	return finishRecv(s)
 }


### PR DESCRIPTION
## Problem

`fsend <code> --out -` for a **zero-byte** file hung for ~30s and then failed as a network error. The sender skips the data phase entirely for empty files (`send.go`), but `recvFilesToSink` unconditionally called `streamPayload`, which blocked reading a data chunk that never came. Sink mode gets one attempt (no retry), so it was a hard failure.

## Fix

Skip `streamPayload` when the single file is empty — there's nothing to write — and go straight to `finishRecv`. Three lines. The non-sink receive path already handled empty files correctly (via `materialize`); only the sink path had the gap.

## After

```
$ fsend <code> --out -   # empty source
exit=0  elapsed=0.3s  stdout_bytes=0
✓ Received · 0 B · 2ms · Direct on local network
```

(was ~30s + failure)

## Validation

- Live before/after (above).
- New `TestEngine_EmptyFileToSink`: transfers a 0-byte file to a sink under a 10s watchdog (fails if it deadlocks), asserts no error and zero bytes out.
- Existing `TestEngine_StreamToSink` / `TestEngine_StreamToFile` unchanged.
- `go test ./internal/transfer ./cmd/fsend` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)