### PR TITLE
feat(cli): --json — NDJSON code and summary events on stdout

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -920,14 +920,10 @@ func TestPromptAccept_YesWarnsAboutKeptDiffers(t *testing.T) {
 // butt against it when both streams share a sink (2>&1, CI logs) — the line
 // break goes to stderr, keeping the piped stdout bytes exact.
 func TestPrintTextPayload_BreaksLineForPipedStdout(t *testing.T) {
-	path := filepath.Join(t.TempDir(), "payload")
-	if err := os.WriteFile(path, []byte("no-newline"), 0o600); err != nil {
-		t.Fatal(err)
-	}
 	var stdout string
 	stderr := captureStderr(t, func() {
 		stdout = captureStdout(t, func() {
-			if err := printTextPayload([]string{path}); err != nil {
+			if err := printTextPayload("no-newline"); err != nil {
 				t.Errorf("printTextPayload: %v", err)
 			}
 		})
@@ -940,11 +936,8 @@ func TestPrintTextPayload_BreaksLineForPipedStdout(t *testing.T) {
 	}
 
 	// A newline-terminated payload needs no break.
-	if err := os.WriteFile(path, []byte("clean\n"), 0o600); err != nil {
-		t.Fatal(err)
-	}
 	stderr = captureStderr(t, func() {
-		_ = captureStdout(t, func() { _ = printTextPayload([]string{path}) })
+		_ = captureStdout(t, func() { _ = printTextPayload("clean\n") })
 	})
 	if stderr != "" {
 		t.Errorf("newline-terminated payload must not emit a break, got %q", stderr)

--- a/cmd/fsend/jsonout.go
+++ b/cmd/fsend/jsonout.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/polius/fsend/internal/connpath"
+	"github.com/polius/fsend/internal/fserrors"
+)
+
+// --json turns stdout into NDJSON: one JSON object per line, schema
+// versioned by "v" and evolved additively only (documented in
+// docs/usage.md). Human output stays on stderr, untouched.
+//
+// Two events exist:
+//   - "code": the sender's pairing code, emitted as soon as it is issued
+//     so a script can relay it before the transfer completes.
+//   - "done": the final outcome, emitted exactly once per run — from the
+//     summary path when the transfer reached one (rich: bytes/files/route),
+//     or from renderError otherwise (ok/error/exit only).
+//
+// jsonOut is package-level state, mirroring errorRoleSender: renderError
+// runs after the transfer stack has unwound, and the once-guard is what
+// lets the rich summary event win over the generic failure event.
+var jsonOut struct {
+	mu      sync.Mutex
+	enabled bool
+	done    bool
+}
+
+func jsonEnable() {
+	jsonOut.mu.Lock()
+	jsonOut.enabled = true
+	jsonOut.mu.Unlock()
+}
+
+func jsonEnabled() bool {
+	jsonOut.mu.Lock()
+	defer jsonOut.mu.Unlock()
+	return jsonOut.enabled
+}
+
+// jsonEvent marshals and prints one NDJSON line. Events are small structs
+// of strings/ints; a marshal failure is a programming error, but stdout is
+// the machine channel so it must never carry a half-written line — drop
+// the event instead.
+func jsonEvent(v any) {
+	b, err := json.Marshal(v)
+	if err != nil {
+		return
+	}
+	_, _ = fmt.Fprintln(os.Stdout, string(b))
+}
+
+type jsonCodeEvent struct {
+	V     int    `json:"v"`
+	Event string `json:"event"`
+	Code  string `json:"code"`
+}
+
+// jsonDoneEvent is the terminal event. Omitted fields mean "not known at
+// this exit path" (a failure before the summary has no byte counts).
+type jsonDoneEvent struct {
+	V          int    `json:"v"`
+	Event      string `json:"event"`
+	Ok         bool   `json:"ok"`
+	Role       string `json:"role"`
+	Error      string `json:"error,omitempty"` // catalog code, e.g. "E013"
+	Exit       int    `json:"exit"`
+	BytesTotal *int64 `json:"bytes_total,omitempty"`
+	BytesMoved *int64 `json:"bytes_moved,omitempty"`
+	// Sender: files_sent / files_skipped (receiver-declined, reason
+	// unknown for old peers) / files_kept. Receiver: files_saved /
+	// files_up_to_date / files_kept.
+	FilesSent    *int   `json:"files_sent,omitempty"`
+	FilesSkipped *int   `json:"files_skipped,omitempty"`
+	FilesSaved   *int   `json:"files_saved,omitempty"`
+	FilesSame    *int   `json:"files_up_to_date,omitempty"`
+	FilesKept    *int   `json:"files_kept,omitempty"`
+	DurationMS   *int64 `json:"duration_ms,omitempty"`
+	Route        string `json:"route,omitempty"`
+	Dir          string `json:"dir,omitempty"`  // receiver: where files landed
+	Text         string `json:"text,omitempty"` // receiver: --text payload (replaces raw stdout)
+}
+
+func jsonEmitCode(code string) {
+	jsonOut.mu.Lock()
+	on := jsonOut.enabled
+	jsonOut.mu.Unlock()
+	if on {
+		jsonEvent(jsonCodeEvent{V: 1, Event: "code", Code: code})
+	}
+}
+
+// jsonEmitDone emits the done event once; later calls are no-ops.
+func jsonEmitDone(ev jsonDoneEvent) {
+	jsonOut.mu.Lock()
+	defer jsonOut.mu.Unlock()
+	if !jsonOut.enabled || jsonOut.done {
+		return
+	}
+	jsonOut.done = true
+	ev.V, ev.Event = 1, "done"
+	jsonEvent(ev)
+}
+
+// jsonDoneFromErr builds the generic failure event renderError emits when
+// no summary ran. err == nil is a clean exit some caller narrated itself.
+func jsonDoneFromErr(err error, exit int, sender bool) jsonDoneEvent {
+	ev := jsonDoneEvent{Ok: err == nil && exit == 0, Role: "receiver", Exit: exit}
+	if sender {
+		ev.Role = "sender"
+	}
+	if err != nil {
+		entry, _ := fserrors.Lookup(err)
+		ev.Error = entry.Code
+	}
+	return ev
+}
+
+// jsonRoute maps a connection path to its stable machine name; "" (omitted)
+// when the path was never established.
+func jsonRoute(k connpath.Kind) string {
+	switch k {
+	case connpath.KindLocal:
+		return "local"
+	case connpath.KindDirectNAT:
+		return "direct"
+	case connpath.KindRelay:
+		return "relay"
+	}
+	return ""
+}
+
+func ptr64(v int64) *int64 { return &v }
+func ptrInt(v int) *int    { return &v }
+
+func msPtr(d time.Duration) *int64 { return ptr64(d.Milliseconds()) }

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -38,6 +38,12 @@ func main() {
 	//   fsend --connect host:port [password]  → set custom
 	os.Args = normalizeConnectArgs(os.Args)
 
+	// Raw-args scan (like debugRequested): flag parsing itself can fail,
+	// and a script that asked for --json still deserves a JSON failure.
+	if argsHaveFlag("--json") {
+		jsonEnable()
+	}
+
 	if err := rootCmd().Execute(); err != nil {
 		os.Exit(renderError(err, debugRequested()))
 	}
@@ -193,6 +199,8 @@ func renderError(err error, debug bool) int {
 			fmt.Fprintf(os.Stderr, "  DEBUG: %s\n", c)
 		}
 	}
+	// No-op if the summary already emitted the rich done event.
+	jsonEmitDone(jsonDoneFromErr(err, entry.Exit, errorRoleSender))
 	return entry.Exit
 }
 

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -43,6 +43,10 @@ func runReceive(f *flags, c string) error {
 	if f.outDir == "-" && f.manifest != "" {
 		return fmt.Errorf("%w: --manifest has no effect with --out -", fserrors.ErrUsage)
 	}
+	// Sink mode gives stdout to the file bytes; NDJSON would corrupt them.
+	if f.outDir == "-" && f.json {
+		return fmt.Errorf("%w: --json cannot be combined with --out - (stdout carries the received bytes)", fserrors.ErrUsage)
+	}
 	// Validate --out before any network work: a missing directory would
 	// otherwise only fail at write time, after the sender's one-shot code
 	// has been consumed.

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -371,36 +371,60 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 		elapsed = time.Since(firstByte)
 	}
 
-	if h != nil && h.Mode == wire.ModeStream && h.IsText && !ui.sink {
-		if err := printTextPayload(files); err != nil {
+	total, moved := ui.bytes()
+	text := ""
+	isText := h != nil && h.Mode == wire.ModeStream && h.IsText && !ui.sink
+	if isText {
+		payload, err := readTextPayload(files)
+		if err != nil {
 			return err
 		}
-		total, moved := ui.bytes()
+		text = payload
+		// Under --json the payload rides in the done event instead of
+		// raw stdout, which must stay pure NDJSON.
+		if !jsonEnabled() {
+			if err := printTextPayload(text); err != nil {
+				return err
+			}
+		}
 		printRecvSummary(f, "Received text", total, moved, kept, 0, elapsed, ui.pathInfo)
-		return nil
+	} else {
+		headline := ui.headline(h, files)
+		// With kept-back files the peer-supplied display name ("2 files") would
+		// overcount what actually landed — say how many of the offer were written.
+		if kept > 0 && !ui.sink {
+			headline = fmt.Sprintf("Saved %d of %s to %s",
+				len(files), uxlog.CountNoun(len(files)+skippedSame+kept, "file"), displayPath(ui.outDir))
+		}
+		printRecvSummary(f, headline, total, moved, kept, skippedSame, elapsed, ui.pathInfo)
 	}
-	total, moved := ui.bytes()
-	headline := ui.headline(h, files)
-	// With kept-back files the peer-supplied display name ("2 files") would
-	// overcount what actually landed — say how many of the offer were written.
-	if kept > 0 && !ui.sink {
-		headline = fmt.Sprintf("Saved %d of %s to %s",
-			len(files), uxlog.CountNoun(len(files)+skippedSame+kept, "file"), displayPath(ui.outDir))
-	}
-	printRecvSummary(f, headline, total, moved, kept, skippedSame, elapsed, ui.pathInfo)
 	// manifestErr is set by onManifest, which runs on this goroutine before we
 	// return, so no lock is needed. The transfer succeeded; the failure is only
 	// that --manifest couldn't be written.
-	if ui.manifestErr != nil {
-		return ui.manifestErr
+	var retErr error
+	switch {
+	case ui.manifestErr != nil:
+		retErr = ui.manifestErr
+	case kept > 0 && keptByChoice:
+		retErr = errKeptByChoice
+	case kept > 0:
+		retErr = fserrors.ErrTargetExists
 	}
-	if kept > 0 {
-		if keptByChoice {
-			return errKeptByChoice
+	ev := jsonDoneEvent{Ok: retErr == nil, Role: "receiver",
+		BytesTotal: ptr64(total), BytesMoved: ptr64(moved),
+		DurationMS: msPtr(elapsed), Route: jsonRoute(ui.pathInfo.Kind), Text: text}
+	if retErr != nil {
+		entry, _ := fserrors.Lookup(retErr)
+		ev.Error, ev.Exit = entry.Code, entry.Exit
+	}
+	if !isText {
+		ev.FilesSaved, ev.FilesSame, ev.FilesKept = ptrInt(len(files)), ptrInt(skippedSame), ptrInt(kept)
+		if !ui.sink {
+			ev.Dir = ui.outDir
 		}
-		return fserrors.ErrTargetExists
 	}
-	return nil
+	jsonEmitDone(ev)
+	return retErr
 }
 
 // errKeptByChoice is ErrTargetExists after the user answered "n" at the
@@ -408,19 +432,28 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 // as their decision (ℹ, no "use --overwrite" advice they just declined).
 var errKeptByChoice = fmt.Errorf("%w: kept by choice", fserrors.ErrTargetExists)
 
-func printTextPayload(files []string) error {
+// readTextPayload lifts the text payload off disk (it was staged as a file)
+// and removes the staging file.
+func readTextPayload(files []string) (string, error) {
 	if len(files) == 0 {
-		return nil
+		return "", nil
 	}
 	b, err := os.ReadFile(files[0])
 	if err != nil {
-		return fmt.Errorf("%w: text payload: %v", fserrors.ErrReadFailed, err)
+		return "", fmt.Errorf("%w: text payload: %v", fserrors.ErrReadFailed, err)
 	}
 	_ = os.Remove(files[0])
-	if _, err := os.Stdout.Write(b); err != nil {
+	return string(b), nil
+}
+
+func printTextPayload(text string) error {
+	if text == "" {
+		return nil
+	}
+	if _, err := os.Stdout.WriteString(text); err != nil {
 		return err
 	}
-	if len(b) > 0 && b[len(b)-1] != '\n' {
+	if text[len(text)-1] != '\n' {
 		if term.IsTerminal(int(os.Stdout.Fd())) {
 			fmt.Println()
 		} else {

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -48,6 +48,7 @@ type flags struct {
 
 	// Misc
 	quiet     bool
+	json      bool // NDJSON events on stdout; human output stays on stderr
 	debug     bool
 	update    bool
 	uninstall bool
@@ -120,6 +121,7 @@ Examples:
 	c.Flags().BoolVar(&f.preview, "preview", false, "list what would be sent (CSV: path,size) and exit; no transfer")
 	c.Flags().StringVar(&f.manifest, "manifest", "", "write a CSV record (path,size,status) of the received files to this path")
 	c.Flags().BoolVar(&f.quiet, "quiet", false, "suppress non-error output")
+	c.Flags().BoolVar(&f.json, "json", false, "emit NDJSON events (code, final summary) on stdout")
 	c.Flags().StringVar(&f.hostname, "name", "", "override the hostname shown to the peer")
 	c.Flags().StringSliceVar(&f.excludes, "exclude", nil,
 		"glob patterns to skip when bundling a directory (repeatable or comma-separated)")
@@ -278,6 +280,8 @@ RECEIVING
 
 GENERAL
   --quiet                Suppress all non-error output
+  --json                 NDJSON events on stdout: the code when issued, and
+                         a final summary (see docs/usage.md for the schema)
   --debug                Verbose logging to stderr (also: FSEND_DEBUG=1)
   --help, -h             Show this help
   --version, -v          Show version
@@ -351,7 +355,7 @@ const connectShowSentinel = ":show:"
 // line would silently not run. allowYes exempts --yes, which --uninstall
 // documents as skipping its confirmation prompt.
 func maintenanceGuard(cmd *cobra.Command, f *flags, name string, allowYes bool) error {
-	for _, conflict := range []string{"send", "receive", "text", "password", "yes", "out", "overwrite", "name", "exclude", "mode", "checksum", "manifest", "preview"} {
+	for _, conflict := range []string{"send", "receive", "text", "password", "yes", "out", "overwrite", "name", "exclude", "mode", "checksum", "manifest", "preview", "json"} {
 		if conflict == "yes" && allowYes {
 			continue
 		}
@@ -368,12 +372,15 @@ func maintenanceGuard(cmd *cobra.Command, f *flags, name string, allowYes bool) 
 // dispatch implements the CLI dispatch rules documented on the main.go
 // package comment.
 func dispatch(cmd *cobra.Command, f *flags) error {
+	if f.json {
+		jsonEnable()
+	}
 	// Handle --connect (server configuration) before anything else.
 	// Reject pairings with transfer-mode flags so the user can't be
 	// surprised by "I asked for both --connect and --send and only the
 	// first ran."
 	if cmd.Flags().Changed("connect") {
-		for _, conflict := range []string{"send", "receive", "text", "password", "yes", "out", "overwrite", "name", "exclude", "mode", "update", "uninstall", "checksum", "manifest", "preview"} {
+		for _, conflict := range []string{"send", "receive", "text", "password", "yes", "out", "overwrite", "name", "exclude", "mode", "update", "uninstall", "checksum", "manifest", "preview", "json"} {
 			if cmd.Flags().Changed(conflict) {
 				return fmt.Errorf("%w: --connect cannot be combined with --%s", fserrors.ErrUsage, conflict)
 			}

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -75,6 +75,9 @@ func runSend(f *flags, paths []string) error {
 		if plan.mode != wire.ModeFiles {
 			return fmt.Errorf("%w: --preview only applies to file or folder sends", fserrors.ErrUsage)
 		}
+		if f.json {
+			return fmt.Errorf("%w: --json does not apply to --preview (its CSV is already machine-readable)", fserrors.ErrUsage)
+		}
 		return writeSendPreview(os.Stdout, plan.sources)
 	}
 
@@ -214,8 +217,13 @@ func shortRand() string {
 // printSendArtifact renders the receive-command block and starts the
 // "Waiting for receiver" spinner. --quiet emits just the code on stdout.
 func printSendArtifact(f *flags, c string, plan *sendPlan) *uxlog.Spinner {
+	// Under --json the code event replaces --quiet's bare-code line —
+	// stdout must carry exactly one machine format.
+	jsonEmitCode(c)
 	if f.quiet {
-		_, _ = fmt.Fprintln(os.Stdout, c)
+		if !jsonEnabled() {
+			_, _ = fmt.Fprintln(os.Stdout, c)
+		}
 		return nil
 	}
 	fmt.Fprintln(os.Stderr)

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -25,6 +25,7 @@ import (
 	"github.com/polius/fsend/internal/transfer"
 	"github.com/polius/fsend/internal/uxlog"
 	"github.com/polius/fsend/internal/version"
+	"github.com/polius/fsend/internal/wire"
 )
 
 // This file implements the parallel-pair sender. The high-level shape:
@@ -790,7 +791,17 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 	// down to a full skip ("0 B sent") — reconciles instead of silently
 	// dropping to the sent bytes. The skipped-file count explains the gap and
 	// reconciles with the receiver's breakdown. printSend* no-op under --quiet.
-	printSendSummary(f, int64(plan.totalBytes), stats(), elapsed, pathInfo)
+	s := stats()
+	printSendSummary(f, int64(plan.totalBytes), s, elapsed, pathInfo)
+	ev := jsonDoneEvent{Ok: true, Role: "sender",
+		BytesTotal: ptr64(int64(plan.totalBytes)), BytesMoved: ptr64(s.moved),
+		DurationMS: msPtr(elapsed), Route: jsonRoute(pathInfo.Kind)}
+	if plan.mode == wire.ModeFiles {
+		ev.FilesSent = ptrInt(plan.totalFiles - s.skippedFiles)
+		ev.FilesSkipped = ptrInt(s.skippedFiles - s.keptFiles)
+		ev.FilesKept = ptrInt(s.keptFiles)
+	}
+	jsonEmitDone(ev)
 	return nil
 }
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -176,6 +176,39 @@ prompt) and pass any password via `FSEND_PASSWORD`:
 FSEND_PASSWORD=swordfish fsend "$(cat code.txt)" --quiet --yes --out ~/incoming
 ```
 
+### JSON output (`--json`)
+
+`--json` turns stdout into NDJSON — one JSON object per line, nothing
+else. Human output (progress, prompts, summaries) stays on stderr, so
+`--json` composes with or without `--quiet`. Exit codes are unchanged.
+
+Two events exist. The **sender** emits the pairing code as soon as it is
+issued, then a final summary; the **receiver** emits only the summary:
+
+```json
+{"v":1,"event":"code","code":"abc-defg-jkm"}
+{"v":1,"event":"done","ok":true,"role":"sender","exit":0,"bytes_total":2100000,"bytes_moved":2100000,"files_sent":1,"files_skipped":0,"files_kept":0,"duration_ms":312,"route":"local"}
+```
+
+Fields of `done`:
+
+| Field | Meaning |
+| --- | --- |
+| `ok` / `error` / `exit` | Outcome; `error` is the catalog code (e.g. `"E013"`) and matches the exit code table below |
+| `bytes_total` / `bytes_moved` | Offered size vs. bytes that crossed the wire (a re-send of unchanged files moves 0) |
+| `files_sent`, `files_skipped`, `files_kept` | Sender counts (`files_skipped` = receiver-declined for an unknown reason — old receivers don't report the distinction) |
+| `files_saved`, `files_up_to_date`, `files_kept` | Receiver counts |
+| `duration_ms`, `route` | Timed from the first byte; `route` is `local`, `direct`, or `relay` |
+| `dir` | Receiver: absolute directory files landed in |
+| `text` | Receiver: a `--text` payload rides here instead of raw stdout |
+
+On a failure before any summary exists (bad code, unreachable server),
+the `done` event carries only `ok`/`error`/`exit`. Fields are only ever
+**added** to this schema; `v` bumps on the first breaking change.
+
+`--json` is rejected with `--preview` (already CSV) and with `--out -`
+(stdout carries the received bytes).
+
 ## Chaining through a middle machine
 
 If the sender and receiver can't reach each other but a third machine can

--- a/test/e2e/json_test.go
+++ b/test/e2e/json_test.go
@@ -1,0 +1,128 @@
+package e2e
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// jsonLines parses stdout as NDJSON, failing on any non-JSON line — the
+// --json contract is that stdout carries nothing else.
+func jsonLines(t *testing.T, stdout string) []map[string]any {
+	t.Helper()
+	var out []map[string]any
+	for _, line := range strings.Split(strings.TrimSpace(stdout), "\n") {
+		if line == "" {
+			continue
+		}
+		var m map[string]any
+		if err := json.Unmarshal([]byte(line), &m); err != nil {
+			t.Fatalf("non-JSON line on --json stdout: %q (%v)", line, err)
+		}
+		out = append(out, m)
+	}
+	return out
+}
+
+func TestJSON_SendReceiveHappyPath(t *testing.T) {
+	requireE2E(t)
+	src, dst := t.TempDir(), t.TempDir()
+	srcFile := filepath.Join(src, "p.bin")
+	writeRandom(t, srcFile, 64*1024)
+
+	// --quiet on the sender: the code event must replace the bare-code
+	// line, keeping stdout pure NDJSON.
+	r := h.runPair(t, []string{srcFile, "--json", "--quiet"}, dst, []string{"--json", "--yes"}, "")
+	if r.senderExitCode != 0 || r.receiverExitCode != 0 {
+		t.Fatalf("exits: sender=%d receiver=%d\nsender stderr:\n%s\nreceiver stderr:\n%s",
+			r.senderExitCode, r.receiverExitCode, r.senderErr, r.receiverErr)
+	}
+
+	sev := jsonLines(t, r.senderOut)
+	if len(sev) != 2 || sev[0]["event"] != "code" || sev[1]["event"] != "done" {
+		t.Fatalf("sender events = %v, want [code done]", sev)
+	}
+	if sev[0]["code"] != r.code {
+		t.Errorf("code event carries %v, harness paired on %q", sev[0]["code"], r.code)
+	}
+	done := sev[1]
+	if done["ok"] != true || done["role"] != "sender" || done["files_sent"] != float64(1) || done["exit"] != float64(0) {
+		t.Errorf("sender done event: %v", done)
+	}
+
+	rev := jsonLines(t, r.receiverOut)
+	if len(rev) != 1 || rev[0]["event"] != "done" {
+		t.Fatalf("receiver events = %v, want [done]", rev)
+	}
+	rd := rev[0]
+	if rd["ok"] != true || rd["role"] != "receiver" || rd["files_saved"] != float64(1) || rd["dir"] == nil {
+		t.Errorf("receiver done event: %v", rd)
+	}
+	if rd["route"] == "" || rd["route"] == nil {
+		t.Errorf("established transfer must report a route: %v", rd)
+	}
+}
+
+// A kept differing file must surface in both done events: receiver
+// ok=false error=E013 exit=13, sender ok (its exit stays 0) but files_kept=1.
+func TestJSON_KeptFilesReported(t *testing.T) {
+	requireE2E(t)
+	src, dst := t.TempDir(), t.TempDir()
+	srcFile := filepath.Join(src, "p.bin")
+	writeRandom(t, srcFile, 64*1024)
+	if err := os.WriteFile(filepath.Join(dst, "p.bin"), []byte("PREEXISTING"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	r := h.runPair(t, []string{srcFile, "--json"}, dst, []string{"--json", "--yes"}, "")
+
+	rd := jsonLines(t, r.receiverOut)
+	last := rd[len(rd)-1]
+	if last["ok"] != false || last["error"] != "E013" || last["exit"] != float64(13) || last["files_kept"] != float64(1) {
+		t.Errorf("receiver done event should report the kept file: %v", last)
+	}
+	if r.receiverExitCode != 13 {
+		t.Errorf("receiver exit = %d, want 13", r.receiverExitCode)
+	}
+	sd := jsonLines(t, r.senderOut)
+	sdone := sd[len(sd)-1]
+	if sdone["files_kept"] != float64(1) || sdone["files_sent"] != float64(0) {
+		t.Errorf("sender done event should report the kept file: %v", sdone)
+	}
+}
+
+// A --text payload rides in the done event, never on raw stdout.
+func TestJSON_TextPayloadInEvent(t *testing.T) {
+	requireE2E(t)
+	dst := t.TempDir()
+	r := h.runPair(t, []string{"--text", "hello json", "--json"}, dst, []string{"--json", "--yes"}, "")
+	if r.receiverExitCode != 0 {
+		t.Fatalf("receiver exit = %d\nstderr:\n%s", r.receiverExitCode, r.receiverErr)
+	}
+	rd := jsonLines(t, r.receiverOut)
+	last := rd[len(rd)-1]
+	if last["text"] != "hello json" {
+		t.Errorf("text payload should ride in the done event: %v", last)
+	}
+	if strings.Contains(r.receiverOut, "\nhello json\n") || strings.HasPrefix(r.receiverOut, "hello json") {
+		t.Errorf("raw payload leaked onto --json stdout:\n%s", r.receiverOut)
+	}
+}
+
+// Failures that never reach a summary still end with a done event — here a
+// usage error, which exits before any pairing.
+func TestJSON_UsageErrorEmitsDone(t *testing.T) {
+	requireE2E(t)
+	src := t.TempDir()
+	srcFile := filepath.Join(src, "p.bin")
+	writeRandom(t, srcFile, 1024)
+	stdout, _, exit := h.runFsend(t, h.newXDG(t), srcFile, "--json", "--preview")
+	if exit != 24 {
+		t.Fatalf("exit = %d, want 24", exit)
+	}
+	ev := jsonLines(t, stdout)
+	if len(ev) != 1 || ev[0]["event"] != "done" || ev[0]["ok"] != false || ev[0]["error"] != "E024" {
+		t.Errorf("usage failure should emit a done event: %v", ev)
+	}
+}


### PR DESCRIPTION
Implements P2#8 from the 2026-07-03 CLI UX audit. **Stacked on #146** (uses the sender-side `keptFiles` count and reworked summary from that branch; GitHub will retarget to main when #146 merges).

## Contract

`--json` turns stdout into NDJSON; human output stays on stderr, so it composes with or without `--quiet`. Exit codes unchanged. Two events:

```json
{"v":1,"event":"code","code":"qpq-arrd-urn"}
{"v":1,"event":"done","ok":true,"role":"sender","exit":0,"bytes_total":2097152,"bytes_moved":2097152,"files_sent":1,"files_skipped":0,"files_kept":0,"duration_ms":60,"route":"local"}
```

- The sender emits `code` as soon as the code is issued — a wrapper can relay it before the transfer completes (validated live: the loopback receive below was driven purely by parsing this event).
- `done` is emitted exactly once per run: rich from the summary path, minimal (`ok`/`error`/`exit`) from `renderError` when the run failed before any summary. The once-guard lets the rich event win.
- Failures still produce machine truth: `{"event":"done","ok":false,"error":"E002","exit":2}` for a bad code; usage errors emit `E024` even when flag parsing itself failed (raw-args scan, same pattern as `FSEND_DEBUG`).
- Guards: rejected with `--preview` (already CSV) and `--out -` (stdout carries the payload). Under `--quiet` the code event replaces the bare-code line — stdout carries exactly one machine format. A `--text` payload rides in the done event's `text` field instead of raw stdout.
- Schema documented in docs/usage.md; versioned `"v":1`, evolved additively only.

## Validation

- Full `go test ./...` including e2e — green.
- New e2e: happy path (both sides, quiet sender, all-lines-parse assertion), kept-files (receiver `ok:false error:E013 files_kept:1`, sender `files_kept:1 files_sent:0`), text-payload-in-event (no raw leak), usage-error done event.
- Live loopback: receive driven by parsing the sender's code event with python; failure probes for E002/E024 pasted above from real runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)