### PR TITLE
fix(cli): name the server-password and rate-limit causes in the sender's pairing notice

### DIFF
--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -587,18 +587,24 @@ func runSendOnce(ctx context.Context, f *flags, plan *sendPlan, code string, cfg
 				drainBoth(lanCh, serverCh, lanDone, serverDone)
 				return serverErr
 			}
-			// Any server-path failure (unreachable, rate-limited, bad
-			// password, 5xx) leaves the code working on the local network
-			// only — say so, or the sender waits forever on a code that
-			// cross-network receivers can't redeem. Skipped when the user
-			// explicitly forced the internet path with --mode=direct/relay:
-			// LAN is disabled, so the notice would be misleading. No
-			// E-coded line here: if the LAN path also fails, the final
-			// renderError prints the same catalog entry — once is enough.
+			// Any server-path failure leaves the code working on the local
+			// network only — say so, or the sender waits forever on a code
+			// that cross-network receivers can't redeem. The notice names
+			// the cause when the sender can act on it (password, rate
+			// limit); the LAN wait that follows never ends, so this line
+			// is the only place those causes can surface. Skipped when the
+			// user explicitly forced the internet path with
+			// --mode=direct/relay: LAN is disabled, so the notice would be
+			// misleading. No E-coded line here: if the LAN path also
+			// fails, the final renderError prints the catalog entry —
+			// once is enough.
+			if f.debug {
+				fmt.Fprintln(os.Stderr, "DEBUG: server pairing failed:", serverErr)
+			}
 			if !serverDownNoticed && !f.quiet && !lanDisabled {
 				serverDownNoticed = true
 				waitSpin.Stop()
-				fmt.Fprintln(os.Stderr, uxlog.Warn(), "Server unavailable — only receivers on your local network can connect.")
+				fmt.Fprintln(os.Stderr, uxlog.Warn(), serverPairNotice(serverErr))
 				waitSpin = startWaitSpinner(f, "Waiting for receiver on local network")
 			}
 		}
@@ -810,6 +816,21 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 // transfer-side failure.
 func isServerDown(err error) bool {
 	return errors.Is(err, fserrors.ErrServerUnreachable)
+}
+
+// serverPairNotice renders the mid-wait warning for a failed server
+// path. 401 and 429 are the sender's own problem to fix — name them;
+// everything else (unreachable, 5xx) stays the generic "unavailable".
+func serverPairNotice(err error) string {
+	const lanOnly = "only receivers on your local network can connect."
+	switch {
+	case errors.Is(err, fserrors.ErrServerAuthRequired):
+		return "The server requires a password (fsend --connect <host:port>,<password>) — " + lanOnly
+	case errors.Is(err, fserrors.ErrRateLimited):
+		return "The server rate-limited this device; wait a minute and try again — until then " + lanOnly
+	default:
+		return "Server unavailable — " + lanOnly
+	}
 }
 
 // pickFinalSendError chooses which error to surface when both pair

--- a/cmd/fsend/sendpair_test.go
+++ b/cmd/fsend/sendpair_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -139,6 +140,30 @@ func TestPickFinalSendError(t *testing.T) {
 				t.Errorf("got %v, want %v", got, tc.want)
 			}
 		})
+	}
+}
+
+// serverPairNotice must name the causes the sender can act on (401,
+// 429) — the LAN wait that follows never ends, so this notice is the
+// only place they surface — and keep the generic line for the rest.
+func TestServerPairNotice(t *testing.T) {
+	cases := []struct {
+		err  error
+		want string // substring
+	}{
+		{fmt.Errorf("claim: %w", fserrors.ErrServerAuthRequired), "requires a password"},
+		{fmt.Errorf("claim: %w", fserrors.ErrRateLimited), "rate-limited"},
+		{fserrors.ErrServerUnreachable, "Server unavailable"},
+		{errors.New("http 503"), "Server unavailable"},
+	}
+	for _, tc := range cases {
+		got := serverPairNotice(tc.err)
+		if !strings.Contains(got, tc.want) {
+			t.Errorf("serverPairNotice(%v) = %q, want substring %q", tc.err, got, tc.want)
+		}
+		if !strings.Contains(got, "local network") {
+			t.Errorf("notice %q must keep the LAN consolation", got)
+		}
 	}
 }
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -20,6 +20,13 @@ directly and don't need the server. Only *cross-network* receivers
 When the server can't be reached at all — no local-network fallback in
 play — the run ends with `E001`: "Could not reach the server (timeout)."
 
+Two variants of this warning name a cause you can fix yourself:
+
+- "The server requires a password" — set it with
+  `fsend --connect <host:port>,<password>` (ask the server operator).
+- "The server rate-limited this device" — wait a minute and run
+  fsend again.
+
 What to try:
 
 - Check your internet connection.


### PR DESCRIPTION
P1 from the third CLI UX audit: a sender whose configured server requires a password (401) or has rate-limited it (429) printed **`Server unavailable — only receivers on your local network can connect.`** — factually wrong (the server is up) — and then sat in the endless LAN wait. Because that wait never ends, the E028/E017 catalog entries never render for senders, and `--debug` said nothing about the real cause. A receiver in the identical situation gets the correct, actionable E028/E017.

## Fix
- `serverPairNotice` picks the warning line by cause: 401 → *"The server requires a password (fsend --connect <host:port>,<password>) — only receivers on your local network can connect."*; 429 → *"The server rate-limited this device; wait a minute and try again — …"*; everything else keeps the existing generic line **verbatim** (docs/troubleshooting.md and architecture.md quote it).
- The server-path error is now always logged under `--debug` (`DEBUG: server pairing failed: …`).
- The LAN degradation is deliberately preserved in all cases — the design intent (code keeps working locally) was right; only the words and debug silence were wrong.
- troubleshooting.md gains the two new variants under the existing "Server unavailable" section.

## Validation (live, before/after)
- `FSEND_SERVER_PASSWORD=sekret` server: sender now prints the password notice + DEBUG line, keeps waiting on LAN (unchanged behavior otherwise).
- `FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MINUTE=1` server: second sender prints the rate-limit notice.
- Dead server: generic copy byte-identical to before.
- Regression: 200MB two-file loopback transfer completes, sha256 match both ends.
- New unit test pins all three variants; `go vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)