### PR TITLE
fix(deploy): give the server its full 30s drain on shutdown (stop_grace_period)

### DIFF
--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     container_name: fsend
     command: ["server"]
     restart: unless-stopped
+    stop_grace_period: 35s   # cover the server's 30s shutdown drain
     ports:
       - "443:443/udp"
     # See `fsend server --help` for all settings.

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -144,7 +144,10 @@ Connecting without it — or with the wrong one — fails with `E028`.
   IPs, no share codes.
 - **Update.** `docker compose pull && docker compose up -d`. The image
   tracks the floating `poliuscorp/fsend:latest` tag; pin a version tag if
-  you want immutable, reproducible upgrades.
+  you want immutable, reproducible upgrades. On stop the server drains
+  in-flight transfers and long-polls for up to 30s; the compose file sets
+  `stop_grace_period: 35s` so an upgrade doesn't cut them short (keep it if
+  you edit the file — Docker's 10s default would SIGKILL mid-drain).
 - **Backup.** Nothing to back up. Pairing state lives in RAM and evicts
   within an hour; certificates live in the `caddy_data` volume, and Caddy
   reissues them automatically if you lose it.


### PR DESCRIPTION
## Problem

The server drains in-flight relay transfers and 25s `/wait` long-polls for up to `shutdownGrace` (30s) on SIGTERM. But `deploy/compose/docker-compose.yml` set no `stop_grace_period`, so Docker's **10s default** SIGKILLed the container mid-drain on every documented upgrade (`docker compose pull && docker compose up -d`) — cutting active transfers and parked long-polls. The graceful-shutdown code was effectively unreachable in the shipped deployment.

## Why not just reduce `shutdownGrace` to 10s?

Because 30s isn't arbitrary — it's sized to sit above the 25s long-poll so in-flight polls return naturally, plus slack for short in-flight transfers to drain. And it's a **ceiling, not a fixed wait**: a quiet server hits `ActiveAllocations == 0` and shuts down immediately. Cutting it to 10s only costs you (it starts severing real transfers at 10s) and saves nothing on an idle shutdown — it would make the drain barely better than the SIGKILL it exists to prevent. Raising Docker's grace to match the drain is free when idle and preserves it when busy.

## Fix

- `stop_grace_period: 35s` on the fsend service (a few seconds above the 30s drain budget).
- Documented in `self-hosting.md` (Operations → Update), including a note to keep it if editing the compose file.

Rate-limiting / abuse caps are intentionally left at their `0 = unlimited` defaults per project decision — this PR is scoped to the shutdown drain only.

## Validation

`docker compose config` parses cleanly and normalizes `stop_grace_period: 35s`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)