### PR TITLE
fix(update): correct Windows installer URL, detect Caskroom, treat pseudo-versions as dev

### DIFF
--- a/cmd/fsend/selfupdate.go
+++ b/cmd/fsend/selfupdate.go
@@ -62,7 +62,7 @@ func runUpdate() error {
 // and the project ships a brew tap so it's the real-world case — the
 // curl script, go install, and hand-placed binaries stay self-managed.
 func managedByHomebrew(binPath string) bool {
-	for _, marker := range []string{"/Cellar/", "/homebrew/", "/linuxbrew/"} {
+	for _, marker := range []string{"/Cellar/", "/Caskroom/", "/homebrew/", "/linuxbrew/"} {
 		if strings.Contains(binPath, marker) {
 			return true
 		}

--- a/cmd/fsend/selfupdate_test.go
+++ b/cmd/fsend/selfupdate_test.go
@@ -29,6 +29,7 @@ func TestManagedByHomebrew(t *testing.T) {
 	for _, managed := range []string{
 		"/opt/homebrew/Cellar/fsend/1.9.1/bin/fsend",
 		"/usr/local/Cellar/fsend/1.9.1/bin/fsend",
+		"/usr/local/Caskroom/fsend/1.9.1/fsend", // cask on Intel: no Cellar, no /homebrew/
 		"/home/linuxbrew/.linuxbrew/bin/fsend",
 	} {
 		if !managedByHomebrew(managed) {

--- a/cmd/fsend/selfupdate_windows.go
+++ b/cmd/fsend/selfupdate_windows.go
@@ -23,7 +23,7 @@ func runInstaller(binPath string) error {
 	}
 
 	cmd := exec.Command("powershell", "-NoProfile", "-Command",
-		"irm https://getfsend.alzina.dev/install.ps1 | iex")
+		"irm https://getfsend.alzina.dev/windows | iex")
 	cmd.Env = append(os.Environ(), "FSEND_PREFIX="+filepath.Dir(binPath))
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,6 +7,7 @@
 package version
 
 import (
+	"regexp"
 	"runtime/debug"
 	"strings"
 )
@@ -31,12 +32,23 @@ func init() {
 	}
 }
 
+// pseudoVersion matches the timestamp-commit tail of a Go module
+// pseudo-version — "v1.9.1-0.20260703131912-cbe8109ecebb" or the
+// untagged "v0.0.0-20260703131912-cbe8109ecebb".
+var pseudoVersion = regexp.MustCompile(`[-.]\d{14}-[0-9a-f]{12}$`)
+
 // buildInfoVersion maps a build-info main-module version onto the
 // ldflags convention (goreleaser injects {{.Version}}, which has no
-// leading "v"). Returns "" when build info carries nothing usable —
-// `go build` from a checkout reports "(devel)".
+// leading "v"). Returns "" when build info carries nothing usable:
+// `go build` from a checkout reports "(devel)" on older Go, and a VCS
+// pseudo-version (possibly "+dirty") on current Go — both are dev
+// builds with no release to compare against, and must not unlock the
+// update check or --update.
 func buildInfoVersion(v string) string {
 	if v == "" || v == "(devel)" {
+		return ""
+	}
+	if strings.Contains(v, "+") || pseudoVersion.MatchString(v) {
 		return ""
 	}
 	return strings.TrimPrefix(v, "v")

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -27,13 +27,18 @@ func TestString(t *testing.T) {
 	}
 }
 
-// buildInfoVersion feeds the `go install` fallback: module versions are
-// v-prefixed and must match the ldflags convention (no "v"), while a
-// plain `go build` reports "(devel)" and must stay "dev".
+// buildInfoVersion feeds the `go install` fallback: exact module
+// versions are v-prefixed and must match the ldflags convention (no
+// "v"). Everything a dev checkout can produce — "(devel)", a VCS
+// pseudo-version, "+dirty" — must stay "dev", or the binary would
+// treat itself as a release and self-update over the developer's WIP.
 func TestBuildInfoVersion(t *testing.T) {
 	cases := []struct{ in, want string }{
 		{"v1.0.0", "1.0.0"},
-		{"v1.0.1-0.20260611000000-abcdef123456", "1.0.1-0.20260611000000-abcdef123456"},
+		{"v1.0.1-rc.1", "1.0.1-rc.1"},
+		{"v1.0.1-0.20260611000000-abcdef123456", ""},
+		{"v1.9.1-0.20260703131912-cbe8109ecebb+dirty", ""},
+		{"v1.0.0+dirty", ""},
 		{"(devel)", ""},
 		{"", ""},
 	}

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -8,10 +8,10 @@
   on Windows 10/11) is the only requirement — no Git Bash needed.
 
   Quick install:
-    irm https://getfsend.alzina.dev/install.ps1 | iex
+    irm https://getfsend.alzina.dev/windows | iex
 
   With options, set env vars before piping:
-    $env:FSEND_VERSION='1.2.3'; irm https://getfsend.alzina.dev/install.ps1 | iex
+    $env:FSEND_VERSION='1.2.3'; irm https://getfsend.alzina.dev/windows | iex
 
   Or download and run with parameters:
     .\install.ps1 -Prefix C:\tools\bin -Version 1.2.3
@@ -57,7 +57,7 @@ function Show-Usage {
 fsend installer (Windows / PowerShell)
 
 Usage:
-  irm https://getfsend.alzina.dev/install.ps1 | iex
+  irm https://getfsend.alzina.dev/windows | iex
   .\install.ps1 [-Prefix DIR] [-Version VERSION]
 
 Parameters (or matching env var):


### PR DESCRIPTION
Three self-update lifecycle fixes from the third CLI UX audit (all P1/P2):

## Windows `--update` is broken today (P1)
`selfupdate_windows.go` and `install.ps1`'s own usage text invoke `https://getfsend.alzina.dev/install.ps1`, which serves **403 AccessDenied** (verified live). The working route is `/windows` (302 → raw.githubusercontent), which the README already uses. Every Windows self-update currently fails — cleanly, thanks to the rename-aside rollback, but fails.

## Homebrew guard misses Caskroom (P1)
`managedByHomebrew` matched only `/Cellar/`, `/homebrew/`, `/linuxbrew/`. The published cask uses a `binary` stanza, so on Intel macs the on-PATH symlink resolves to `/usr/local/Caskroom/fsend/<ver>/fsend` — no marker matched, and `--update`/`--uninstall` would modify a brew-managed binary behind brew's back, exactly what the guard exists to prevent. Apple Silicon was covered by accident (`/opt/homebrew`).

## VCS pseudo-versions defeat the dev-build guard (P2)
Go 1.24+ stamps `go build` checkout binaries with a pseudo-version (`1.9.1-0.2026…+dirty`) via build info, which the version plumbing accepted as release `1.9.1`: dev builds got the daily update nag despite the "dev builds never check" intent, and `--update` would replace a developer's WIP binary with the latest release. `buildInfoVersion` now rejects pseudo-versions and `+` build metadata at the single choke point, fixing the nag, `--update`, and `--version` at once. Exact `go install …@vX.Y.Z` builds (the intended beneficiaries) keep working; goreleaser's ldflags path is untouched.

## Validation
- Unit tests extended: Caskroom path, pseudo-version/`+dirty`/`-rc.1` cases (the old test pinned the buggy pass-through and now asserts the fix)
- `GOOS=windows go build ./...` clean
- Live: `/windows` → 302→200, `/install.ps1` → 403 (the bug)
- Empirical: fresh checkout build now prints `fsend dev` and refuses `--update` with the dev-build message before any output or network I/O (exit 33)

🤖 Generated with [Claude Code](https://claude.com/claude-code)