### PR TITLE
fix(lifecycle): install-script and operator polish from the third CLI UX audit

### DIFF
--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -189,6 +189,8 @@ func renderError(err error, debug bool) int {
 			fmt.Fprintf(os.Stderr, "  For the fsend version, run: fsend --version\n")
 		case detail == "send" || detail == "receive":
 			fmt.Fprintf(os.Stderr, "  fsend has no %q subcommand — `fsend <file>` sends, `fsend <code>` receives.\n", detail)
+		case detail == "update" || detail == "uninstall":
+			fmt.Fprintf(os.Stderr, "  To %s fsend, run: fsend --%s\n", detail, detail)
 		}
 		if entry.Action != "" {
 			fmt.Fprintf(os.Stderr, "  %s\n", entry.Action)

--- a/cmd/fsend/server.go
+++ b/cmd/fsend/server.go
@@ -177,6 +177,9 @@ func runServer() error {
 	go func() { defer wg.Done(); drainRelay(shutdownCtx, relaySrv, logger) }()
 	wg.Wait()
 	cancel()
+	// Marks a clean drain: absent from the logs when SIGKILL (e.g. a too-low
+	// stop_grace_period) cut the shutdown short.
+	logger.Info("shutdown complete")
 	return nil
 }
 
@@ -266,7 +269,11 @@ func loadServerConfig() (serverRuntimeConfig, error) {
 	if cfg.enableRelay, err = envBool(envRelayEnabled, defaultRelayEnabled); err != nil {
 		return cfg, err
 	}
-	switch strings.ToLower(os.Getenv(envLogLevel)) {
+	// A typo'd level fails loudly like every other FSEND_* var — silently
+	// running at info would hide the debug logs the operator asked for.
+	switch v := strings.TrimSpace(os.Getenv(envLogLevel)); strings.ToLower(v) {
+	case "", "info":
+		cfg.logLevel = slog.LevelInfo
 	case "debug":
 		cfg.logLevel = slog.LevelDebug
 	case "warn":
@@ -274,7 +281,7 @@ func loadServerConfig() (serverRuntimeConfig, error) {
 	case "error":
 		cfg.logLevel = slog.LevelError
 	default:
-		cfg.logLevel = slog.LevelInfo
+		return cfg, fmt.Errorf("%s=%q: not a log level (use debug, info, warn, or error)", envLogLevel, v)
 	}
 	return cfg, nil
 }

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -228,6 +228,7 @@ func TestServerLoadConfigRejectsBadValues(t *testing.T) {
 		"FSEND_RELAY_MAX_BYTES_PER_SESSION":           "1GiB",
 		"FSEND_SERVER_MAX_SESSIONS_PER_IP":            "many",
 		"FSEND_SERVER_MAX_SESSIONS_PER_IP_PER_MINUTE": "-1",
+		"FSEND_LOG_LEVEL":                             "verbose",
 	}
 	for k, v := range cases {
 		t.Run(k+"="+v, func(t *testing.T) {
@@ -246,10 +247,10 @@ func TestServerLoadConfigLogLevels(t *testing.T) {
 		"DEBUG":   slog.LevelDebug,
 		"warn":    slog.LevelWarn,
 		"WARN":    slog.LevelWarn,
-		"error":   slog.LevelError,
-		"info":    slog.LevelInfo,
-		"":        slog.LevelInfo,
-		"garbage": slog.LevelInfo,
+		"error": slog.LevelError,
+		"info":  slog.LevelInfo,
+		"INFO":  slog.LevelInfo,
+		"":      slog.LevelInfo,
 	}
 	for input, want := range cases {
 		t.Run(input, func(t *testing.T) {

--- a/cmd/fsend/server_test.go
+++ b/cmd/fsend/server_test.go
@@ -243,10 +243,10 @@ func TestServerLoadConfigRejectsBadValues(t *testing.T) {
 
 func TestServerLoadConfigLogLevels(t *testing.T) {
 	cases := map[string]slog.Level{
-		"debug":   slog.LevelDebug,
-		"DEBUG":   slog.LevelDebug,
-		"warn":    slog.LevelWarn,
-		"WARN":    slog.LevelWarn,
+		"debug": slog.LevelDebug,
+		"DEBUG": slog.LevelDebug,
+		"warn":  slog.LevelWarn,
+		"WARN":  slog.LevelWarn,
 		"error": slog.LevelError,
 		"info":  slog.LevelInfo,
 		"INFO":  slog.LevelInfo,

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -87,6 +87,9 @@ func runUninstall(f *flags) error {
 	}
 
 	fmt.Fprintln(os.Stderr, "  fsend uninstalled.")
+	// Shell rc files are out of reach here (unlike Windows, where the
+	// helper strips the PATH entry itself), so leave it to the user.
+	fmt.Fprintln(os.Stderr, "  If you added a PATH export or \"fsend completion\" line to your shell rc, remove it.")
 	return nil
 }
 

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -268,7 +268,7 @@ TCP listener and per-IP session limits), and the **relay / data plane**
 
 | Variable | Default | Notes |
 |---|---|---|
-| `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. |
+| `FSEND_LOG_LEVEL` | `info` | `debug` / `info` / `warn` / `error`. Any other value fails startup, like every other `FSEND_*` variable. |
 | `FSEND_SERVER_PASSWORD` | _(unset)_ | Shared secret restricting all endpoints except `/v1/health` — see [Require a password](#require-a-password-optional). |
 | `FSEND_SERVER_ADDR` | `:8080` | TCP signaling listener. |
 | `FSEND_SERVER_MAX_SESSIONS_PER_IP` | `0` (unlimited) | **Concurrency cap** — how many sessions one source IP may have **alive at once**. A session gates relay allocation too, so this caps relay access as well. Defaults to unlimited; **set a positive value to enable this DoS protection** (recommended on a public server). |

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -7,6 +7,7 @@
 package version
 
 import (
+	"runtime"
 	"runtime/debug"
 	"strings"
 )
@@ -42,12 +43,15 @@ func buildInfoVersion(v string) string {
 	return strings.TrimPrefix(v, "v")
 }
 
-// String returns "fsend X.Y.Z (build abc1234, 2026-06-01)" for release
-// builds. Dev builds (Commit/Date unset) collapse to "fsend dev" so the
-// parenthetical doesn't read "(build unknown, unknown)".
+// String returns "fsend X.Y.Z (build abc1234, 2026-06-01, linux/amd64)"
+// for release builds. Dev builds (Commit/Date unset) collapse to
+// "fsend dev (linux/amd64)" so the parenthetical doesn't read
+// "(build unknown, unknown)". The platform is always present: bug
+// reports and Rosetta/wrong-arch checks need it.
 func String() string {
+	plat := runtime.GOOS + "/" + runtime.GOARCH
 	if Commit == "" || Commit == "unknown" || Date == "" || Date == "unknown" {
-		return "fsend " + Version
+		return "fsend " + Version + " (" + plat + ")"
 	}
-	return "fsend " + Version + " (build " + Commit + ", " + Date + ")"
+	return "fsend " + Version + " (build " + Commit + ", " + Date + ", " + plat + ")"
 }

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,23 +1,27 @@
 package version
 
-import "testing"
+import (
+	"runtime"
+	"testing"
+)
 
 // String shapes the user-visible header on --version and --help. Dev
-// builds collapse to "fsend dev" because Commit/Date are unset; release
-// builds carry the full "(build SHA, DATE)" parenthetical.
+// builds collapse to "fsend dev (os/arch)" because Commit/Date are unset;
+// release builds carry the full "(build SHA, DATE, os/arch)" parenthetical.
 func TestString(t *testing.T) {
 	orig := struct{ Ver, Commit, Date string }{Version, Commit, Date}
 	t.Cleanup(func() { Version, Commit, Date = orig.Ver, orig.Commit, orig.Date })
 
+	plat := runtime.GOOS + "/" + runtime.GOARCH
 	cases := []struct {
 		name                  string
 		version, commit, date string
 		want                  string
 	}{
-		{"dev_default", "dev", "unknown", "unknown", "fsend dev"},
-		{"dev_empty_commit", "dev", "", "2026-06-01", "fsend dev"},
-		{"dev_empty_date", "dev", "abc1234", "", "fsend dev"},
-		{"release", "0.1.0", "abc1234", "2026-06-01", "fsend 0.1.0 (build abc1234, 2026-06-01)"},
+		{"dev_default", "dev", "unknown", "unknown", "fsend dev (" + plat + ")"},
+		{"dev_empty_commit", "dev", "", "2026-06-01", "fsend dev (" + plat + ")"},
+		{"dev_empty_date", "dev", "abc1234", "", "fsend dev (" + plat + ")"},
+		{"release", "0.1.0", "abc1234", "2026-06-01", "fsend 0.1.0 (build abc1234, 2026-06-01, " + plat + ")"},
 	}
 	for _, c := range cases {
 		Version, Commit, Date = c.version, c.commit, c.date

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -65,6 +65,9 @@ Parameters (or matching env var):
   -Version VERSION   Version to install    (default: latest; env FSEND_VERSION)
   -Help              Show this help and exit
 
+Environment variables:
+  FSEND_REQUIRE_SIGNATURE=1   Refuse to install unless cosign verifies the release signature
+
 Source: https://github.com/polius/fsend/blob/main/scripts/install.ps1
 '@
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,10 +17,19 @@ else
     PREFIX_EXPLICIT=0
 fi
 
-err()  { printf '\033[31m✗\033[0m %s\n' "$*" >&2; exit 1; }
-info() { printf '\033[36m›\033[0m %s\n' "$*" >&2; }
-warn() { printf '\033[33m!\033[0m %s\n' "$*" >&2; }
-ok()   { printf '\033[32m✓\033[0m %s\n' "$*" >&2; }
+# Color only when stderr is a tty and NO_COLOR is unset/empty — the same
+# auto-detection the fsend binary applies (https://no-color.org).
+if [ -t 2 ] && [ -z "${NO_COLOR:-}" ]; then
+    esc="$(printf '\033')"
+    C_RED="${esc}[31m" C_GRN="${esc}[32m" C_YLW="${esc}[33m" C_CYN="${esc}[36m" C_RST="${esc}[0m"
+else
+    C_RED='' C_GRN='' C_YLW='' C_CYN='' C_RST=''
+fi
+
+err()  { printf '%s✗%s %s\n' "$C_RED" "$C_RST" "$*" >&2; exit 1; }
+info() { printf '%s›%s %s\n' "$C_CYN" "$C_RST" "$*" >&2; }
+warn() { printf '%s!%s %s\n' "$C_YLW" "$C_RST" "$*" >&2; }
+ok()   { printf '%s✓%s %s\n' "$C_GRN" "$C_RST" "$*" >&2; }
 
 usage() {
     cat <<'EOF'
@@ -35,8 +44,9 @@ Flags:
   -v VERSION    Version to install (default: latest)
   -h            Show this help and exit
 
-Environment variables (overridden by the matching flag):
-  PREFIX, FSEND_VERSION
+Environment variables:
+  PREFIX, FSEND_VERSION      Same as -p / -v (the flag wins)
+  FSEND_REQUIRE_SIGNATURE=1  Refuse to install unless cosign verifies the release signature
 
 Source: https://github.com/polius/fsend/blob/main/scripts/install.sh
 EOF
@@ -80,6 +90,11 @@ detect_arch() {
         x86_64|amd64)  echo "amd64" ;;
         arm64|aarch64) echo "arm64" ;;
         armv7*)        echo "armv7" ;;
+        # 32-bit userland on a 64-bit ARM kernel: the armv7 binary is the
+        # one that runs there. (aarch64 kernels reporting their native arch
+        # despite a 32-bit userland, and Rosetta-translated x86_64 shells,
+        # keep their native mapping.)
+        armv8l|armv9l) echo "armv7" ;;
         armv6*)        echo "armv6" ;;
         riscv64)       echo "riscv64" ;;
         i386|i686)     echo "386" ;;
@@ -271,7 +286,8 @@ install_binary() {
 
     info "$PREFIX is not writable, attempting elevation"
     if ! run_elevated mv "$src" "$dst"; then
-        err "could not move binary into $PREFIX (no sudo/doas available;\n  re-run as root, or set PREFIX=\$HOME/.local/bin)"
+        err "could not move binary into $PREFIX (no sudo/doas available;
+  re-run as root, or set PREFIX=\$HOME/.local/bin)"
     fi
     run_elevated chmod 755 "$dst" \
         || err "could not chmod $dst"
@@ -369,10 +385,17 @@ main() {
 
     ok "installed: $PREFIX/$bin_file"
 
-    if command -v "$BINARY" >/dev/null 2>&1 \
-       && [ "$(command -v "$BINARY")" = "$PREFIX/$bin_file" ]; then
+    found="$(command -v "$BINARY" 2>/dev/null || true)"
+    if [ "$found" = "$PREFIX/$bin_file" ]; then
         installed_version="$("$BINARY" --version 2>/dev/null | head -n1 || echo "?")"
         ok "verify: $installed_version"
+    elif [ -n "$found" ]; then
+        # A stale install earlier on PATH shadows the fresh one — a
+        # different problem than a missing PATH entry, so say which it is.
+        printf '\n'
+        warn "another fsend at $found takes precedence on your PATH. Put $PREFIX first with:"
+        print_path_hint
+        printf '\n  Then restart your shell, or run %s directly.\n' "$PREFIX/$bin_file"
     else
         printf '\n'
         warn "$PREFIX is not on your PATH. Add it with:"


### PR DESCRIPTION
Ten P3 lifecycle findings from the third CLI UX audit: five in the installers, five in the Go CLI. Every item validated empirically (evidence below).

## Install scripts

**1. Literal `\n` in the no-sudo error** (`scripts/install.sh`)
`err()` prints with `%s\n`, so the embedded `\n` rendered verbatim.

Before (forced no-sudo branch, `cat -v`):
```
✗ could not move binary into .../ro-prefix (no sudo/doas available;\n  re-run as root, or set PREFIX=$HOME/.local/bin)
```
After — a real newline in the message, two clean lines:
```
✗ could not move binary into .../ro-prefix (no sudo/doas available;
  re-run as root, or set PREFIX=$HOME/.local/bin)
```

**2. Unconditional ANSI color**
Escapes were emitted even when piped or with `NO_COLOR` set. Now auto-detected — color only when stderr is a tty and `NO_COLOR` is unset/empty (https://no-color.org), matching the binary's own gating. No `--no-color` flag (deliberately rejected). Verified with `cat -v`: piped → no escapes; pty (`script -q`) → escapes; pty + `NO_COLOR=1` → none; pty + `NO_COLOR=` (empty) → escapes, per spec.

**3. `armv8l`/`armv9l` rejected**
32-bit userland on a 64-bit ARM kernel reported "unsupported architecture" although the linux-armv7 binary runs fine there. Mapping table (via a `uname` shim harness):
```
x86_64 → amd64   aarch64 → arm64   armv7l → armv7   armv6l → armv6
armv8l → armv7   armv9l  → armv7   riscv64 → riscv64   i686 → 386
sparc64 → unsupported architecture (exit 1)
```
aarch64-with-32-bit-userland and Rosetta stay on their native mapping (comment added).

**4. PATH shadowing misdiagnosed as "not on your PATH"**
When another fsend earlier on PATH shadows the fresh install, the script claimed the prefix wasn't on PATH. Live installs into scratch prefixes now show:
- shadow case: `! another fsend at /.../shadow-bin/fsend takes precedence on your PATH. Put /.../inst-bin first with:` + the existing prepend hint
- fsend-free PATH: unchanged `! ... is not on your PATH. Add it with:`
- prefix on PATH: unchanged `✓ verify: fsend 1.9.0 (build f072ac5, ...)`

(Amusingly, the unfixed script on the dev machine would have mislabeled the Homebrew fsend case — the new message caught it.)

**5. `FSEND_REQUIRE_SIGNATURE` undocumented in usage**
Both `install.sh -h` and `install.ps1` `Show-Usage` now list it:
```
Environment variables:
  PREFIX, FSEND_VERSION      Same as -p / -v (the flag wins)
  FSEND_REQUIRE_SIGNATURE=1  Refuse to install unless cosign verifies the release signature
```

Shell validation: `sh -n` clean; shellcheck findings identical to main (only pre-existing info-level SC2016 in untouched `print_path_hint`).

## Go CLI

**6. Uninstall closing hint** (`cmd/fsend/uninstall.go`, Unix path only — the Windows branch returns earlier and already strips its PATH entry):
```
  fsend uninstalled.
  If you added a PATH export or "fsend completion" line to your shell rc, remove it.
```
Verified against a throwaway binary copy with scratch `XDG_CONFIG_HOME`, `--uninstall --yes`, exit 0.

**7. Platform in `--version`** (`internal/version/version.go` `String()` only — `buildInfoVersion` untouched to avoid colliding with fix/selfupdate-lifecycle):
```
fsend 1.9.1-0.20260703...+dirty (darwin/arm64)
```
Release shape: `fsend 0.1.0 (build abc1234, 2026-06-01, darwin/arm64)`. Tests use `runtime.GOOS/GOARCH`, not hardcoded strings.

**8. Pseudo-subcommand hints** (`cmd/fsend/main.go`): `fsend update` / `fsend uninstall` now mirror the existing `version` hint, same E025 and exit 25:
```
[FAIL] [E025] No such file or directory: update
  To update fsend, run: fsend --update
```

**9. Strict `FSEND_LOG_LEVEL`** (`cmd/fsend/server.go`): unknown values failed silently to info while every sibling env var fails loudly by design. Now:
```
$ FSEND_LOG_LEVEL=verbose fsend server
[FAIL] [E030] The server could not start.
  FSEND_LOG_LEVEL="verbose": not a log level (use debug, info, warn, or error)
(exit 30)
```
Valid levels still work (server ran on :19160/:19161 with `FSEND_LOG_LEVEL=debug`). `docs/self-hosting.md` table synced; test case moved from the accepts-map to `TestServerLoadConfigRejectsBadValues`.

**10. "shutdown complete" after graceful drain** (`runServer`, after `wg.Wait()`):
```
level=INFO msg="shutdown requested"
level=INFO msg="shutdown complete"
```
SIGTERM'd live server exits 0 with both lines; a SIGKILL mid-drain would lack the second. No drained-session count — it isn't trivially available and plumbing was out of scope.

Go validation: `go test ./cmd/fsend ./internal/version` ok, `go vet ./...` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)