### PR TITLE
fix(transfer): preserve directory modes on the receiver

### DIFF
--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -612,3 +612,71 @@ func TestEngine_PasswordFixedWrongSingleAttempt(t *testing.T) {
 		t.Fatalf("send=%v recv=%v, want ErrWrongPassword on both", se, re)
 	}
 }
+
+// Directory modes are preserved on the receiver — including a restrictive
+// mode, which must be applied after the dir's children land (not before, or
+// writing them would fail).
+func TestEngine_DirModePreserved(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows has no Unix directory permission bits")
+	}
+	src, dst := t.TempDir(), t.TempDir()
+	// A 0750 dir and a read-only 0555 dir containing a file.
+	writeFile(t, filepath.Join(src, "tree", "priv", "keep.txt"), []byte("secret"))
+	writeFile(t, filepath.Join(src, "tree", "ro", "data.bin"), []byte("payload"))
+	if err := os.Chmod(filepath.Join(src, "tree", "priv"), 0o750); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(filepath.Join(src, "tree", "ro"), 0o555); err != nil {
+		t.Fatal(err)
+	}
+	// Loosen the read-only dirs on both trees so t.TempDir cleanup can remove them.
+	t.Cleanup(func() {
+		_ = os.Chmod(filepath.Join(src, "tree", "ro"), 0o755)
+		_ = os.Chmod(filepath.Join(dst, "tree", "ro"), 0o755)
+	})
+
+	if se, re := fileTransfer(t, []string{filepath.Join(src, "tree")}, dst, nil); se != nil || re != nil {
+		t.Fatalf("send=%v recv=%v", se, re)
+	}
+
+	for rel, want := range map[string]os.FileMode{"tree/priv": 0o750, "tree/ro": 0o555} {
+		st, err := os.Stat(filepath.Join(dst, rel))
+		if err != nil {
+			t.Fatalf("stat %s: %v", rel, err)
+		}
+		if got := st.Mode() & os.ModePerm; got != want {
+			t.Errorf("%s mode = %o, want %o", rel, got, want)
+		}
+	}
+	// The child under the read-only dir must still have landed (mode applied last).
+	if got := mustRead(t, filepath.Join(dst, "tree", "ro", "data.bin")); string(got) != "payload" {
+		t.Errorf("file under read-only dir did not land: %q", got)
+	}
+}
+
+// A chmod on a source directory propagates on an identical re-send, matching
+// the file behavior — the dir is otherwise never re-created.
+func TestEngine_DirModePropagatesOnIdenticalResend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows has no Unix directory permission bits")
+	}
+	src, dst := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(src, "d", "f.txt"), []byte("x"))
+	if err := os.Chmod(filepath.Join(src, "d"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if se, re := fileTransfer(t, []string{filepath.Join(src, "d")}, dst, nil); se != nil || re != nil {
+		t.Fatalf("seed send=%v recv=%v", se, re)
+	}
+	// chmod the source dir and re-send (contents identical).
+	if err := os.Chmod(filepath.Join(src, "d"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if se, re := fileTransfer(t, []string{filepath.Join(src, "d")}, dst, nil); se != nil || re != nil {
+		t.Fatalf("resend send=%v recv=%v", se, re)
+	}
+	if st, _ := os.Stat(filepath.Join(dst, "d")); st.Mode()&os.ModePerm != 0o700 {
+		t.Errorf("dir mode not propagated: %o, want 0700", st.Mode()&os.ModePerm)
+	}
+}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -186,6 +186,7 @@ func recvFiles(ctx context.Context, s *Streams, hello *wire.SenderHello, opts Re
 	if err := receiveData(ctx, s, byIndex, decisions, plans, expected, opts); err != nil {
 		return err
 	}
+	restoreDirModes(plans)
 	if err := finishRecv(s); err != nil {
 		return err
 	}
@@ -616,6 +617,24 @@ func materialize(s *Streams, p *entryPlan, approveOverwrite bool) error {
 			_ = os.Chtimes(target, t, t)
 		}
 		return nil
+	}
+}
+
+// restoreDirModes sets each received directory to the sender's mode, after
+// its children are written. Dirs are created writable (Mode|0o700) during
+// the transfer and an identical dir is never re-created, so without this a
+// restrictive or changed dir mode would never land. Applied last, deepest
+// first, so a read-only mode can't block writing the dir's own children.
+func restoreDirModes(plans []entryPlan) {
+	for i := len(plans) - 1; i >= 0; i-- {
+		p := &plans[i]
+		if p.entry.Type != wire.EntryDir {
+			continue
+		}
+		want := os.FileMode(p.entry.Mode) & os.ModePerm
+		if st, err := os.Stat(p.target); err == nil && st.IsDir() && st.Mode()&os.ModePerm != want {
+			_ = os.Chmod(p.target, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Problem

Directory permissions weren't faithfully preserved. Two reasons:
- A **new** dir is created writable (`MkdirAll(target, Mode|0o700)`) so the transfer can write files into it — its exact mode was never restored.
- An **already-identical** dir is never re-created, so a `chmod` on a source dir never propagated (the file-mode fix in #137 only covered files).

So a `0700` private dir or a `0555` read-only dir arrived as `0755`.

## Fix

Restore each received directory to the sender's mode in a final pass **after** its children are written — deepest first, so applying a read-only mode can't block writing the dir's own contents. Covers new and identical dirs; skips conflicts (where a non-dir sits at the target). ~15 lines.

## After

```
src:  proj 0755, proj/private 0700 (contains key.txt)
dst:  proj 0755, proj/private 0700  ✓   key.txt landed ✓
```

## Validation

- Live: a `proj/private` `0700` dir lands with its exact mode and its child transfers fine (mode applied after the child).
- New tests: `TestEngine_DirModePreserved` (0750 + a 0555 dir whose child must still land), `TestEngine_DirModePropagatesOnIdenticalResend` (chmod source dir → re-send → propagates). Both skip on Windows (no Unix dir perms).
- `go test ./internal/transfer ./cmd/fsend ./test/e2e` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)