### PR TITLE
docs(readme): tuck the tab-completion snippet into a <details>

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,12 +58,16 @@ irm https://getfsend.alzina.dev/windows | iex
 
 All three verify the release's SHA-256 checksum before installing.
 
-Optional: tab-completion for bash, zsh, fish, or powershell — add to your
-shell's rc file:
+<details>
+<summary>Tab-completion (optional)</summary>
+
+For bash, zsh, fish, or powershell — add to your shell's rc file:
 
 ```bash
 eval "$(fsend completion zsh)"
 ```
+
+</details>
 
 <details>
 <summary>Other install methods</summary>


### PR DESCRIPTION
The completion snippet added in #145 cluttered the install section; wrap it in a `<details>` matching the "Other install methods" block below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)