### PR TITLE
cleanup(transfer,server): drop dead symlink branch, fix relay TTL, comment drift

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -359,7 +359,7 @@ func (s *Server) allocateRelay(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, RelayAllocateResponse{
 		RelayAddr:          s.relayAddrFor(r),
 		SessionToken:       relayTok.String(),
-		TTLSeconds:         600,
+		TTLSeconds:         int(s.cfg.PairedTTL.Seconds()),
 		ForwardingDisabled: !s.relayAllocator.Forwarding(),
 	})
 }

--- a/internal/transfer/classify.go
+++ b/internal/transfer/classify.go
@@ -35,7 +35,7 @@ type entryPlan struct {
 	imohash      [ImohashSize]byte
 }
 
-// isConflict reports a destructive disagreement requiring --overwrite.
+// needsConsent reports a destructive disagreement requiring --overwrite.
 func (p *entryPlan) needsConsent() bool { return p.disp == dispDiffers || p.disp == dispConflict }
 
 // classifySummary is the breakdown shown in the accept prompt.
@@ -150,20 +150,9 @@ func classifyOne(e wire.ListingEntry, target, targetDir string, checksum bool) e
 		}
 		return p
 
-	case wire.EntrySymlink:
-		switch {
-		case !exists:
-			p.disp = dispNew
-		case st.Mode()&os.ModeSymlink != 0:
-			if tgt, err := os.Readlink(target); err == nil && tgt == e.SymlinkTarget {
-				p.disp = dispIdentical
-			} else {
-				p.disp = dispDiffers
-			}
-		default:
-			p.disp = dispConflict
-		}
-		return p
+	// No EntrySymlink case: classify() rejects peer symlinks outright before
+	// reaching here (a security boundary — the sender dereferences symlinks
+	// and never emits one).
 
 	default: // EntryFile
 		// Precedence: identical/verify target → resume → differ/conflict → new.

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -619,7 +619,6 @@ func materialize(s *Streams, p *entryPlan, approveOverwrite bool) error {
 	}
 }
 
-// planToDecision maps a plan to its wire decision and fires receiver-side
 // repairIdenticalMode propagates a permission-only change onto an
 // already-identical regular file, whose unchanged size+mtime (or content
 // hash under --checksum) would otherwise skip it and never pick up the new
@@ -634,6 +633,7 @@ func repairIdenticalMode(p *entryPlan) {
 	}
 }
 
+// planToDecision maps a plan to its wire decision and fires receiver-side
 // notifications (skip / conflict-kept).
 func planToDecision(p *entryPlan, approveOverwrite bool, opts RecvOptions) wire.Decision {
 	d := wire.Decision{Index: p.entry.Index}

--- a/internal/transfer/transport.go
+++ b/internal/transfer/transport.go
@@ -1,7 +1,7 @@
 // Package transfer implements fsend's end-to-end transfer protocol: HELLO
 // negotiation, optional password gating, per-file metadata + acceptance,
-// chunked data streaming with BLAKE3 verification, resume via imohash on
-// partial sidecars, and deterministic tar bundling for directories.
+// chunked data streaming with BLAKE3 verification, and resume via imohash
+// on partial sidecars. Directories travel as per-file entries, not a tar.
 //
 // The Send and Recv entry points operate on a Streams pair (one control,
 // one data) — production wires them to QUIC streams, tests wire them to

--- a/internal/wire/control.go
+++ b/internal/wire/control.go
@@ -85,9 +85,9 @@ func ReadControl(r io.Reader, payloadPtr any) (FrameType, error) {
 
 // ReadControlRaw reads one control frame from r and returns its type
 // and the still-gob-encoded body. Callers that need to dispatch on
-// FrameType before decoding (e.g. the sender's FILE_INFO loop, which
-// may receive FILE_ACCEPT or ERROR) use this to avoid a wasted decode
-// against the wrong target type.
+// FrameType before decoding (e.g. a negotiate loop that may receive a
+// data frame or an ERROR) use this to avoid a wasted decode against the
+// wrong target type.
 func ReadControlRaw(r io.Reader) (FrameType, []byte, error) {
 	var header [controlHeaderSize]byte
 	if _, err := io.ReadFull(r, header[:]); err != nil {

--- a/internal/wire/wire.go
+++ b/internal/wire/wire.go
@@ -20,10 +20,10 @@ package wire
 // the mismatch at HELLO and report a protocol error.
 const ProtocolVersion = 0x02
 
-// MaxControlFrameSize bounds gob payload size on control frames. One
-// FILE_INFO at a time is the largest control frame in flight, so a
-// modest limit is enough — and prevents a malicious peer from
-// allocating unbounded memory.
+// MaxControlFrameSize bounds gob payload size on control frames. A
+// listing batch (capped by maxListingBatchBytes) is the largest control
+// frame in flight, so a modest limit is enough — and prevents a malicious
+// peer from allocating unbounded memory.
 const MaxControlFrameSize = 64 * 1024 // 64 KiB
 
 // MaxChunkSize bounds the plaintext payload in a data CHUNK frame.


### PR DESCRIPTION
Low-risk cleanup, no behavior change.

## Changes

- **Dead code:** removed the unreachable `EntrySymlink` case in `classifyOne`. `classify()` rejects any peer symlink *before* `classifyOne` runs (a security boundary — the sender dereferences symlinks and never emits one), so the branch was dead. Its `os.Readlink` "compare" looked like real symlink support and was exactly the maintainer trap the review flagged: someone reviving it would silently reopen the traversal hole `classify()` closes. The security rejection, the defense-in-depth `materialize` symlink case, and the reachable symlink-conflict path are all untouched.
- **Correctness:** the relay-allocate response hardcoded `TTLSeconds: 600` while the session's paired TTL is `FSEND_PAIRED_TTL` — an operator raising it got the wrong value reported. Now uses `cfg.PairedTTL`. (The field is informational — the client doesn't consume it today — but the API surface is now accurate.)
- **Comment drift:** `transport.go` still described tar bundling (removed in protocol v2); `wire.go`/`control.go` referenced the dead `FILE_INFO`/`FILE_ACCEPT` frames; a prior PR (#137) split `planToDecision`'s doc comment across `repairIdenticalMode`; `classify.go`'s `needsConsent` still carried its old `isConflict` name.

## Deferred (not in this PR)

- The benign `SummaryEntry.SymlinkTarget` / `previewItem.link` plumbing is also dead but touches reachable preview rendering — left alone to keep this cleanup low-risk.
- The **directory-mode propagation gap** (an identical dir's mode never propagates, unlike files after #137) is a *behavior* change needing a final-pass design — it's coming as its own PR.

## Validation

- `go test ./internal/transfer ./internal/server ./internal/wire ./cmd/fsend` green; `go vet ./...` clean.
- `TestHostile_SymlinkListingRejected` and the traversal tests still pass — the security boundary is intact.
- Live directory transfer: sender preview renders, all files land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)