### PR TITLE
fix(relay): resend the bootstrap datagram so a lost one can't strand pairing

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -401,6 +401,9 @@ func dialRelay(alloc *server.RelayAllocateResponse) (net.PacketConn, error) {
 		_ = rc.Close()
 		return nil, fmt.Errorf("relay bootstrap: %w", err)
 	}
+	// Resend the bootstrap until the relay forwards us a datagram: a single
+	// lost one would strand the passive sender (it only waits to be dialed).
+	rc.KeepBootstrapping(500*time.Millisecond, 20*time.Second)
 	return rc, nil
 }
 

--- a/internal/relay/conn.go
+++ b/internal/relay/conn.go
@@ -67,6 +67,12 @@ func (c *Conn) KeepBootstrapping(interval, max time.Duration) {
 			case <-c.stop:
 				return
 			case <-t.C:
+				// Recheck stop: a Close racing the tick shouldn't send.
+				select {
+				case <-c.stop:
+					return
+				default:
+				}
 				if c.gotInbound.Load() || time.Now().After(deadline) {
 					return
 				}

--- a/internal/relay/conn.go
+++ b/internal/relay/conn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
@@ -24,6 +25,10 @@ type Conn struct {
 	relayAddr  *net.UDPAddr
 	token      Token
 
+	gotInbound atomic.Bool   // set once the relay forwards us a datagram
+	stop       chan struct{} // closed by Close to stop the bootstrap resender
+	stopOnce   sync.Once
+
 	mu     sync.Mutex
 	closed bool
 }
@@ -42,7 +47,33 @@ func NewClient(underlying net.PacketConn, relayAddr *net.UDPAddr, token Token) *
 		underlying: underlying,
 		relayAddr:  relayAddr,
 		token:      token,
+		stop:       make(chan struct{}),
 	}
+}
+
+// KeepBootstrapping resends the one-byte bootstrap datagram every interval
+// (up to max) until the relay forwards us our first datagram, or the conn
+// closes. The bootstrap is how the relay learns our address; after it, the
+// sender is passive (it waits to be dialed), so a single lost bootstrap
+// would strand the pairing. Harmless for the receiver — it dials QUIC
+// immediately, so its first inbound arrives fast and the resender stops.
+func (c *Conn) KeepBootstrapping(interval, max time.Duration) {
+	go func() {
+		deadline := time.Now().Add(max)
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-c.stop:
+				return
+			case <-t.C:
+				if c.gotInbound.Load() || time.Now().After(deadline) {
+					return
+				}
+				_, _ = c.WriteTo([]byte{0}, nil)
+			}
+		}
+	}()
 }
 
 // LocalAddr returns the underlying socket's local address.
@@ -65,6 +96,7 @@ func (c *Conn) Close() error {
 		return nil
 	}
 	c.closed = true
+	c.stopOnce.Do(func() { close(c.stop) })
 	return c.underlying.Close()
 }
 
@@ -87,6 +119,9 @@ func (c *Conn) ReadFrom(p []byte) (n int, addr net.Addr, err error) {
 		if token != c.token {
 			continue
 		}
+		// The relay only forwards once both peers are registered, so any
+		// inbound datagram means our address is known — stop resending.
+		c.gotInbound.Store(true)
 		n = copy(p, payload)
 		return n, syntheticPeer, nil
 	}

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -620,16 +620,19 @@ func TestKeepBootstrapping_StopsOnInbound(t *testing.T) {
 	}
 }
 
-// Close stops the resender promptly.
+// Close stops the resender: after it, the write count settles (one tick may
+// already be in flight when Close lands) and then stops growing.
 func TestKeepBootstrapping_StopsOnClose(t *testing.T) {
 	u := newCountingConn()
 	c := NewClient(u, &net.UDPAddr{}, Token{})
 	c.KeepBootstrapping(10*time.Millisecond, 5*time.Second)
 	time.Sleep(30 * time.Millisecond)
 	_ = c.Close()
+	// Let any in-flight tick land and the goroutine observe the close.
+	time.Sleep(50 * time.Millisecond)
 	settled := u.writes.Load()
-	time.Sleep(60 * time.Millisecond)
+	time.Sleep(80 * time.Millisecond)
 	if u.writes.Load() != settled {
-		t.Errorf("resends continued after Close: %d → %d", settled, u.writes.Load())
+		t.Errorf("resends continued after Close settled: %d → %d", settled, u.writes.Load())
 	}
 }

--- a/internal/relay/relay_test.go
+++ b/internal/relay/relay_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -571,5 +572,64 @@ func TestServer_ActiveAllocationsCountsLiveSessions(t *testing.T) {
 	// in-flight for drain purposes.
 	if n := srv.ActiveAllocations(); n != 1 {
 		t.Fatalf("active = %d, want 1", n)
+	}
+}
+
+// countingConn is a minimal net.PacketConn that counts WriteTo calls and
+// blocks ReadFrom until closed. It lets the bootstrap-resend loop run
+// without a real relay.
+type countingConn struct {
+	writes atomic.Int64
+	done   chan struct{}
+	once   sync.Once
+}
+
+func newCountingConn() *countingConn { return &countingConn{done: make(chan struct{})} }
+func (c *countingConn) WriteTo(p []byte, _ net.Addr) (int, error) {
+	c.writes.Add(1)
+	return len(p), nil
+}
+func (c *countingConn) ReadFrom(p []byte) (int, net.Addr, error) {
+	<-c.done
+	return 0, nil, net.ErrClosed
+}
+func (c *countingConn) Close() error                     { c.once.Do(func() { close(c.done) }); return nil }
+func (c *countingConn) LocalAddr() net.Addr              { return &net.UDPAddr{} }
+func (c *countingConn) SetDeadline(time.Time) error      { return nil }
+func (c *countingConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *countingConn) SetWriteDeadline(time.Time) error { return nil }
+
+// The bootstrap resender keeps sending until an inbound datagram arrives,
+// then stops — so a passive sender recovers from a lost bootstrap.
+func TestKeepBootstrapping_StopsOnInbound(t *testing.T) {
+	u := newCountingConn()
+	c := NewClient(u, &net.UDPAddr{}, Token{})
+	c.KeepBootstrapping(10*time.Millisecond, 5*time.Second)
+
+	time.Sleep(60 * time.Millisecond) // several resends
+	if got := u.writes.Load(); got < 2 {
+		t.Fatalf("expected repeated bootstraps, got %d writes", got)
+	}
+	// Simulate the relay forwarding us a datagram (what ReadFrom sets).
+	c.gotInbound.Store(true)
+	time.Sleep(40 * time.Millisecond)
+	settled := u.writes.Load()
+	time.Sleep(60 * time.Millisecond)
+	if u.writes.Load() != settled {
+		t.Errorf("resends did not stop after inbound: %d → %d", settled, u.writes.Load())
+	}
+}
+
+// Close stops the resender promptly.
+func TestKeepBootstrapping_StopsOnClose(t *testing.T) {
+	u := newCountingConn()
+	c := NewClient(u, &net.UDPAddr{}, Token{})
+	c.KeepBootstrapping(10*time.Millisecond, 5*time.Second)
+	time.Sleep(30 * time.Millisecond)
+	_ = c.Close()
+	settled := u.writes.Load()
+	time.Sleep(60 * time.Millisecond)
+	if u.writes.Load() != settled {
+		t.Errorf("resends continued after Close: %d → %d", settled, u.writes.Load())
 	}
 }


### PR DESCRIPTION
## Problem

Relay pairing rode on a **single unacknowledged UDP datagram**. `dialRelay` sent one bootstrap (`[]byte{0}`) to register the client's address with the relay, then the **sender went passive** — it just waits on `Accept`. If that one datagram was lost (plain UDP, no retry), the relay never learned the sender's address, the receiver's packets could never be forwarded to it, and the transfer hard-failed after 60s with a misleading *"receiver paired but the connection could not be established."* On a link with p% loss, ~p% of relay transfers failed this way.

The receiver was unaffected — it dials QUIC immediately, so its Initial packets register it even if its bootstrap is lost. Only the passive sender was exposed.

## Fix

Resend the bootstrap every 500ms (capped at 20s) until the relay forwards us our first datagram — which, because the relay only forwards once **both** peers are registered, proves our address is known. Self-contained in the relay `Conn` (a goroutine stopped by `Close` or the first inbound read). One call added to `dialRelay`, covering both sender and receiver.

Harmless by construction: resends arriving while `peerB` is still unknown are dropped by the relay (not forwarded as junk), and the receiver's resender stops on its first inbound almost immediately.

## Validation

- Live 6 MB relay transfer (`--mode relay` both sides): completes, byte-for-byte integrity match, "Relayed via …".
- New unit tests: `TestKeepBootstrapping_StopsOnInbound` (resends repeat, then stop once inbound arrives), `TestKeepBootstrapping_StopsOnClose`.
- `go test ./internal/relay -race`, existing `TestRelay_EndToEnd`/`TestForwardingDisabled`, and the e2e relay-path transfer all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)