### PR TITLE
feat(cli): current-file chip and sliding-window rate/ETA

### DIFF
--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -35,6 +35,8 @@ type receiverUI struct {
 	mu           sync.Mutex
 	hello        *wire.SenderHello
 	files        []string
+	names        map[uint32]string // index → sanitized name; multi-file only
+	curFile      uint32            // last index labelled on the bar
 	prev         map[uint32]uint64
 	total        int64 // bytes received this run (excludes resumed prefixes)
 	skipped      int64 // resumed prefixes already on disk
@@ -51,7 +53,10 @@ type receiverUI struct {
 }
 
 func newReceiverUI(ctx context.Context, f *flags, outDir string, sink bool, pathInfo connpath.Info) *receiverUI {
-	return &receiverUI{ctx: ctx, f: f, outDir: outDir, sink: sink, pathInfo: pathInfo, prev: make(map[uint32]uint64)}
+	// curFile starts at a sentinel no wire index uses, so file 0 still
+	// triggers the first bar label.
+	return &receiverUI{ctx: ctx, f: f, outDir: outDir, sink: sink, pathInfo: pathInfo,
+		prev: make(map[uint32]uint64), curFile: ^uint32(0)}
 }
 
 // resolveOutDir resolves --out: "-" selects sink (stdout); "" defaults to CWD.
@@ -128,6 +133,14 @@ func (ui *receiverUI) accept(h wire.SenderHello, summary transfer.ClassifySummar
 	// upfront. The prompt path instead bumps the hint in confirmOverwrite.
 	if ui.f.overwrite {
 		ui.bytesHint += ui.diffBytes
+	}
+	// Current-file chip data: multi-file only. Names are peer-supplied, so
+	// sanitize here — the only place they enter the UI state.
+	if h.Mode == wire.ModeFiles && len(summary.Files) > 1 {
+		ui.names = make(map[uint32]string, len(summary.Files))
+		for _, e := range summary.Files {
+			ui.names[e.Index] = sanitizeForDisplay(e.RelativePath, 128)
+		}
 	}
 	ui.mu.Unlock()
 	return ui.promptAccept(h, summary)
@@ -258,7 +271,7 @@ func (ui *receiverUI) onResume(fileIndex uint32, offset, total uint64) {
 		ui.prev[fileIndex] = offset
 		ui.skipped += d
 		if ui.bar == nil && !ui.f.quiet {
-			ui.bar = uxlog.New(ui.bytesHint)
+			ui.bar = uxlog.New(ui.bytesHint, ui.names != nil)
 		}
 		ui.bar.Add(d)
 	}
@@ -315,7 +328,11 @@ func (ui *receiverUI) progress(fileIndex uint32, bytesWritten uint64) {
 		ui.firstByte = time.Now()
 	}
 	if ui.bar == nil && !ui.f.quiet {
-		ui.bar = uxlog.New(ui.bytesHint)
+		ui.bar = uxlog.New(ui.bytesHint, ui.names != nil)
+	}
+	if name, ok := ui.names[fileIndex]; ok && fileIndex != ui.curFile {
+		ui.curFile = fileIndex
+		ui.bar.SetLabel(name)
 	}
 	d := bytesWritten - ui.prev[fileIndex]
 	ui.prev[fileIndex] = bytesWritten

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -312,14 +312,35 @@ func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn fun
 	prev := make(map[uint32]uint64)
 	var s senderStats
 	var bar *uxlog.Progress
+	// Current-file chip: multi-file transfers only — a single file's name is
+	// already in the pre-transfer block. Names are our own local paths, so no
+	// display sanitization is needed (matches senderPreview).
+	var names map[uint32]string
+	if plan.mode == wire.ModeFiles && plan.totalFiles > 1 {
+		names = make(map[uint32]string, len(plan.sources))
+		for _, src := range plan.sources {
+			if src.Entry.Type != wire.EntryDir {
+				names[src.Entry.Index] = src.Entry.RelativePath
+			}
+		}
+	}
+	curFile := ^uint32(0)
+	setLabel := func(fi uint32) {
+		if names == nil || fi == curFile {
+			return
+		}
+		curFile = fi
+		bar.SetLabel(names[fi])
+	}
 	ensureBar := func() {
 		if bar == nil && !f.quiet {
-			bar = uxlog.New(int64(plan.totalBytes))
+			bar = uxlog.New(int64(plan.totalBytes), names != nil)
 		}
 	}
 	return func() { bar.Done() },
 		func(fi uint32, b uint64) {
 			ensureBar()
+			setLabel(fi)
 			d := b - prev[fi]
 			prev[fi] = b
 			bar.Add(int64(d))

--- a/internal/transfer/classify.go
+++ b/internal/transfer/classify.go
@@ -59,6 +59,7 @@ type classifySummary struct {
 // SummaryEntry is one regular file (or symlink) the receiver is offered, with
 // the per-entry status the preview annotates rows with.
 type SummaryEntry struct {
+	Index         uint32 // wire file index, keys the progress callbacks
 	RelativePath  string
 	Size          uint64
 	Status        string // "new" | "identical" | "differs" | "resume"
@@ -244,6 +245,7 @@ func summarize(plans []entryPlan) classifySummary {
 		// so the preview's row count matches the headline's file count.
 		if p.entry.Type != wire.EntryDir {
 			s.Files = append(s.Files, SummaryEntry{
+				Index:         p.entry.Index,
 				RelativePath:  p.entry.RelativePath,
 				Size:          p.entry.Size,
 				Status:        dispStatus(p.disp),

--- a/internal/uxlog/progress_test.go
+++ b/internal/uxlog/progress_test.go
@@ -31,7 +31,7 @@ func silenceStderr(t *testing.T) {
 // final Done() must return cleanly even when the bar reached 100 %.
 func TestProgress_KnownTotalLifecycle(t *testing.T) {
 	silenceStderr(t)
-	p := New(1000)
+	p := New(1000, false)
 	p.Add(400)
 	p.Add(600)
 	p.Done()
@@ -43,7 +43,7 @@ func TestProgress_KnownTotalLifecycle(t *testing.T) {
 // than waiting forever for an Increment that will never come.
 func TestProgress_AbortBeforeComplete(t *testing.T) {
 	silenceStderr(t)
-	p := New(1000)
+	p := New(1000, false)
 	p.Add(250) // partial — bar at 25 %
 	p.Done()   // must not hang
 }
@@ -55,7 +55,7 @@ func TestProgress_AbortBeforeComplete(t *testing.T) {
 // for the streaming-stdin work.
 func TestProgress_StreamingSetTotal(t *testing.T) {
 	silenceStderr(t)
-	p := New(0)
+	p := New(0, false)
 	p.Add(123)
 	p.Add(456)
 	p.SetTotal(579, true)
@@ -63,12 +63,14 @@ func TestProgress_StreamingSetTotal(t *testing.T) {
 }
 
 // TestProgress_NilSafety locks in the nil-receiver guards in Add /
-// SetTotal / Done. Callers (the CLI's --quiet path) rely on being able
-// to pass a nil *Progress without branching on it at every call site.
+// SetTotal / SetLabel / Done. Callers (the CLI's --quiet path) rely on
+// being able to pass a nil *Progress without branching on it at every
+// call site.
 func TestProgress_NilSafety(t *testing.T) {
 	var p *Progress
 	p.Add(100)
 	p.SetTotal(200, true)
+	p.SetLabel("file.txt")
 	p.Done()
 }
 
@@ -86,7 +88,7 @@ func TestProgress_PlainModeNoEscapes(t *testing.T) {
 	os.Stderr = f
 	t.Cleanup(func() { os.Stderr = orig; _ = f.Close() })
 
-	p := New(1000)
+	p := New(1000, false)
 	p.Add(400)
 	p.Add(600)
 	p.Done()
@@ -114,7 +116,7 @@ func TestProgress_PlainModePartialSilent(t *testing.T) {
 	os.Stderr = f
 	t.Cleanup(func() { os.Stderr = orig; _ = f.Close() })
 
-	p := New(1000)
+	p := New(1000, false)
 	p.Add(250)
 	p.Done()
 
@@ -148,5 +150,39 @@ func TestProgress_PlainModeUnknownTotalShowsRate(t *testing.T) {
 	p2.add(10 * 1000)
 	if out := buf.String(); strings.Contains(out, "/s") {
 		t.Errorf("sub-floor stream must not show a rate: %q", out)
+	}
+}
+
+// Plain mode carries the current-file chip in its throttled line — still
+// one line per print and zero ANSI (the caller sanitizes the name).
+func TestProgress_PlainModeLabelInLine(t *testing.T) {
+	var buf bytes.Buffer
+	p := &plainProgress{w: &buf, total: 1000, start: time.Now().Add(-2 * time.Second), lastLine: time.Now().Add(-2 * time.Second)}
+	p.setLabel("docs/report.pdf")
+	p.add(400)
+	out := buf.String()
+	if !strings.Contains(out, "  ·  docs/report.pdf") {
+		t.Errorf("plain line missing current-file chip: %q", out)
+	}
+	if bytes.ContainsRune(buf.Bytes(), 0x1b) {
+		t.Errorf("plain line with label emitted ANSI escapes: %q", out)
+	}
+	if strings.Count(out, "\n") != 1 {
+		t.Errorf("plain progress must print one line per update: %q", out)
+	}
+}
+
+// truncateName keeps the tail (extension) visible with a middle ellipsis
+// and leaves short names untouched.
+func TestTruncateName(t *testing.T) {
+	if got := truncateName("short.txt", 20); got != "short.txt" {
+		t.Errorf("short name changed: %q", got)
+	}
+	got := truncateName("a-very-long-directory/deeply/nested/file.tar.gz", 20)
+	if r := []rune(got); len(r) != 20 {
+		t.Errorf("truncated to %d runes, want 20: %q", len(r), got)
+	}
+	if !strings.HasSuffix(got, ".tar.gz") || !strings.Contains(got, "…") {
+		t.Errorf("truncation must keep the tail and show an ellipsis: %q", got)
 	}
 }

--- a/internal/uxlog/rate.go
+++ b/internal/uxlog/rate.go
@@ -1,0 +1,66 @@
+package uxlog
+
+import (
+	"sync"
+	"time"
+)
+
+// rateWindowSpan is how much recent history the rate/ETA reflect. Long
+// enough to smooth per-frame jitter, short enough that a mid-transfer
+// speed change shows within seconds.
+const rateWindowSpan = 5 * time.Second
+
+// rateWindow measures throughput over the last rateWindowSpan of samples
+// so the bar's rate and ETA track current conditions instead of the
+// lifetime mean, which a slow handshake or a speed change would skew for
+// the rest of the transfer. Fed once per refresh frame by the rate
+// decorator; the ETA decorator reads it.
+type rateWindow struct {
+	mu      sync.Mutex
+	samples []rateSample
+}
+
+type rateSample struct {
+	t   time.Time
+	cum int64 // cumulative bytes at t
+}
+
+// observe records the cumulative byte count at now and returns the
+// windowed rate in bytes/sec (see rate).
+func (w *rateWindow) observe(now time.Time, cum int64) float64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	w.samples = append(w.samples, rateSample{now, cum})
+	// Drop samples older than the window, but keep the newest of them as
+	// the baseline so the measured span stays ~window wide instead of
+	// shrinking toward the sampling interval.
+	cutoff := now.Add(-rateWindowSpan)
+	i := 0
+	for i < len(w.samples)-1 && w.samples[i+1].t.Before(cutoff) {
+		i++
+	}
+	w.samples = w.samples[i:]
+	return w.rateLocked()
+}
+
+// rate returns the current windowed rate in bytes/sec, or 0 when the
+// window is too short to divide by meaningfully.
+func (w *rateWindow) rate() float64 {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.rateLocked()
+}
+
+func (w *rateWindow) rateLocked() float64 {
+	if len(w.samples) < 2 {
+		return 0
+	}
+	first, last := w.samples[0], w.samples[len(w.samples)-1]
+	span := last.t.Sub(first.t)
+	// A few frames of history minimum — a near-zero span would just
+	// amplify per-chunk jitter (and 0 would divide by zero).
+	if span < 300*time.Millisecond || last.cum <= first.cum {
+		return 0
+	}
+	return float64(last.cum-first.cum) / span.Seconds()
+}

--- a/internal/uxlog/rate_test.go
+++ b/internal/uxlog/rate_test.go
@@ -1,0 +1,79 @@
+package uxlog
+
+import (
+	"testing"
+	"time"
+)
+
+// TestRateWindow_ReflectsRecentThroughput is the point of the window: after
+// a fast stretch followed by a slow one, the reported rate must be the
+// recent (slow) throughput, not the lifetime mean.
+func TestRateWindow_ReflectsRecentThroughput(t *testing.T) {
+	w := &rateWindow{}
+	t0 := time.Now()
+	// 5 s at 10 MB/s, then 10 s at 1 MB/s (sampled every 100 ms, like the
+	// bar's refresh rate). Lifetime mean would be 4 MB/s.
+	cum := int64(0)
+	for ts := time.Duration(0); ts <= 15*time.Second; ts += 100 * time.Millisecond {
+		if ts <= 5*time.Second {
+			cum += 1000 * 1000 // 1 MB per 100 ms
+		} else {
+			cum += 100 * 1000 // 0.1 MB per 100 ms
+		}
+		w.observe(t0.Add(ts), cum)
+	}
+	got := w.rate()
+	if got < 0.9*1000*1000 || got > 1.1*1000*1000 {
+		t.Errorf("windowed rate = %.0f B/s, want ~1 MB/s (recent), not the ~4 MB/s lifetime mean", got)
+	}
+}
+
+// TestRateWindow_StallDecaysToZero: when bytes stop moving, the rate must
+// drop to 0 once the window no longer spans any progress — the chip then
+// hides instead of freezing on a stale figure.
+func TestRateWindow_StallDecaysToZero(t *testing.T) {
+	w := &rateWindow{}
+	t0 := time.Now()
+	w.observe(t0, 0)
+	w.observe(t0.Add(time.Second), 5*1000*1000)
+	// Stalled: same cumulative count for longer than the window.
+	got := w.observe(t0.Add(1*time.Second+rateWindowSpan+time.Second), 5*1000*1000)
+	if got != 0 {
+		t.Errorf("stalled window rate = %.0f, want 0", got)
+	}
+}
+
+// TestRateWindow_NoDivideByZero: empty and degenerate windows must return
+// 0, never divide by a zero span.
+func TestRateWindow_NoDivideByZero(t *testing.T) {
+	w := &rateWindow{}
+	if got := w.rate(); got != 0 {
+		t.Errorf("empty window rate = %.0f, want 0", got)
+	}
+	now := time.Now()
+	if got := w.observe(now, 1000); got != 0 {
+		t.Errorf("single-sample rate = %.0f, want 0", got)
+	}
+	// Two samples at the same instant: zero span.
+	if got := w.observe(now, 2000); got != 0 {
+		t.Errorf("zero-span rate = %.0f, want 0", got)
+	}
+}
+
+// TestRateWindow_PrunesOldSamples: samples older than the window are
+// dropped (one kept as the baseline), so memory stays bounded and the
+// baseline tracks the window's leading edge.
+func TestRateWindow_PrunesOldSamples(t *testing.T) {
+	w := &rateWindow{}
+	t0 := time.Now()
+	for i := range 100 {
+		w.observe(t0.Add(time.Duration(i)*100*time.Millisecond), int64(i)*1000)
+	}
+	w.mu.Lock()
+	n := len(w.samples)
+	w.mu.Unlock()
+	// 5 s window at 100 ms sampling ≈ 51 samples + 1 baseline.
+	if n > 60 {
+		t.Errorf("window kept %d samples, want ≤ 60 (pruned)", n)
+	}
+}

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -18,6 +18,7 @@ import (
 	"io"
 	"os"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/vbauerster/mpb/v8"
@@ -33,6 +34,7 @@ type Progress struct {
 	mp    *mpb.Progress
 	bar   *mpb.Bar
 	plain *plainProgress
+	label atomic.Value // string: current-file chip (see SetLabel)
 }
 
 // plainProgress renders progress as occasional complete lines — no
@@ -48,6 +50,7 @@ type plainProgress struct {
 	closed   bool
 	lastLine time.Time
 	start    time.Time
+	label    string // current-file chip, "" when unset
 }
 
 // plainInterval throttles plain-mode lines. One line per second keeps
@@ -63,8 +66,12 @@ func (p *plainProgress) add(n int64) {
 	}
 	p.lastLine = time.Now()
 	if p.total > 0 {
-		_, _ = fmt.Fprintf(p.w, "  %d%%  %s / %s\n",
+		line := fmt.Sprintf("%d%%  %s / %s",
 			p.current*100/p.total, HumanBytes(p.current), HumanBytes(p.total))
+		if p.label != "" {
+			line += "  ·  " + p.label
+		}
+		_, _ = fmt.Fprintf(p.w, "  %s\n", line)
 		return
 	}
 	// Unknown total (stdin streams): a bare byte counter is all a long
@@ -75,6 +82,12 @@ func (p *plainProgress) add(n int64) {
 		line += "  ·  " + r
 	}
 	_, _ = fmt.Fprintf(p.w, "  %s\n", line)
+}
+
+func (p *plainProgress) setLabel(name string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.label = name
 }
 
 func (p *plainProgress) setTotal(total int64, complete bool) {
@@ -146,7 +159,11 @@ func setActive(p *Progress) {
 // totalBytes is the entire transfer's byte count. It must be known up
 // front; for stdin/text transfers we pass 0 and the bar renders without
 // a percentage, ETA, or rate chip.
-func New(totalBytes int64) *Progress {
+//
+// showNames reserves room for the current-file chip (SetLabel). Callers
+// pass true only for multi-file transfers — a single file's name is
+// already in the pre-transfer block, so the columns go to the bar instead.
+func New(totalBytes int64, showNames bool) *Progress {
 	// Plain mode for pipes/CI, and for terminals that report a 0×0
 	// window (some pty wrappers) — mpb discards every row at height 0.
 	width, _, sizeErr := term.GetSize(int(os.Stderr.Fd()))
@@ -157,8 +174,16 @@ func New(totalBytes int64) *Progress {
 	}
 	// The fixed width assumes ~55 columns of decorators around the bar; on
 	// narrower terminals the line would wrap and the in-place redraw only
-	// clears its last visual row, leaving stale fragments behind.
-	bw := min(barWidth, max(10, width-55))
+	// clears its last visual row, leaving stale fragments behind. The
+	// current-file chip widens that budget; terminals too narrow for both
+	// keep the bar and drop the chip (wrapping is worse than no name).
+	const nameCols = 20 // chip name budget; +5 for its "  ·  " separator
+	pad, labelCap := 55, 0
+	if showNames && width >= 55+10+nameCols+5 {
+		pad += nameCols + 5
+		labelCap = nameCols
+	}
+	bw := min(barWidth, max(10, width-pad))
 
 	p := &Progress{}
 	defer setActive(p)
@@ -172,10 +197,13 @@ func New(totalBytes int64) *Progress {
 	// telegraph aesthetic the default style carries.
 	style := mpb.BarStyle().Lbound(" ").Rbound(" ").Filler("━").Tip("╸").Padding("─")
 
-	// Track elapsed locally — decor.Statistics doesn't carry it, and we
-	// want the rate decor to use the same "since New()" baseline the
-	// summary line will use for "(<rate>)".
+	// Track elapsed locally — decor.Statistics doesn't carry it. Only the
+	// ETA's ≥1 s warm-up gate uses it; the rate itself comes from win, a
+	// sliding window, so it tracks current throughput instead of a lifetime
+	// mean skewed by a slow handshake or a mid-transfer speed change. The
+	// summary line still reports the lifetime figure — that one is correct.
 	start := time.Now()
+	win := &rateWindow{}
 	hasTotal := totalBytes > 0
 	// Rate needs no total — a multi-GB stdin stream is exactly where the
 	// user wants throughput. HumanRate's own noise floor keeps it hidden
@@ -217,18 +245,19 @@ func New(totalBytes int64) *Progress {
 	if showRate {
 		appendDecs = append(appendDecs,
 			// Rate: hidden when the figure would be misleading (start
-			// of transfer, zero elapsed, or on completion — the
-			// summary line carries the final figure).
+			// of transfer, sub-MB movement — HumanRate's noise floor —
+			// or on completion; the summary carries the final figure).
+			// This decorator also feeds the window each refresh frame,
+			// so a stall shows up as a decaying rate and a growing ETA.
 			decor.Any(func(s decor.Statistics) string {
 				if s.Completed || s.Aborted || s.Current == 0 {
 					return ""
 				}
-				elapsed := time.Since(start)
-				r := HumanRate(s.Current, elapsed)
-				if r == "" {
+				r := win.observe(time.Now(), s.Current)
+				if r <= 0 || s.Current < rateThreshold {
 					return ""
 				}
-				return "  ·  " + r
+				return "  ·  " + HumanBytes(int64(r)) + "/s"
 			}),
 			// ETA: needs a known total, non-zero progress, and at least
 			// 1 s elapsed so the projection isn't dominated by handshake
@@ -237,11 +266,10 @@ func New(totalBytes int64) *Progress {
 				if s.Completed || s.Aborted || s.Total <= 0 || s.Current == 0 {
 					return ""
 				}
-				elapsed := time.Since(start)
-				if elapsed < time.Second {
+				if time.Since(start) < time.Second {
 					return ""
 				}
-				rate := float64(s.Current) / elapsed.Seconds()
+				rate := win.rate()
 				if rate <= 0 {
 					return ""
 				}
@@ -252,6 +280,18 @@ func New(totalBytes int64) *Progress {
 				return "  ·  ETA " + HumanDuration(time.Duration(remainingSecs*float64(time.Second)))
 			}),
 		)
+	}
+	if labelCap > 0 {
+		// Current-file chip, last so its per-file width changes don't
+		// jiggle the rate/ETA chips. Kept on aborted bars: the frozen
+		// name records which file the transfer stopped in.
+		appendDecs = append(appendDecs, decor.Any(func(s decor.Statistics) string {
+			name, _ := p.label.Load().(string)
+			if name == "" {
+				return ""
+			}
+			return "  ·  " + truncateName(name, labelCap)
+		}))
 	}
 
 	p.bar = p.mp.New(totalBytes,
@@ -282,6 +322,33 @@ func (p *Progress) Add(n int64) {
 	if p.bar != nil {
 		p.bar.IncrInt64(n)
 	}
+}
+
+// SetLabel sets the current-file chip rendered after the bar's other
+// decorators ("  ·  <name>"). Only shown when New was given showNames;
+// "" clears it. Callers pass display-safe names (peer-supplied strings
+// must be sanitized first) and should call only when the file changes.
+func (p *Progress) SetLabel(name string) {
+	if p == nil {
+		return
+	}
+	if p.plain != nil {
+		p.plain.setLabel(name)
+		return
+	}
+	p.label.Store(name)
+}
+
+// truncateName caps s at max runes, cutting in the middle so the tail —
+// where the extension lives — stays visible. Mirrors the consent-time
+// truncation in cmd/fsend's sanitizer.
+func truncateName(s string, max int) string {
+	r := []rune(s)
+	if len(r) <= max {
+		return s
+	}
+	tail := min(8, max/2)
+	return string(r[:max-tail-1]) + "…" + string(r[len(r)-tail:])
 }
 
 // SetTotal updates the bar's total. Useful for stdin transfers where the


### PR DESCRIPTION
Two progress-display findings from the CLI UX audit.

## Finding 1 — multi-file transfers are a black box mid-flight

One aggregate bar for the whole transfer; the current filename was never shown, so a stall on file 1,500/2,000 was indistinguishable from a network stall.

**Fix:** the bar carries a trailing `  ·  <name>` chip that follows the active file, driven by the per-chunk progress callbacks (label set only when the file index changes). Multi-file transfers only — for single-file/stream sends the name is already in the pre-transfer block and the columns go to the bar instead.

- `uxlog.Progress` gains `SetLabel` (atomic string, read by an mpb `decor.Any` and by plain mode); `New` takes a `showNames` flag so the chip is budgeted into the width math — 25 columns reserved when the terminal is ≥ 90 wide, chip dropped entirely below that (a wrapped line ghosts stale rows).
- Names are truncated middle-out to 20 runes keeping the tail, so the extension stays visible.
- Receiver names are peer-supplied: they route through `sanitizeForDisplay` (control chars, bidi, format chars) when the map is built in `accept()` — the only place they enter UI state. `transfer.SummaryEntry` gains the wire `Index` so the receiver can key the map without new callback plumbing.
- Plain (non-TTY) mode appends the name to its throttled once-per-second line; still zero ANSI, one line per print.

## Finding 2 — rate/ETA used the lifetime average

Both computed `Current/elapsed since New()`, so a slow handshake or a mid-transfer speed change skewed them for the rest of the transfer.

**Fix:** a ~5 s sliding window of `(time, cumulative bytes)` samples (`internal/uxlog/rate.go`), fed once per refresh frame by the rate decorator and read by the ETA decorator. A full stall decays the rate to 0 and hides both chips instead of freezing stale figures. Kept as-is:

- gating (rate hidden below the 1 MB noise floor and on completion; ETA needs known total, nonzero progress, ≥ 1 s elapsed),
- the end-of-transfer SUMMARY rate stays lifetime (`HumanRate(moved, elapsed)`) — that figure is correct,
- **plain mode's unknown-total stream line keeps the lifetime rate** — windowing didn't drop in trivially there (plain throttles to 1 line/s and has no per-frame tick to feed a window), and lifetime is acceptable for log-oriented output.

Window logic is unit-tested: recent-throughput-not-lifetime-mean, stall decay to zero, no divide-by-zero on empty/degenerate windows, sample pruning.

## Validation

`go build ./... && go vet ./... && go test ./...` — all green.

Live loopback, 5-file directory (734 MB of `/dev/urandom`), pty at 120 cols. Chip + windowed rate + ETA, truncated name:

```
    7%    ━━╸───────────────────────────────────    53.5 MB / 734 MB  ·  52.4 MB/s  ·  ETA 12s  ·  data/big-mo…ghts.bin
   22%    ━━━━━━━╸──────────────────────────────    159.4 MB / 734 MB  ·  52.8 MB/s  ·  ETA 10s  ·  data/big-mo…ghts.bin
```

Chip follows the active file (distinct values across the transfer): `data/big-mo…ghts.bin` → `data/nested…otos.tar` → `data/readme.md`. Max rendered line width: exactly 120 runes — no wrap.

Single-file send, same setup — no chip:

```
   16%    ━━━━━╸────────────────────────────────    66.1 MB / 419.4 MB  ·  50.7 MB/s  ·  ETA 7.0s
```

Non-TTY (piped stderr, both sides): `grep -c $'\x1b'` = 0, name in the throttled plain lines:

```
  7%  56.6 MB / 734 MB  ·  data/big-model-weights.bin
  68%  501.2 MB / 734 MB  ·  data/nested/archive-photos.tar
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)