### PR TITLE
docs(cli): reconcile help text and docs with actual behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,13 @@ irm https://getfsend.alzina.dev/windows | iex
 
 All three verify the release's SHA-256 checksum before installing.
 
+Optional: tab-completion for bash, zsh, fish, or powershell — add to your
+shell's rc file:
+
+```bash
+eval "$(fsend completion zsh)"
+```
+
 <details>
 <summary>Other install methods</summary>
 

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -115,14 +115,14 @@ Examples:
 	passFlag.NoOptDefVal = passPromptSentinel
 	passFlag.DefValue = ""
 	c.Flags().BoolVar(&f.yes, "yes", false, "auto-accept incoming transfers (differing files still need --overwrite)")
-	c.Flags().StringVar(&f.outDir, "out", "", "receive into this directory")
+	c.Flags().StringVar(&f.outDir, "out", "", "receive into this directory, created if missing")
 	c.Flags().BoolVar(&f.overwrite, "overwrite", false, "overwrite existing files that differ on receive")
 	c.Flags().BoolVar(&f.checksum, "checksum", false, "decide identical files by content hash, not size+mtime (like rsync -c)")
 	c.Flags().BoolVar(&f.preview, "preview", false, "list what would be sent (CSV: path,size) and exit; no transfer")
 	c.Flags().StringVar(&f.manifest, "manifest", "", "write a CSV record (path,size,status) of the received files to this path")
-	c.Flags().BoolVar(&f.quiet, "quiet", false, "suppress non-error output")
+	c.Flags().BoolVar(&f.quiet, "quiet", false, "suppress all non-error output (send still prints the bare code to stdout)")
 	c.Flags().BoolVar(&f.json, "json", false, "emit NDJSON events (code, final summary) on stdout")
-	c.Flags().StringVar(&f.hostname, "name", "", "override the hostname shown to the peer")
+	c.Flags().StringVar(&f.hostname, "name", "", "override the device name shown to the peer (default: hostname)")
 	c.Flags().StringSliceVar(&f.excludes, "exclude", nil,
 		"glob patterns to skip when bundling a directory (repeatable or comma-separated)")
 
@@ -262,7 +262,6 @@ SENDING
                          keep it with: fsend <code> > note.txt)
   --preview              List what would be sent (CSV: path,size) and exit —
                          no code, no transfer (pipe-friendly: --preview > out.csv)
-  --name <string>        Override the hostname shown to the peer
 
 RECEIVING
   --yes                  Auto-accept incoming transfers (no prompt).
@@ -281,7 +280,10 @@ RECEIVING
                          received files to <file>
 
 GENERAL
-  --quiet                Suppress all non-error output
+  --name <string>        Override the device name shown to the peer
+                         (default: hostname)
+  --quiet                Suppress all non-error output (send still prints
+                         the bare code to stdout)
   --json                 NDJSON events on stdout: the code when issued, and
                          a final summary (see docs/usage.md for the schema)
   --debug                Verbose logging to stderr (also: FSEND_DEBUG=1)
@@ -297,6 +299,10 @@ ADVANCED
   --send / --receive     Force mode (skip code/path auto-detect)
   --update               Update fsend to the latest release
   --uninstall            Remove the fsend binary and its config dir
+  fsend server           Run your own pairing/relay server (--help for env vars)
+  fsend completion <shell>
+                         Print a tab-completion script (bash, zsh, fish,
+                         powershell)
 
 LEARN MORE
   https://github.com/polius/fsend

--- a/docs/development.md
+++ b/docs/development.md
@@ -103,7 +103,7 @@ FSEND_SERVER_ADDR=":18080" /tmp/fsend server --health-check
 | `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error` |
 | `FSEND_SERVER_ADDR` | `:8080` | Signaling listener (TCP) |
 | `FSEND_RELAY_ADDR` | `:443` | Relay listener (UDP); also the STUN endpoint |
-| `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `1GB` | Per-session relay cap (wire bytes, post-compression). |
+| `FSEND_RELAY_MAX_BYTES_PER_SESSION` | `0` (unlimited) | Per-session relay cap (wire bytes, post-compression). |
 
 Full list: `/tmp/fsend server --help`. For deployment, ports, and all
 tunables, see [Self-hosting](self-hosting.md).

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -10,12 +10,15 @@ two machines. See [Security](security.md) for the details.
 
 ## Connecting
 
-### "Server unavailable — only receivers on your local network can connect" (`E001`)
+### "Server unavailable — only receivers on your local network can connect"
 
-fsend couldn't reach the pairing server. **Same-Wi-Fi transfers still
-work** — they use the local network directly and don't need the server.
-Only *cross-network* receivers (someone on a different network) can't
-connect right now.
+fsend couldn't reach the pairing server. This sender-side warning isn't
+fatal: **same-Wi-Fi transfers still work** — they use the local network
+directly and don't need the server. Only *cross-network* receivers
+(someone on a different network) can't connect right now.
+
+When the server can't be reached at all — no local-network fallback in
+play — the run ends with `E001`: "Could not reach the server (timeout)."
 
 What to try:
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -44,7 +44,7 @@ sending and what, then asks before writing anything:
 $ fsend abc-defg-jkm
   Incoming from mbp.local  ·  direct
 
-      report.pdf  ·  1 item  ·  2.4 MB
+      report.pdf  ·  1 file  ·  2.4 MB
 
   Save to ./? [Y/n] y
   Saved report.pdf to ./
@@ -68,7 +68,6 @@ without a positional argument.
 | `--text <string>` | Send a literal string instead of a file. The receiver prints it to stdout; nothing is saved to disk. To keep it: `fsend <code> > note.txt`. |
 | `--password[=<password>]` | Require the receiver to supply this password. Bare `--password` prompts interactively with a random default; supply it inline as `--password=<password>`. Also `FSEND_PASSWORD`. |
 | `--exclude <glob,…>` | Skip entries when bundling a directory. |
-| `--name <hostname>` | Override the hostname shown to the peer. |
 | `--preview` | List what would be sent as CSV (`path,size`) and exit — no code, no transfer. Redirect with `> files.csv` to inspect. |
 
 ```sh
@@ -122,6 +121,15 @@ fsend --yes --out ~/Downloads abc-defg-jkm
 fsend --yes --out - abc-defg-jkm > dump.sql   # pipe-to-pipe with the sender's `… | fsend`
 FSEND_PASSWORD=swordfish fsend --yes abc-defg-jkm
 ```
+
+### Password attempts
+
+When the sender required a password and the receiver didn't supply one,
+the receiver is prompted interactively and gets **3 attempts**. A wrong
+password supplied non-interactively (`--password=<password>` or
+`FSEND_PASSWORD`) aborts the transfer **on the first try** and burns the
+code — with no human present to retry, failing fast beats hanging a
+script. The sender has to run again for a fresh code.
 
 ### When a file already exists
 
@@ -250,6 +258,7 @@ Config is at `~/.config/fsend/config.json` (Linux),
 | Flag | Purpose |
 |---|---|
 | `--send` / `--receive` | Force mode instead of auto-detecting from the argument. Mutually exclusive; handy in scripts. |
+| `--name <string>` | Override the device name shown to the peer (default: hostname) — the sender's name in the receiver's `Incoming from …` line, the receiver's name in the sender's `Receiver connected` line. |
 | `--quiet` | Suppress non-error output. On send, prints **just the share code** to stdout (see [Scripting](#scripting)); on receive, requires `--yes`. |
 | `--debug` | Verbose logging to stderr. Also `FSEND_DEBUG=1`. |
 | `--update` | Update fsend to the latest release by re-running the installer in place. Reports when already up to date. |
@@ -264,6 +273,9 @@ Config is at `~/.config/fsend/config.json` (Linux),
 | `FSEND_PASSWORD` | `--password` | Supply the transfer password out-of-band. |
 | `FSEND_DEBUG` | `--debug` | Set to `1` (any value except `0`/`false`) for verbose stderr logging. |
 | `FSEND_NO_UPDATE_CHECK` | — | Set to `1` (any value except `0`/`false`) to disable the once-a-day check for a newer release. |
+| `NO_COLOR` | — | Set to any non-empty value to disable ANSI colors ([no-color.org](https://no-color.org)). |
+| `FORCE_COLOR` | — | Set to `1` (any value except `0`/`false`) to force ANSI colors on, even when output isn't a terminal. Colors only — spinners and progress bars still require a terminal. |
+| `TERM` | — | `TERM=dumb` disables all ANSI escapes: colors, spinners, progress rendering. |
 
 Flags always win when both are set.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,7 +76,7 @@ func SetPathForTesting(p string) { pathMu.Lock(); pathOverride = p; pathMu.Unloc
 // Path returns the absolute path where the config file lives.
 //
 // Production: resolved via XDG (Linux $XDG_CONFIG_HOME, macOS Application
-// Support, Windows %AppData%).
+// Support, Windows %LOCALAPPDATA%).
 // Test: overridden via SetPathForTesting.
 //
 // Errors only on truly broken environments where the home directory cannot

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -9,7 +9,7 @@
 //   - First line says what failed in user terms.
 //   - Second line gives an actionable next step.
 //   - Never blame the user.
-//   - Exit codes are stable from v0.1.0 onward.
+//   - Exit codes are stable from v1.0.0 onward.
 package fserrors
 
 import (
@@ -189,7 +189,7 @@ func (e Entry) Render() string {
 // Exit codes are kept in lockstep with the Exxx number (E001 → exit 1,
 // E024 → exit 24, etc.) so scripts can match on either. The only
 // exceptions are E016 (a non-fatal warning, exit 0) and E026 (Ctrl-C,
-// exit 130 by shell convention). Codes are stable from v0.1.0 onward.
+// exit 130 by shell convention). Codes are stable from v1.0.0 onward.
 //
 // Placeholders like {addr}, {code}, {path} are filled in by the caller via
 // fmt.Sprintf when known; we use plain text so unknown contexts still render.


### PR DESCRIPTION
Docs/help-template-only PR from a senior CLI UX audit — no behavior changes. Drift → fix, numbered as audited:

1. **--quiet help lied**: template said "Suppress all non-error output" but a quiet send deliberately prints the bare code on stdout (the documented scripting contract). Template line and the registered flag string now both say "(send still prints the bare code to stdout)".
2. **--name listed under SENDING only** but it works on receive too (the receiver's name is shown to the sender on "Receiver connected"). Moved to GENERAL in the help template and to Shared flags in docs/usage.md; reworded from "hostname shown to the peer" to "device name shown to the peer (default: hostname)" — flag name kept.
3. **Registered flag strings vs template drift**: --out's flag string was missing "created if missing" (template and mkdir-p behavior include it). Swept the other flag strings against the template; no other contradictions found (remaining differences are template elaborations, not conflicts).
4. **docs/development.md**: FSEND_RELAY_MAX_BYTES_PER_SESSION default corrected from `1GB` to `0` (unlimited), matching self-hosting.md, `fsend server --help`, and the code default.
5. **Exit-code stability claim**: `git tag` starts at v1.0.0 (no v0.x tags), so docs/usage.md's "Stable from v1.0.0" is the truth — fixed the two `v0.1.0` comments in internal/fserrors/fserrors.go instead.
6. **troubleshooting.md** labeled the sender-side mid-wait warning ("Server unavailable — only receivers on your local network can connect") as (E001). Dropped the tag from the heading and the section now quotes the real E001 message ("Could not reach the server (timeout).") for the total-failure case — grepping either string lands here. Did not document the abbreviated mid-wait `[E001]` line (being removed in fix/error-plumbing).
7. **docs/usage.md receive example**: "1 item" → "1 file" (the code renders CountNoun "file(s)", never "item").
8. **internal/config comment drift**: Path()'s comment said Windows `%AppData%`; verified against the actual dependency (`adrg/xdg` v0.5.3, `paths_windows.go`: `configHome = LOCALAPPDATA`) — the pkg doc and usage.md were already correct with `%LOCALAPPDATA%`, so the Path() comment was fixed to match, not the other way around (see note below).
9. **Root help** now lists `fsend server` and `fsend completion <shell>` under ADVANCED; README's Install section gains a short shell-completion snippet.
10. **NO_COLOR / FORCE_COLOR / TERM=dumb** added to docs/usage.md's environment-variables table (env vars only — the upcoming --no-color flag belongs to fix/prompts-dispatch).
11. **Password asymmetry documented**: interactive receivers get 3 attempts; a wrong password via `--password=X`/`FSEND_PASSWORD` aborts on the first try and burns the code — intended (no human present to retry).
12. E013 wording and its troubleshooting section untouched (owned by fix/kept-files-truth).

**Deliberate deviation from the audit note on item 8**: the audit assumed `os.UserConfigDir` (→ `%AppData%`), but the code resolves the path via `github.com/adrg/xdg`, which maps ConfigHome to `%LOCALAPPDATA%` on Windows. The existing pkg doc and usage.md were right; only the Path() comment was wrong.

**Validation**
- `go build ./... && go test ./...` — all packages pass, including test/e2e (no retries needed).
- Rebuilt binary; `./fsend --help </dev/null` renders cleanly with correct column alignment; every claim in the template verified against code.
- root_test.go template guards pass (`TestHelpTemplate_ListsEveryFlag`, `TestBoldHelpHeaders`).
- Sanity greps: no remaining "1 item", "v0.1.0", or "hostname shown to the peer".

🤖 Generated with [Claude Code](https://claude.com/claude-code)