### PR TITLE
docs(comparison): fix croc code facts and qualify the rate-limiting claim

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -34,9 +34,9 @@ no accounts, end-to-end encrypted, self-hostable. The differences are in
   layer.
 - **Hardest codes to guess, by default.** fsend's codes carry ~45 bits
   (matching croc), and the server has built-in per-IP rate limiting of
-  guesses. magic-wormhole
-  defaults to 16 bits with no rate limiting — its own threat model
-  documents a 1-in-65,536 guess chance.
+  guesses — on for the public server, opt-in when self-hosting.
+  magic-wormhole defaults to 16 bits with no rate limiting — its own
+  threat model documents a 1-in-65,536 guess chance.
 - **Works on a LAN with no internet.** fsend (mDNS) and croc (multicast)
   pair locally and transfer offline. magic-wormhole can't — it must reach
   its mailbox server to pair, even on the same Wi-Fi.
@@ -60,7 +60,7 @@ no accounts, end-to-end encrypted, self-hostable. The differences are in
 | MITM protection                   | **Automatic** (channel-bound)              | PAKE only                             | Manual `--verify`                           |
 | Post-quantum forward secrecy      | **✓ X25519 + ML-KEM-768**                  | ✗                                     | ✗                                           |
 | Default code entropy              | **~45 bits**                               | **~45 bits**                          | 16 bits (adjustable)                        |
-| Online-guess protection           | **✓ built-in per-IP rate limiting + bounded TTL** | None server-side           | None (acknowledged in docs)                 |
+| Online-guess protection           | **✓ built-in per-IP rate limiting + bounded TTL** (on for the public server; opt-in self-hosted) | None server-side           | None (acknowledged in docs)                 |
 | Password on top of the code       | **✓ `--password`**                             | ✗ (code is the secret)                | ✗ (code is the secret)                      |
 | Choose your own code phrase       | ✗                                          | **✓ `--code`**                        | **✓ `--code`**                              |
 | Resume after interruption         | **✓ (BLAKE3 chunk-verified)**              | **✓ (chunk-based)**                   | ✗ (classic transit restarts)               |
@@ -206,22 +206,23 @@ X25519 + ML-KEM-768 hybrid is not.
 
 | | **fsend** | **croc** | **magic-wormhole** |
 |---|---|---|---|
-| Format | `abc-defg-jkm` (3-4-3 letters) | `1234-word-word-word-word` (PIN + 4 words) | `7-crossover-clockwork` (nameplate + words) |
-| Alphabet / wordlist | 23 letters (excludes `i`,`l`,`o`) | 4-digit PIN + 256-word mnemonic list | 256-word PGP word list |
+| Format | `abc-defg-jkm` (3-4-3 letters) | `1234-word-word-word` (PIN + 3 words) | `7-crossover-clockwork` (nameplate + words) |
+| Alphabet / wordlist | 23 letters (excludes `i`,`l`,`o`) | 4-digit PIN + 1,626-word mnemonicode list | 256-word PGP word list |
 | Default secret entropy | **~45 bits** | **~45 bits** (~13-bit PIN + ~32-bit words) | 16 bits (two words) |
 | Adjustable length | Fixed | Fixed (custom phrase via `--code`) | **`--code-length N`** (~8 bits/word) |
 | Custom code phrase | ✗ (system-generated) | **✓ `--code` (min 6 chars)** | **✓ `--code`** |
 | Receiver allocates the code | ✗ | ✗ | **✓ `--allocate`** |
 | One-shot | ✓ (can't be reused) | ✓ per session (reusable via `--code`) | ✓ nameplate single-use |
 | Server-side TTL | **1 h unclaimed / 10 min after pairing** | 3 h room TTL | Not specified in client docs |
-| Rate limiting | **✓ built-in, per source IP (opt-in via env)** | None server-side | None (acknowledged in docs) |
+| Rate limiting | **✓ built-in, per source IP** (on for the public server; opt-in via env when self-hosting) | None server-side | None (acknowledged in docs) |
 | Code reaches a server | **Never** — only an argon2id-stretched slot | The relay sees the room (SHA-256 of code prefix) | Words never; the (non-secret) nameplate does |
 
 fsend is strong by default, with nothing to configure. The code carries
 ~45 bits and never reaches the server (both peers register under a 64-MiB
 argon2id-stretched *slot* derived from it), and the server has per-IP
-rate limiting built in (opt-in via env; the other two have none to turn
-on) — so online brute force is infeasible.
+rate limiting built in — on for the public server, opt-in via env when
+self-hosting (the other two have none to turn on) — so online brute
+force is infeasible.
 magic-wormhole's own
 [threat model](https://magic-wormhole.readthedocs.io/en/latest/attacks.html)
 is candid about the cost of its 16-bit default: an attacker on the
@@ -310,9 +311,9 @@ it; or Python is already your path of least resistance.
   relay through a third party;
 - you transfer on a **LAN with no internet**: fsend pairs over mDNS with
   the server entirely offline; magic-wormhole can't pair at all;
-- you want **harder-to-brute-force codes by default** (built-in rate
-  limiting, bounded TTL, code never sent to the server) without asking
-  anyone to lengthen anything;
+- you want **harder-to-brute-force codes by default** (per-IP rate
+  limiting on the public server, bounded TTL, code never sent to the
+  server) without asking anyone to lengthen anything;
 - you want **defense-in-depth** (SPAKE2 *over* TLS 1.3) and
   **post-quantum** forward secrecy — neither of the others has either;
 - you want **resume**, a separate **`--password`** secret, a **`--preview`**


### PR DESCRIPTION
Two accuracy fixes to `docs/comparison.md` before it starts fielding "why not croc / magic-wormhole?" questions. The doc opens with "verified against the actual source code", so these are exactly the slips a competitor's user would pounce on.

## croc's code format was wrong

The Share codes table showed `1234-word-word-word-word` (4 words) from a "256-word mnemonic list". Croc's actual [`GetRandomName()`](https://github.com/schollz/croc/blob/master/src/utils/utils.go) encodes 4 random bytes with **mnemonicode**, which yields **3 words** from its **1,626-word** list — real croc codes look like `8853-crusade-tobacco-vega`.

The entropy row was already correct and is unchanged: ~13-bit PIN + ~32 bits of words ≈ 45 bits holds either way (3 words × ~10.7 bits/word).

## The rate-limiting claim is now qualified consistently

The TL;DR and At-a-glance table claimed "built-in per-IP rate limiting" unqualified, while the Share codes section said "opt-in via env" — a skeptical reader diffing the rows would call it out (and #111 already settled the intended posture as built-in, opt-in). All five mentions now carry the same formula: **on for the public server, opt-in when self-hosting**. The croc/wormhole cells ("None server-side" / "None") are untouched, so the contrast still lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)