### PR TITLE
docs(readme,cli): per-shell completion lines, host[:port], json role field

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ irm https://getfsend.alzina.dev/windows | iex
 
 All three verify the release's SHA-256 checksum before installing.
 
+Install somewhere else: pipe into `PREFIX=~/.local/bin sh` instead of `sh`, or set `$env:FSEND_PREFIX` before the `irm` line.
+
 <details>
 <summary>Other install methods</summary>
 
@@ -74,10 +76,13 @@ Or grab a release binary from [the releases page](https://github.com/polius/fsen
 <details>
 <summary>Tab-completion (optional)</summary>
 
-For bash, zsh, fish, or powershell — add to your shell's rc file:
+Add the line for your shell to its rc file (`$PROFILE` on PowerShell):
 
 ```bash
-eval "$(fsend completion zsh)"
+eval "$(fsend completion zsh)"                                 # zsh
+eval "$(fsend completion bash)"                                # bash
+fsend completion fish | source                                 # fish
+fsend completion powershell | Out-String | Invoke-Expression   # powershell
 ```
 
 </details>
@@ -108,7 +113,7 @@ fsend ./project                    # a whole folder
 fsend a.txt b.txt c.txt            # several at once
 pg_dump mydb | fsend               # a stream from stdin
 fsend --text "wifi: hunter2"       # a literal string
-fsend report.pdf --password            # gated behind a password
+fsend report.pdf --password        # gated behind a password
 ```
 
 …and to receive:

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -199,9 +199,10 @@ USAGE
   fsend completion <bash|zsh|fish|powershell>
 
 EXAMPLES
-  zsh:   eval "$(fsend completion zsh)"
-  bash:  eval "$(fsend completion bash)"
-  fish:  fsend completion fish | source
+  zsh:         eval "$(fsend completion zsh)"
+  bash:        eval "$(fsend completion bash)"
+  fish:        fsend completion fish | source
+  powershell:  fsend completion powershell | Out-String | Invoke-Expression
 
   Add the line to your shell's rc file to load it on every session.
 `
@@ -292,8 +293,9 @@ GENERAL
 
 ADVANCED
   --connect              Show current server
-  --connect <host:port>  Set the server (persisted)
-  --connect <host:port>,<password>
+  --connect <host[:port]>
+                         Set the server (persisted)
+  --connect <host[:port]>,<password>
                          Set the server + shared password
   --connect default      Revert to the compiled-in default server
   --send / --receive     Force mode (skip code/path auto-detect)

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -190,7 +190,7 @@ FSEND_PASSWORD=swordfish fsend "$(cat code.txt)" --quiet --yes --out ~/incoming
 else. Human output (progress, prompts, summaries) stays on stderr, so
 `--json` composes with or without `--quiet`. Exit codes are unchanged.
 
-Two events exist. The **sender** emits the pairing code as soon as it is
+Two events exist. The **sender** emits the share code as soon as it is
 issued, then a final summary; the **receiver** emits only the summary:
 
 ```json
@@ -203,6 +203,7 @@ Fields of `done`:
 | Field | Meaning |
 | --- | --- |
 | `ok` / `error` / `exit` | Outcome; `error` is the catalog code (e.g. `"E013"`) and matches the exit code table below |
+| `role` | `"sender"` or `"receiver"` — which side emitted the event; always present |
 | `bytes_total` / `bytes_moved` | Offered size vs. bytes that crossed the wire (a re-send of unchanged files moves 0) |
 | `files_sent`, `files_skipped`, `files_kept` | Sender counts (`files_skipped` = receiver-declined for an unknown reason — old receivers don't report the distinction) |
 | `files_saved`, `files_up_to_date`, `files_kept` | Receiver counts |
@@ -211,7 +212,7 @@ Fields of `done`:
 | `text` | Receiver: a `--text` payload rides here instead of raw stdout |
 
 On a failure before any summary exists (bad code, unreachable server),
-the `done` event carries only `ok`/`error`/`exit`. Fields are only ever
+the `done` event carries only `ok`/`role`/`error`/`exit`. Fields are only ever
 **added** to this schema; `v` bumps on the first breaking change.
 
 `--json` is rejected with `--preview` (already CSV) and with `--out -`


### PR DESCRIPTION
Documentation-surface fixes from the third CLI UX audit. Scope is exactly the audit's seven findings; no behavior changes.

## Checklist

- [x] **1 (P2)** README tab-completion: the lone `eval "$(fsend completion zsh)"` line errors in fish (no `$()` command substitution) and PowerShell (no `eval`, no rc file). Replaced with one working line per shell (zsh, bash, fish, powershell — the last via `| Out-String | Invoke-Expression` in `$PROFILE`), still inside the `<details>` block.
- [x] **2 (P3)** Help template ADVANCED: `--connect <host:port>` → `--connect <host[:port]>` (set form and password form), matching the flag usage string, connect.go stderr guidance, and normalizeServer's port defaulting. The set form's token is now 25 chars, colliding with the description column, so its description moved to a continuation line — the same pattern the password form and `fsend completion <shell>` already use. Block stays column-aligned and ≤80 cols.
- [x] **3 (P3)** `fsend completion --help`: added the powershell example line; labels re-padded so all four commands align.
- [x] **4 (P3)** docs/usage.md: "pairing code" → "share code" (the term used everywhere else).
- [x] **5 (P3)** docs/usage.md `done` fields table: added the missing `role` row (`"sender"` or `"receiver"`). Also updated the failure-path sentence ("carries only `ok`/`error`/`exit`") to include `role`, since `jsonDoneFromErr` always sets it — the row and the sentence would otherwise contradict each other.
- [x] **6 (P3)** README: aligned the `--password` example comment to column 36 with its four siblings.
- [x] **7 (P3)** README install: one line making `PREFIX` (install.sh) / `$env:FSEND_PREFIX` (install.ps1) discoverable. Worded as "pipe into `PREFIX=~/.local/bin sh`" because in `curl … | sh` a var prefixed to `curl` would not reach `sh`.

## Coordination note (item 5)

`fix/outcome-copy-truth` does not exist on the remote as of this PR, so the `role` row documents today's behavior: always present (no `omitempty` in `jsonDoneEvent`, cmd/fsend/jsonout.go). If that branch later makes `role` absent on usage errors detected before a role exists, this row and the failure-path sentence should be re-worded to match.

## Validation

- `go build ./cmd/fsend`, `go vet ./...`, `go test ./cmd/fsend` all pass (no help-text test pins these strings).
- `fsend --help` ADVANCED block re-checked: all descriptions at column 26, longest line exactly 80 cols.
- zsh: `eval "$(fsend completion zsh)"` defines `_fsend`; bash: registers `complete -F __start_fsend fsend`. fish and pwsh are not installed on the dev machine — those lines follow cobra's documented loading forms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)