### PR TITLE
fix(cli): resume progress no longer reads past 100%

### DIFF
--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -270,8 +270,16 @@ func (ui *receiverUI) onResume(fileIndex uint32, offset, total uint64) {
 		d := int64(offset - ui.prev[fileIndex])
 		ui.prev[fileIndex] = offset
 		ui.skipped += d
+		// bytesHint counts only bytes still to receive (classify deducts
+		// the partial's aligned offset), but the bar's numerator counts the
+		// resumed prefix too — grow the total by the same delta or the bar
+		// reads past 100%. Both sides then show absolute-over-full-size,
+		// matching the sender.
+		ui.bytesHint += d
 		if ui.bar == nil && !ui.f.quiet {
 			ui.bar = uxlog.New(ui.bytesHint, ui.names != nil)
+		} else {
+			ui.bar.SetTotal(ui.bytesHint, false)
 		}
 		ui.bar.Add(d)
 	}

--- a/internal/uxlog/progress_test.go
+++ b/internal/uxlog/progress_test.go
@@ -172,6 +172,18 @@ func TestProgress_PlainModeLabelInLine(t *testing.T) {
 	}
 }
 
+// A caller whose accounting overshoots the total must never see a
+// percentage past 100 — the raw counters still expose the mismatch.
+func TestProgress_PlainModePercentClamped(t *testing.T) {
+	var buf bytes.Buffer
+	p := &plainProgress{w: &buf, total: 1000, start: time.Now().Add(-2 * time.Second), lastLine: time.Now().Add(-2 * time.Second)}
+	p.add(1180)
+	out := buf.String()
+	if !strings.HasPrefix(strings.TrimSpace(out), "100%") {
+		t.Errorf("overshot progress must clamp to 100%%: %q", out)
+	}
+}
+
 // truncateName keeps the tail (extension) visible with a middle ellipsis
 // and leaves short names untouched.
 func TestTruncateName(t *testing.T) {

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -66,8 +66,10 @@ func (p *plainProgress) add(n int64) {
 	}
 	p.lastLine = time.Now()
 	if p.total > 0 {
+		// Clamp: a percentage past 100 is never correct output, whatever
+		// the caller's accounting did.
 		line := fmt.Sprintf("%d%%  %s / %s",
-			p.current*100/p.total, HumanBytes(p.current), HumanBytes(p.total))
+			min(100, p.current*100/p.total), HumanBytes(p.current), HumanBytes(p.total))
 		if p.label != "" {
 			line += "  ·  " + p.label
 		}


### PR DESCRIPTION
P1 from the third CLI UX audit: a resumed receive rendered progress past 100% — `118%  278.9 MB / 235 MB` (non-TTY), `102%` at the tail of TTY-plain runs.

## Cause
`bytesHint` (the bar's total) counts only bytes still to receive: classify deducts each partial's chunk-aligned resume offset. But `onResume` added that resumed prefix into the bar's **numerator** without growing the total — so the bar ends at `BytesToRecv + offset` over a denominator of `BytesToRecv`, overshooting by exactly the partial size.

## Fix
- `onResume` grows `bytesHint` by the same delta it adds (and `SetTotal`s a bar that already exists, for the multi-file case where a later file resumes mid-transfer). Both sides now render absolute-over-full-size, matching the sender's basis. The `offset > prev` guard keeps reconnect-resumes (bytes already counted) from double-growing.
- `plainProgress` clamps its percentage at 100 — a percentage past 100 is never correct output, and the raw byte counters still expose any future accounting mismatch.

## Validation
- Empirical repro of the audit scenario: 200MB loopback transfer, receiver killed at ~35%, resumed with piped stderr — now renders `Resuming from 69.2 MB (33%)`, `60%  125.8 MB / 209.7 MB`, `87%  183.5 MB / 209.7 MB`, exit 0, sha256 match on both ends; the summary's `209.7 MB (140.5 MB received)` annotation is unchanged.
- New unit test pins the plain-mode clamp; full `internal/uxlog` + `cmd/fsend` suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)