### PR TITLE
fix(cli): honest diagnoses and fail-fast preflight for bad source paths

### DIFF
--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -190,6 +190,12 @@ func containsDirectory(paths []string) (bool, error) {
 		st, err := os.Stat(p)
 		if err != nil {
 			if os.IsNotExist(err) {
+				// Stat follows symlinks, so a dangling link lands here even
+				// though the path exists. Leave it for Walk, which reports
+				// E036 with the link's target — not a false "no such file".
+				if _, lerr := os.Lstat(p); lerr == nil {
+					continue
+				}
 				return false, fmt.Errorf("%w: %s", fserrors.ErrSourceNotFound, p)
 			}
 			return false, fmt.Errorf("%w: %s: %v", fserrors.ErrReadFailed, p, err)

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -248,8 +248,12 @@ var catalog = map[error]Entry{
 	},
 	ErrReadFailed: {
 		Code: "E010", Exit: 10,
-		Message: "Could not read the source file.",
-		Action:  "Check the file permissions and try again.",
+		// Base wording is receiver-side (the error is mirrored across the
+		// wire): the receiver can't check the sender's permissions.
+		Message:       "The sender could not read the source file.",
+		Action:        "Ask them to check its permissions and run fsend again.",
+		SenderMessage: "Could not read the source file.",
+		SenderAction:  "Check the file permissions and try again.",
 	},
 	ErrHashMismatch: {
 		Code: "E011", Exit: 11,

--- a/internal/fserrors/fserrors_test.go
+++ b/internal/fserrors/fserrors_test.go
@@ -135,6 +135,26 @@ func TestNewSentinels_LookupAndExit(t *testing.T) {
 	}
 }
 
+// E010 originates on the sender and is mirrored to the receiver, so the base
+// (receiver) wording must point at the sender — the receiver can't check the
+// sender's file permissions — while ForSender keeps the direct imperative.
+func TestReadFailed_RoleSplitWording(t *testing.T) {
+	entry, ok := Lookup(ErrReadFailed)
+	if !ok {
+		t.Fatal("expected catalog match for ErrReadFailed")
+	}
+	if !strings.Contains(entry.Message, "sender") || !strings.Contains(entry.Action, "Ask them") {
+		t.Errorf("receiver wording should attribute the failure to the sender: %q / %q", entry.Message, entry.Action)
+	}
+	s := entry.ForSender()
+	if strings.Contains(s.Message, "sender") {
+		t.Errorf("sender wording should be direct, got %q", s.Message)
+	}
+	if s.Exit != 10 || entry.Exit != 10 {
+		t.Errorf("both roles must keep exit 10, got %d/%d", entry.Exit, s.Exit)
+	}
+}
+
 func TestChain_WalksWrappers(t *testing.T) {
 	wrapped := fmt.Errorf("outer: %w", fmt.Errorf("inner: %w", ErrUsage))
 	got := Chain(wrapped)

--- a/internal/transfer/walk.go
+++ b/internal/transfer/walk.go
@@ -80,6 +80,27 @@ func Walk(paths []string, excludes []string) ([]Source, error) {
 			}
 			continue
 		}
+		// A named argument must be sendable content. A fifo/socket/device
+		// found inside a folder is skipped silently (addEntry), but one the
+		// user pointed at directly deserves an honest refusal — the silent
+		// skip would misreport it as an empty folder. A symlink argument is
+		// resolved by addEntry, which already errors if its target is
+		// unsendable.
+		if mode := st.Mode(); !mode.IsDir() && !mode.IsRegular() && mode&os.ModeSymlink == 0 {
+			return nil, fmt.Errorf("%w: cannot send %s — not a regular file (%s)", fserrors.ErrUsage, raw, fileKind(mode))
+		}
+		// Preflight an unreadable file now, before a code is issued —
+		// otherwise the E010 fires only after a receiver accepts, wasting
+		// the round-trip. Top-level arguments only: opening every file of a
+		// large tree here would double the syscall bill for a rare failure,
+		// so files inside directories keep failing at send time.
+		if st.Mode().IsRegular() {
+			f, err := os.Open(abs)
+			if err != nil {
+				return nil, fmt.Errorf("walk: %s: %w", raw, err)
+			}
+			_ = f.Close()
+		}
 		root := filepath.Base(abs)
 		if prev, ok := roots[strings.ToLower(root)]; ok {
 			return nil, fmt.Errorf("%w: %s and %s would both arrive as %q — rename one before sending", fserrors.ErrUsage, prev, raw, root)
@@ -194,6 +215,20 @@ func addEntry(out *[]Source, seen map[string]string, stack []os.FileInfo, srcPre
 			return fmt.Errorf("%w: %s → %s is not a regular file", fserrors.ErrUnsendableSymlink, rel, linkTarget)
 		}
 		return nil
+	}
+}
+
+// fileKind names a non-regular file mode for the "cannot send" usage error.
+func fileKind(m os.FileMode) string {
+	switch {
+	case m&os.ModeNamedPipe != 0:
+		return "fifo"
+	case m&os.ModeSocket != 0:
+		return "socket"
+	case m&os.ModeDevice != 0:
+		return "device"
+	default:
+		return "special file"
 	}
 }
 

--- a/internal/transfer/walk_test.go
+++ b/internal/transfer/walk_test.go
@@ -139,13 +139,15 @@ func TestWalk_BrokenSymlinkErrors(t *testing.T) {
 func TestWalk_DanglingSymlinkArgErrors(t *testing.T) {
 	dir := t.TempDir()
 	link := filepath.Join(dir, "bad.lnk")
-	mkSymlink(t, "/nope/gone", link)
+	// The message echoes the target with native separators on Windows.
+	target := filepath.FromSlash("/nope/gone")
+	mkSymlink(t, target, link)
 
 	_, err := Walk([]string{link}, nil)
 	if !errors.Is(err, fserrors.ErrUnsendableSymlink) {
 		t.Fatalf("want ErrUnsendableSymlink, got %v", err)
 	}
-	if got := err.Error(); !strings.Contains(got, "bad.lnk") || !strings.Contains(got, "/nope/gone") {
+	if got := err.Error(); !strings.Contains(got, "bad.lnk") || !strings.Contains(got, target) {
 		t.Errorf("error should name the link and target: %q", got)
 	}
 }

--- a/internal/transfer/walk_test.go
+++ b/internal/transfer/walk_test.go
@@ -134,6 +134,22 @@ func TestWalk_BrokenSymlinkErrors(t *testing.T) {
 	}
 }
 
+// A dangling symlink passed directly as an argument gets the same E036 (with
+// link and target named) as one found inside a folder — not a false E025.
+func TestWalk_DanglingSymlinkArgErrors(t *testing.T) {
+	dir := t.TempDir()
+	link := filepath.Join(dir, "bad.lnk")
+	mkSymlink(t, "/nope/gone", link)
+
+	_, err := Walk([]string{link}, nil)
+	if !errors.Is(err, fserrors.ErrUnsendableSymlink) {
+		t.Fatalf("want ErrUnsendableSymlink, got %v", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "bad.lnk") || !strings.Contains(got, "/nope/gone") {
+		t.Errorf("error should name the link and target: %q", got)
+	}
+}
+
 // A symlink that points back into an ancestor directory must be reported as a
 // cycle rather than recursing forever.
 func TestWalk_CycleErrors(t *testing.T) {

--- a/internal/transfer/walk_unix_test.go
+++ b/internal/transfer/walk_unix_test.go
@@ -1,0 +1,93 @@
+//go:build unix
+
+package transfer
+
+import (
+	"errors"
+	"io/fs"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+
+	"github.com/polius/fsend/internal/fserrors"
+)
+
+// A fifo named directly as an argument is refused honestly (E024 naming the
+// kind), not misreported as an empty folder or a missing path.
+func TestWalk_FifoArgErrors(t *testing.T) {
+	dir := t.TempDir()
+	pipe := filepath.Join(dir, "pipe.f")
+	if err := syscall.Mkfifo(pipe, 0o644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+
+	_, err := Walk([]string{pipe}, nil)
+	if !errors.Is(err, fserrors.ErrUsage) {
+		t.Fatalf("want ErrUsage, got %v", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "not a regular file (fifo)") {
+		t.Errorf("error should name the kind: %q", got)
+	}
+}
+
+// Same for a unix socket.
+func TestWalk_SocketArgErrors(t *testing.T) {
+	dir := t.TempDir()
+	sock := filepath.Join(dir, "sock.s")
+	l, err := net.Listen("unix", sock)
+	if err != nil {
+		t.Skipf("unix sockets unsupported here: %v", err)
+	}
+	defer l.Close()
+
+	_, err = Walk([]string{sock}, nil)
+	if !errors.Is(err, fserrors.ErrUsage) {
+		t.Fatalf("want ErrUsage, got %v", err)
+	}
+	if got := err.Error(); !strings.Contains(got, "not a regular file (socket)") {
+		t.Errorf("error should name the kind: %q", got)
+	}
+}
+
+// A fifo inside a walked folder keeps the long-standing silent skip.
+func TestWalk_FifoInsideFolderSkipped(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "keep.txt"), []byte("ok"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := syscall.Mkfifo(filepath.Join(dir, "pipe.f"), 0o644); err != nil {
+		t.Skipf("mkfifo unsupported here: %v", err)
+	}
+
+	srcs, err := Walk([]string{dir}, nil)
+	if err != nil {
+		t.Fatalf("fifo inside a folder must not fail the walk: %v", err)
+	}
+	if _, ok := bySrcRel(srcs)[filepath.Base(dir)+"/pipe.f"]; ok {
+		t.Error("fifo should be skipped, not listed")
+	}
+}
+
+// An unreadable file argument fails at walk (plan) time, before any code is
+// issued, with a permission error the CLI maps to E010.
+func TestWalk_UnreadableFileArgErrors(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root ignores file permissions")
+	}
+	dir := t.TempDir()
+	locked := filepath.Join(dir, "locked.txt")
+	if err := os.WriteFile(locked, []byte("secret"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(locked, 0); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := Walk([]string{locked}, nil)
+	if !errors.Is(err, fs.ErrPermission) {
+		t.Fatalf("want a permission error, got %v", err)
+	}
+}


### PR DESCRIPTION
Fixes the three sender-side source-path findings from the third CLI UX audit.

## Finding A (P2): false diagnoses for non-regular top-level source paths

| Argument | Before | After |
|---|---|---|
| dangling symlink | `[E025] No such file or directory: bad.lnk` (false — the path exists) | `[E036] Cannot follow this symlink: broken link bad.lnk → /nope/gone (target does not exist)` · exit 36 |
| fifo | `[E024] Invalid usage. / nothing to send — the folder is empty` (false — not a folder) | `[E024] Invalid usage. / cannot send pipe.f — not a regular file (fifo)` · exit 24 |
| unix socket | same false "folder is empty" in my repro (the audit logged E025) | `[E024] … cannot send sock.s — not a regular file (socket)` · exit 24 |

- The false E025 came from `containsDirectory`'s `os.Stat`, which follows symlinks: a dangling link read as "missing". It now defers to `Walk`, whose existing `symlinkError` produces the same E036 detail as a link found inside a folder.
- Fifo/socket/device **arguments** are refused honestly with E024 (an existing code — no new exit minted, exit-code table unchanged). Special files found **inside** walked folders keep the long-standing silent skip (verified: a folder containing a fifo still transfers, fifo omitted).

## Finding B (P3): no preflight readability check

A `chmod 000` source published a code and only failed (E010, both sides exit 10) after the receiver accepted. `Walk` now does a cheap `open()`+`close` on **top-level regular file arguments**, so the send fails with E010 exit 10 before any code is issued, no receiver involved.

**Judgment call:** directories keep the current post-accept behavior. The walk only `Lstat`s each file; opening every file of a large tree at plan time would be an open() storm for a rare failure, and permission-bit heuristics without an open are unreliable (ACLs, ownership). Top-level args are the determinable-at-plan-time case the audit identified.

## Finding C (P3): E010 mirrored verbatim to the receiver

E010 now uses the same role-split mechanism as E009/E013/E021/E031 (`Entry.SenderMessage`/`SenderAction` + `ForSender`): the base (receiver) wording becomes "The sender could not read the source file. / Ask them to check its permissions and run fsend again."; the sender keeps "Could not read the source file. / Check the file permissions and try again." Exit stays 10 on both sides.

**Note:** the two receiver-local `ErrReadFailed` sites (partial-prefix verify under `--checksum`, text-payload read) inherit the receiver wording like every role-split entry does; the dominant receiver-side E010 is the mirrored sender failure.

## Validation (real server on 127.0.0.1:19130/19131, fresh configs)

Pre-fix: reproduced all three false diagnoses and the post-accept E010 (code `bej-djqu-rfj` issued for an unreadable file; both sides exited 10 only after accept, receiver told to "check the file permissions").

Post-fix:
- dangling symlink arg → E036 exit 36 with `bad.lnk → /nope/gone (target does not exist)`
- fifo → E024 `not a regular file (fifo)`; socket → E024 `not a regular file (socket)`
- chmod-000 file → E010 exit 10 instantly, sender only, **no code printed**
- 3 MB urandom file end-to-end: sha256 match
- folder with good symlink: link travels as a real copy, sha256 match on all three files
- folder containing a fifo: transfers, fifo silently skipped
- mid-transfer E010 (chmod 000 after code issued, before accept): receiver shows the new role-split copy ("The sender could not read the source file."), sender keeps the imperative, both exit 10

Tests: new walker tests (dangling-symlink arg, fifo/socket args, fifo-inside-folder skip, unreadable-arg preflight — unix-tagged) and an E010 role-split wording test. `go test ./cmd/fsend ./internal/transfer ./internal/fserrors` and `go vet ./...` pass.

Docs: no changes needed — no changed string is quoted in docs/, the exit-code table rows for E010/E024/E025/E036 remain accurate, and troubleshooting's "halts the send before any code is generated" for E036 now also holds for direct symlink arguments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)