### PR TITLE
fix(cli): tell the sender the truth when the receiver keeps files

### DIFF
--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -137,11 +137,17 @@ func renderError(err error, debug bool) int {
 	case entry.Exit == 0:
 		glyph = uxlog.Warn()
 	case errors.Is(err, fserrors.ErrUserCancelled),
+		errors.Is(err, errKeptByChoice),
 		!errorRoleSender && errors.Is(err, fserrors.ErrReceiverDeclined):
 		glyph = uxlog.Info()
 	}
 
 	switch {
+	case errors.Is(err, errKeptByChoice):
+		// The user answered "n" at the overwrite prompt — narrate their
+		// decision, not a failure, and skip the "Use --overwrite" advice
+		// they just declined. Exit stays 13 so scripts see the partial.
+		fmt.Fprintf(os.Stderr, "%s [%s] Kept your local copies — nothing was overwritten.\n", glyph, entry.Code)
 	case detail != "" && errors.Is(err, fserrors.ErrSourceNotFound):
 		// Inline the missing path into the message: the catalog message
 		// ends in "." which we strip so it reads as one sentence —

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -32,19 +32,20 @@ type receiverUI struct {
 	sink     bool
 	pathInfo connpath.Info
 
-	mu          sync.Mutex
-	hello       *wire.SenderHello
-	files       []string
-	prev        map[uint32]uint64
-	total       int64 // bytes received this run (excludes resumed prefixes)
-	skipped     int64 // resumed prefixes already on disk
-	skippedSame int   // files skipped because they were identical
-	kept        int   // differing/conflicting entries left untouched
-	bar         *uxlog.Progress
-	firstByte   time.Time
-	bytesHint   int64
-	diffBytes   int64 // bytes that move only if overwrite is approved
-	manifestErr error // a --manifest write failure, surfaced after the transfer
+	mu           sync.Mutex
+	hello        *wire.SenderHello
+	files        []string
+	prev         map[uint32]uint64
+	total        int64 // bytes received this run (excludes resumed prefixes)
+	skipped      int64 // resumed prefixes already on disk
+	skippedSame  int   // files skipped because they were identical
+	kept         int   // differing/conflicting entries left untouched
+	keptByChoice bool  // kept because the user answered the overwrite prompt with "n"
+	bar          *uxlog.Progress
+	firstByte    time.Time
+	bytesHint    int64
+	diffBytes    int64 // bytes that move only if overwrite is approved
+	manifestErr  error // a --manifest write failure, surfaced after the transfer
 
 	closeOnce sync.Once
 }
@@ -224,6 +225,11 @@ func (ui *receiverUI) confirmOverwrite(conflicts []transfer.Conflict) bool {
 			ui.mu.Unlock()
 			return true
 		case "", "n", "no":
+			// An answered prompt is a choice, not a failure — finishReceive
+			// reports it with errKeptByChoice instead of a bare E013.
+			ui.mu.Lock()
+			ui.keptByChoice = true
+			ui.mu.Unlock()
 			return false
 		case "l", "list":
 			for _, c := range conflicts {
@@ -357,6 +363,7 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 	files := append([]string(nil), ui.files...)
 	firstByte := ui.firstByte
 	kept := ui.kept
+	keptByChoice := ui.keptByChoice
 	skippedSame := ui.skippedSame
 	ui.mu.Unlock()
 
@@ -388,10 +395,18 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 		return ui.manifestErr
 	}
 	if kept > 0 {
+		if keptByChoice {
+			return errKeptByChoice
+		}
 		return fserrors.ErrTargetExists
 	}
 	return nil
 }
+
+// errKeptByChoice is ErrTargetExists after the user answered "n" at the
+// overwrite prompt: same E013 exit so scripts see the partial, but rendered
+// as their decision (ℹ, no "use --overwrite" advice they just declined).
+var errKeptByChoice = fmt.Errorf("%w: kept by choice", fserrors.ErrTargetExists)
 
 func printTextPayload(files []string) error {
 	if len(files) == 0 {

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -292,14 +292,15 @@ func writeSendPreview(w io.Writer, sources []transfer.Source) error {
 // actually crossed the wire, so a partial send reads "Y (X sent)".
 type senderStats struct {
 	moved        int64 // bytes pushed on the wire this run
-	skippedFiles int   // whole files (non-dir) the receiver declined as identical
+	skippedFiles int   // whole files (non-dir) the receiver declined, keptFiles included
+	keptFiles    int   // subset of skippedFiles the receiver kept as differing copies
 }
 
 // newSenderProgress builds the progress callbacks driving a single overall
 // bar. Returns close, progress, onResume, onSkip, a stats getter, and
 // onStreamingEOF (latches the bar total once a stream EOFs). All callbacks
 // run on the single send-loop goroutine, so the counters need no locking.
-func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn func(uint32, uint64), onResume func(uint32, uint64, uint64), onSkip func(uint32), stats func() senderStats, onStreamingEOF func(uint32, uint64)) {
+func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn func(uint32, uint64), onResume func(uint32, uint64, uint64), onSkip func(uint32, bool), stats func() senderStats, onStreamingEOF func(uint32, uint64)) {
 	prev := make(map[uint32]uint64)
 	var s senderStats
 	var bar *uxlog.Progress
@@ -330,7 +331,12 @@ func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn fun
 				uxlog.Println(fmt.Sprintf("  %s %s", uxlog.Info(), resumeNotice(offset, total)))
 			}
 		},
-		func(uint32) { s.skippedFiles++ },
+		func(_ uint32, kept bool) {
+			s.skippedFiles++
+			if kept {
+				s.keptFiles++
+			}
+		},
 		func() senderStats { return s },
 		func(_ uint32, finalBytes uint64) { bar.SetTotal(int64(finalBytes), true) }
 }
@@ -344,23 +350,33 @@ func resumeNotice(offset, total uint64) string {
 	return s
 }
 
-// printSendSummary renders the post-transfer success line. skippedFiles is the
-// count of (non-dir) entries the receiver declined; 0 omits the clause.
-func printSendSummary(f *flags, total, moved int64, skippedFiles int, elapsed time.Duration, path connpath.Info) {
+// printSendSummary renders the post-transfer outcome line. Files the receiver
+// kept (differing, no --overwrite there) make it a warning, not a success —
+// the sender must not read "✓ Sent" when nothing was delivered. Skips without
+// the kept flag stay the neutral "skipped": an old receiver doesn't report
+// the distinction (wire.Decision.Kept), so "up to date" would overclaim.
+func printSendSummary(f *flags, total int64, s senderStats, elapsed time.Duration, path connpath.Info) {
 	if f.quiet {
 		return
 	}
-	parts := summaryParts(total, moved, "sent", elapsed, path)
-	// The receiver may have declined files it already had. The sender can't
-	// tell an identical file from one the receiver kept a different version of
-	// (both arrive as DecisionSkip — see wire.DecisionAction), so it reports
-	// the neutral, always-true "skipped" count. That still reconciles with the
-	// receiver's precise "N up to date · M kept" breakdown by sum, and it's
-	// what explains a partial — or zero — "(X sent)" against the offered total.
-	if skippedFiles > 0 {
-		parts = append(parts, uxlog.CountNoun(skippedFiles, "file")+" skipped")
+	glyph, headline := uxlog.Check(), "Sent"
+	parts := summaryParts(total, s.moved, "sent", elapsed, path)
+	if s.keptFiles > 0 {
+		glyph = uxlog.Warn()
+		if s.moved == 0 {
+			// "Sent · 2.1 MB (0 B sent)" would contradict itself; name the
+			// outcome and drop the redundant moved clause.
+			headline = "Nothing sent"
+			parts[0] = uxlog.HumanBytes(total) + " offered"
+		}
 	}
-	fmt.Fprintf(os.Stderr, "%s Sent  ·  %s\n", uxlog.Check(), strings.Join(parts, "  ·  "))
+	if n := s.skippedFiles - s.keptFiles; n > 0 {
+		parts = append(parts, uxlog.CountNoun(n, "file")+" skipped")
+	}
+	if s.keptFiles > 0 {
+		parts = append(parts, uxlog.CountNoun(s.keptFiles, "file")+" kept by receiver (needs --overwrite there)")
+	}
+	fmt.Fprintf(os.Stderr, "%s %s  ·  %s\n", glyph, headline, strings.Join(parts, "  ·  "))
 	printUpdateNotice(f)
 }
 

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -723,9 +723,9 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 	}
 	// An all-skipped transfer (receiver had everything) emits no bytes, so
 	// the skip is the only event that stops the accept spinner.
-	skip := func(fi uint32) {
+	skip := func(fi uint32, kept bool) {
 		spin.Stop()
-		onSkip(fi)
+		onSkip(fi, kept)
 	}
 	current := firstRes
 	opts := retry.Options{OnRetry: retryNoticeFor(f)}
@@ -790,8 +790,7 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 	// down to a full skip ("0 B sent") — reconciles instead of silently
 	// dropping to the sent bytes. The skipped-file count explains the gap and
 	// reconciles with the receiver's breakdown. printSend* no-op under --quiet.
-	s := stats()
-	printSendSummary(f, int64(plan.totalBytes), s.moved, s.skippedFiles, elapsed, pathInfo)
+	printSendSummary(f, int64(plan.totalBytes), stats(), elapsed, pathInfo)
 	return nil
 }
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -93,6 +93,11 @@ rest of the transfer completed.
   you confirm; `--manifest <file>` records the exact per-file outcome.
 - Byte-identical files are always skipped silently — this only fires on
   real differences.
+- If you answered `n` at the overwrite prompt yourself, the line renders as
+  the neutral "Kept your local copies" instead of an error — the exit code
+  stays 13 either way so scripts can detect the partial.
+- The sender sees the same outcome: "N files kept by receiver", and
+  "Nothing sent" with a warning glyph when no bytes moved at all.
 
 ### "File arrived corrupted" / "source file changed" (`E011`, `E019`)
 

--- a/internal/transfer/classify_test.go
+++ b/internal/transfer/classify_test.go
@@ -53,3 +53,29 @@ func TestSummarize_PopulatesFiles(t *testing.T) {
 		t.Errorf("BytesToRecv = %d, want 350", s.BytesToRecv)
 	}
 }
+
+// The Kept flag must mark exactly the skips of differing/conflicting entries
+// the receiver kept — it's what lets the sender report "kept by receiver"
+// instead of a false "✓ Sent" when nothing was delivered.
+func TestPlanToDecision_KeptFlag(t *testing.T) {
+	for _, tc := range []struct {
+		disp     disposition
+		approve  bool
+		wantAct  wire.DecisionAction
+		wantKept bool
+	}{
+		{dispNew, false, wire.DecisionSend, false},
+		{dispIdentical, false, wire.DecisionSkip, false},
+		{dispDiffers, false, wire.DecisionSkip, true},
+		{dispConflict, false, wire.DecisionSkip, true},
+		{dispDiffers, true, wire.DecisionSend, false},
+		{dispConflict, true, wire.DecisionSend, false},
+	} {
+		p := entryPlan{entry: wire.ListingEntry{Type: wire.EntryFile}, disp: tc.disp}
+		d := planToDecision(&p, tc.approve, RecvOptions{})
+		if d.Action != tc.wantAct || d.Kept != tc.wantKept {
+			t.Errorf("planToDecision(%v, approve=%v) = {Action:%v Kept:%v}, want {%v %v}",
+				tc.disp, tc.approve, d.Action, d.Kept, tc.wantAct, tc.wantKept)
+		}
+	}
+}

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -676,6 +676,7 @@ func planToDecision(p *entryPlan, approveOverwrite bool, opts RecvOptions) wire.
 			d.Action = wire.DecisionSend
 		} else {
 			d.Action = wire.DecisionSkip
+			d.Kept = true
 			if opts.OnConflictKept != nil {
 				opts.OnConflictKept(p.entry.RelativePath)
 			}

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -36,9 +36,12 @@ type SendOptions struct {
 
 	Password string
 
-	ProgressFn     func(index uint32, bytesSent uint64)
-	OnResume       func(index uint32, offset, total uint64)
-	OnSkip         func(index uint32)
+	ProgressFn func(index uint32, bytesSent uint64)
+	OnResume   func(index uint32, offset, total uint64)
+	// OnSkip fires per receiver-declined entry. kept is true when the
+	// receiver reported keeping a differing copy; false also means
+	// "unknown" (old receivers don't send the flag).
+	OnSkip         func(index uint32, kept bool)
 	OnStreamingEOF func(index uint32, finalBytes uint64)
 }
 
@@ -131,7 +134,7 @@ func sendFiles(ctx context.Context, s *Streams, opts SendOptions) error {
 			// Mirror the receiver (recv.go): directories aren't user-facing
 			// "files", so a skipped dir mustn't inflate the unchanged count.
 			if ok && opts.OnSkip != nil && src.Entry.Type != wire.EntryDir {
-				opts.OnSkip(src.Entry.Index)
+				opts.OnSkip(src.Entry.Index, d.Kept)
 			}
 			continue
 		}

--- a/internal/wire/payloads.go
+++ b/internal/wire/payloads.go
@@ -68,6 +68,12 @@ type Decision struct {
 	Action         DecisionAction
 	ResumeOffset   uint64
 	PartialImohash [16]byte
+	// Kept marks a DecisionSkip of a differing/conflicting entry the
+	// receiver kept, as opposed to an identical one. Gob keeps this
+	// compatible across versions: old peers ignore the field, and a zero
+	// value from an old receiver reads as "unknown" — the sender then
+	// falls back to the neutral "skipped" wording.
+	Kept bool
 }
 
 // FileHash carries one file's BLAKE3 root, sent by the sender in a

--- a/test/e2e/transfer_test.go
+++ b/test/e2e/transfer_test.go
@@ -423,6 +423,43 @@ func TestReceive_DifferingFileKept_ReceiverSeesE013(t *testing.T) {
 		t.Errorf("sender exit = %d, want 0 (transfer completes; file skipped)\nstderr:\n%s",
 			r.senderExitCode, r.senderErr)
 	}
+	// The sender must tell the same story: its file was NOT delivered, so no
+	// green "Sent" — warn glyph, "Nothing sent", and the kept-by-receiver
+	// clause (wire.Decision.Kept flowing back).
+	if strings.Contains(r.senderErr, "[OK] Sent") {
+		t.Errorf("sender must not claim success when the receiver kept everything:\nstderr:\n%s", r.senderErr)
+	}
+	if !strings.Contains(r.senderErr, "Nothing sent") || !strings.Contains(r.senderErr, "1 file kept by receiver") {
+		t.Errorf("sender summary should say nothing was delivered and why:\nstderr:\n%s", r.senderErr)
+	}
+	if got, _ := os.ReadFile(filepath.Join(dst, "p.bin")); string(got) != "PREEXISTING" {
+		t.Errorf("destination file was clobbered: %q", got)
+	}
+}
+
+// Answering "n" at the overwrite prompt is a decision, not a failure: the
+// exit stays 13 (scripts must see the partial) but the error line is the
+// neutral ℹ acknowledging the choice — not a red ✗ telling the user to pass
+// the --overwrite they just declined.
+func TestReceive_OverwriteDeclined_NeutralE013(t *testing.T) {
+	requireE2E(t)
+	src, dst := t.TempDir(), t.TempDir()
+	srcFile := filepath.Join(src, "p.bin")
+	writeRandom(t, srcFile, 64*1024)
+	if err := os.WriteFile(filepath.Join(dst, "p.bin"), []byte("PREEXISTING"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// "y" accepts the transfer, "n" answers the overwrite prompt.
+	r := h.runPair(t, []string{srcFile}, dst, nil, "y\nn\n")
+	if r.receiverExitCode != 13 {
+		t.Errorf("receiver exit = %d, want 13\nstderr:\n%s", r.receiverExitCode, r.receiverErr)
+	}
+	if !strings.Contains(r.receiverErr, "[i] [E013] Kept your local copies") {
+		t.Errorf("declined overwrite should render as the user's choice:\nstderr:\n%s", r.receiverErr)
+	}
+	if strings.Contains(r.receiverErr, "[FAIL] [E013]") || strings.Contains(r.receiverErr, "Use --overwrite") {
+		t.Errorf("declined overwrite must not scold with the advice the user declined:\nstderr:\n%s", r.receiverErr)
+	}
 	if got, _ := os.ReadFile(filepath.Join(dst, "p.bin")); string(got) != "PREEXISTING" {
 		t.Errorf("destination file was clobbered: %q", got)
 	}


### PR DESCRIPTION
Fixes the two top findings (P1#1, P1#2) from the 2026-07-03 CLI UX audit.

## P1#1 — sender claimed success when nothing was delivered

Before (receiver kept the only, differing file):

```
sender:   [OK] Sent  ·  2.1 MB (0 B sent)  ·  1ms  ·  Direct on local network  ·  1 file skipped
receiver: [FAIL] [E013] …  (exit 13)
```

After:

```
sender:   [!] Nothing sent  ·  2.1 MB offered  ·  1ms  ·  Direct on local network  ·  1 file kept by receiver (needs --overwrite there)
```

- `wire.Decision` gains a `Kept bool` set for differing/conflicting entries the receiver keeps. Gob keeps it compatible: **old peers ignore the field**, and a zero value from an old receiver reads as "unknown" → the sender falls back to the previous neutral "skipped" wording rather than overclaiming.
- A new enum value was deliberately NOT used: an old sender treats an unknown `DecisionAction` as "send", which would stream data the receiver won't write.
- Sender exit code stays 0 by design (rsync-like): delivery refusal is receiver policy and the receiver signals it with exit 13. The sender's ⚠/wording now carries the truth.

## P1#2 — E013 scolded the user for their own explicit "n"

Answering `n` at the overwrite prompt now renders:

```
[i] [E013] Kept your local copies — nothing was overwritten.
```

instead of `✗ [E013] Target file exists and --overwrite was not given.` + "Use --overwrite…". Exit stays 13 so scripts still detect the partial. Non-interactive keeps (`--yes`, EOF at the prompt) keep the loud red form — no human made a choice there.

## Validation

- `go build`, `go vet`, full `go test ./...` including e2e — green.
- New tests: `TestPlanToDecision_KeptFlag` (unit), sender-side assertions added to `TestReceive_DifferingFileKept_ReceiverSeesE013`, new `TestReceive_OverwriteDeclined_NeutralE013` (e2e, drives both prompts).
- Live loopback runs of the kept flow (output above), plus **mixed-version probes** with a binary built from `main`:
  - new sender + old receiver → `[OK] Sent · … · 1 file skipped` (graceful fallback, no false "kept" claim), exit 13 on the old receiver, no protocol errors.
  - old sender + new receiver → unchanged behavior, exit 13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)