### PR TITLE
fix(cli): close the LAN-loser's paired connection so its receiver doesn't hang

### DIFF
--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -118,6 +118,11 @@ func pairOverLAN(ctx context.Context, code string) (*lanSenderPairing, error) {
 				cleanup: func() {
 					stopMDNS()
 					_ = ln.Close()
+					// Closing the listener leaves an accepted conn open
+					// (quic-go), so close the paired one too — else the loser
+					// in a two-receiver race hangs. Idempotent with the
+					// winning transfer's own close.
+					res.Close()
 				},
 			}, nil
 		}


### PR DESCRIPTION
## Problem

When two receivers redeem the same code — one on the LAN, one remote — and both complete the SPAKE2 handshake, if the **server path wins** the race, `drainLoser` calls the LAN pairing's `cleanup`. That closed the mDNS announce and the listener, but **not** the already-accepted `AcceptResult`. quic-go leaves established connections open when a listener closes, and with 10s keepalives the orphaned connection never idle-times-out — so the losing LAN receiver sat in `transfer.Recv` reading `SenderHello` **forever**, with no error and no timeout, until Ctrl-C.

## Fix

Close the paired connection in `cleanup` too. `AcceptResult.Close()` is idempotent (quic-go's `CloseWithError` no-ops after the first call, stream-close errors are ignored), so on a *winning* LAN transfer — where the transfer loop already closes `firstRes` — the extra close is harmless. One line.

## Validation

- Live 4 MB LAN transfer: completes, byte-for-byte integrity match — confirms the double-close (transfer loop + cleanup) is harmless.
- `go test ./cmd/fsend ./internal/transfer ./internal/quicconn` green.

## Scope note

This PR was originally planned to also close a `quic.Conn` leak on **failed** handshakes (the LAN impostor-accept loop). I dropped that half: empirically, closing the connection on handshake failure races QUIC's delivery of the already-written SPAKE2 confirmation tag, so the peer gets a raw connection-close error instead of the specific `E022` "could not verify the other side" ~70% of the time (flushing the stream first doesn't reliably fix it, and made the sender flaky too). That's a real UX regression on the wrong-code/MITM path in exchange for closing a narrow, adversarial, pairing-window-bounded leak — not a clean trade, so I'm surfacing it for a decision rather than shipping it silently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)