### PR TITLE
polish(cli): prompt house style, l-only-when-truncated, verbatim sender password

### DIFF
--- a/cmd/fsend/password.go
+++ b/cmd/fsend/password.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"context"
 	"crypto/rand"
 	"errors"
@@ -53,7 +54,7 @@ func readPasswordHidden(prompt string) (string, error) {
 // cancellation (Ctrl-C at the prompt), returning context.Canceled. The
 // abandoned ReadPassword goroutine cannot run its own deferred terminal
 // restore, so we capture the terminal state up front and restore it here.
-func readPasswordHiddenCtx(ctx context.Context, prompt string) (string, error) {
+func readPasswordHiddenCtx(ctx context.Context, prompt string, quiet bool) (string, error) {
 	fd := int(os.Stdin.Fd())
 	var oldState *term.State
 	if term.IsTerminal(fd) {
@@ -72,6 +73,11 @@ func readPasswordHiddenCtx(ctx context.Context, prompt string) (string, error) {
 	case <-ctx.Done():
 		if oldState != nil {
 			_ = term.Restore(fd, oldState)
+		}
+		// signalContext's Cancelling notice already broke the prompt line;
+		// another newline here showed up as a stray blank line. --quiet
+		// suppresses that notice, so break the line ourselves then.
+		if quiet {
 			fmt.Fprintln(os.Stderr)
 		}
 		return "", context.Canceled
@@ -109,14 +115,14 @@ func resolvePassword(ctx context.Context, f *flags, sender bool) error {
 		return fmt.Errorf("%w: bare --password needs a terminal; use --password=<value> or FSEND_PASSWORD", fserrors.ErrUsage)
 	}
 	if sender {
-		pw, err := promptPasswordWithSuggestionCtx(ctx)
+		pw, err := promptPasswordWithSuggestionCtx(ctx, f.quiet)
 		if err != nil {
 			return err
 		}
 		f.passArg = pw
 		return nil
 	}
-	pw, err := readPasswordHiddenCtx(ctx, "Password for this transfer: ")
+	pw, err := readPasswordHiddenCtx(ctx, "  Password for this transfer: ", f.quiet)
 	if err != nil {
 		return err
 	}
@@ -128,19 +134,23 @@ func resolvePassword(ctx context.Context, f *flags, sender bool) error {
 // aborts on ctx cancellation (Ctrl-C at the prompt). The prompt echoes
 // normally, so unlike the hidden reader there is no terminal state to
 // restore — just move off the prompt line.
-func promptPasswordWithSuggestionCtx(ctx context.Context) (string, error) {
+func promptPasswordWithSuggestionCtx(ctx context.Context, quiet bool) (string, error) {
 	type result struct {
 		pw  string
 		err error
 	}
 	ch := make(chan result, 1)
 	go func() {
-		pw, err := promptPasswordWithSuggestion()
+		pw, err := promptPasswordWithSuggestion(stdinReader())
 		ch <- result{pw, err}
 	}()
 	select {
 	case <-ctx.Done():
-		fmt.Fprintln(os.Stderr)
+		// As in readPasswordHiddenCtx: signalContext already broke the
+		// line unless --quiet suppressed its notice.
+		if quiet {
+			fmt.Fprintln(os.Stderr)
+		}
 		return "", context.Canceled
 	case r := <-ch:
 		return r.pw, r.err
@@ -151,7 +161,7 @@ func promptPasswordWithSuggestionCtx(ctx context.Context) (string, error) {
 // as the default. The suggestion is printed visibly (the sender needs to
 // see it to share it out-of-band) and a bare <enter> accepts it. Any
 // non-empty typed input replaces the suggestion.
-func promptPasswordWithSuggestion() (string, error) {
+func promptPasswordWithSuggestion(br *bufio.Reader) (string, error) {
 	suggested, err := generateRandomPassword(16)
 	if err != nil {
 		return "", fmt.Errorf("generating suggested password: %w", err)
@@ -159,7 +169,7 @@ func promptPasswordWithSuggestion() (string, error) {
 	fmt.Fprintf(os.Stderr, "  Suggested password: %s\n", suggested)
 	fmt.Fprint(os.Stderr, "  Press Enter to use it, or type your own: ")
 
-	line, err := stdinReader().ReadString('\n')
+	line, err := br.ReadString('\n')
 	if err != nil && line == "" {
 		// EOF on a piped stdin with no data: the caller can't interact.
 		// Be explicit rather than silently accepting the suggested
@@ -170,8 +180,10 @@ func promptPasswordWithSuggestion() (string, error) {
 		}
 		return "", err
 	}
+	// Trim only the line terminator: every other password path (hidden
+	// read, --password=VALUE, FSEND_PASSWORD) takes the value verbatim,
+	// so a trailing space typed here must stay part of the secret too.
 	typed := strings.TrimRight(line, "\r\n")
-	typed = strings.TrimSpace(typed)
 	if typed == "" {
 		return suggested, nil
 	}

--- a/cmd/fsend/password_test.go
+++ b/cmd/fsend/password_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bufio"
 	"strings"
 	"testing"
 )
@@ -40,5 +41,51 @@ func TestGenerateRandomPassword_DistinctDraws(t *testing.T) {
 	}
 	if a == b {
 		t.Fatalf("two random draws collided: %q == %q", a, b)
+	}
+}
+
+// The sender prompt must take typed input verbatim past the line
+// terminator: every other password path (hidden read, --password=VALUE,
+// FSEND_PASSWORD) preserves leading/trailing spaces, so trimming here
+// made a pasted "secret " silently diverge into a wrong-password loop.
+func TestPromptPasswordWithSuggestion_VerbatimInput(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"plain", "hunter2\n", "hunter2"},
+		{"trailing_space_kept", "hunter2 \n", "hunter2 "},
+		{"leading_space_kept", " hunter2\n", " hunter2"},
+		{"crlf_trimmed", "hunter2\r\n", "hunter2"},
+		{"spaces_only_is_a_password", "  \n", "  "},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var pw string
+			var err error
+			captureStderr(t, func() {
+				pw, err = promptPasswordWithSuggestion(bufio.NewReader(strings.NewReader(tc.in)))
+			})
+			if err != nil {
+				t.Fatalf("promptPasswordWithSuggestion(%q): %v", tc.in, err)
+			}
+			if pw != tc.want {
+				t.Errorf("password = %q, want %q", pw, tc.want)
+			}
+		})
+	}
+}
+
+// Bare <enter> still accepts the printed suggestion.
+func TestPromptPasswordWithSuggestion_EnterAcceptsSuggestion(t *testing.T) {
+	var pw string
+	var err error
+	stderr := captureStderr(t, func() {
+		pw, err = promptPasswordWithSuggestion(bufio.NewReader(strings.NewReader("\n")))
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pw == "" || !strings.Contains(stderr, pw) {
+		t.Errorf("bare Enter must return the suggestion shown on stderr; got %q", pw)
 	}
 }

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -183,9 +183,9 @@ func receiverPasswordPrompt(ctx context.Context, f *flags) func(attempt int) (st
 		fmt.Fprintln(os.Stderr)
 		if attempt > 1 {
 			return readPasswordHiddenCtx(ctx,
-				fmt.Sprintf("  Wrong password — try again (%d/%d): ", attempt, transfer.PasswordAttempts))
+				fmt.Sprintf("  Wrong password — try again (%d/%d): ", attempt, transfer.PasswordAttempts), f.quiet)
 		}
-		return readPasswordHiddenCtx(ctx, "  Password for this transfer: ")
+		return readPasswordHiddenCtx(ctx, "  Password for this transfer: ", f.quiet)
 	}
 }
 

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -215,11 +215,17 @@ func (ui *receiverUI) confirmOverwrite(conflicts []transfer.Conflict) bool {
 	for _, c := range conflicts[:shown] {
 		fmt.Fprintf(os.Stderr, "    %s\n", conflictLabel(c))
 	}
-	if more := len(conflicts) - shown; more > 0 {
-		fmt.Fprintf(os.Stderr, "    %s\n", uxlog.Dim(fmt.Sprintf("… and %d more", more)))
+	// Offer "l" only when the preview was truncated — with the full list
+	// already on screen, listing again adds nothing.
+	truncated := len(conflicts) > shown
+	prompt, hint := "  Overwrite all? [y/N] ", "  Please answer y or n."
+	if truncated {
+		fmt.Fprintf(os.Stderr, "    %s\n",
+			uxlog.Dim(fmt.Sprintf("… and %d more — l lists all %d", len(conflicts)-shown, len(conflicts))))
+		prompt, hint = "  Overwrite all? [y/N/l] ", "  Please answer y or n (or l to list all)."
 	}
 	for {
-		fmt.Fprint(os.Stderr, "  Overwrite all? [y / N / l = list all] ")
+		fmt.Fprint(os.Stderr, prompt)
 		line, eof, ok := readLineCtx(ui.ctx)
 		if !ok {
 			return false
@@ -245,12 +251,13 @@ func (ui *receiverUI) confirmOverwrite(conflicts []transfer.Conflict) bool {
 			ui.mu.Unlock()
 			return false
 		case "l", "list":
+			// Still honored when not advertised (harmless reprint).
 			for _, c := range conflicts {
 				fmt.Fprintf(os.Stderr, "    %s\n", conflictLabel(c))
 			}
 			continue
 		}
-		fmt.Fprintln(os.Stderr, "  Please answer y or n (or l to list all).")
+		fmt.Fprintln(os.Stderr, hint)
 	}
 }
 

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -645,7 +645,7 @@ func promptCodeOrPath(f *flags, arg string) error {
 func askCodeOrPath(br *bufio.Reader, arg string) (send bool, err error) {
 	fmt.Fprintf(os.Stderr, "\n  %q matches a code AND is a local file.\n", arg)
 	for {
-		fmt.Fprintf(os.Stderr, "  [s]end this file, or [r]eceive with this code? (r): ")
+		fmt.Fprint(os.Stderr, "  Send this file, or receive with this code? [s/R] ")
 		resp, eof := readLineFrom(br)
 		if eof {
 			fmt.Fprintln(os.Stderr)


### PR DESCRIPTION
Fixes the P3 prompt findings from the third CLI UX audit: prompt grammar drift across the five interactive prompts (Finding A), the stray blank line on Ctrl-C at the password prompts (A2), the sender prompt TrimSpace-ing the typed secret (B), and the overwrite prompt offering `l = list all` when the full list is already on screen (C).

All captures below are from a live pty against a local server on 127.0.0.1:19150 (fresh `XDG_CONFIG_HOME`, `FSEND_NO_UPDATE_CHECK=1`), pre = `main`, post = this branch.

## Overwrite prompt — 2 conflicts (list not truncated: no `l` offered)

Before:
```
  2 files differ from your local copies:
    file1.txt
    file2.txt
  Overwrite all? [y / N / l = list all] n
```

After (invalid answer, then `l` still silently honored, then bare Enter = keep):
```
  2 files differ from your local copies:
    file1.txt
    file2.txt
  Overwrite all? [y/N] x
  Please answer y or n.
  Overwrite all? [y/N] l
    file1.txt
    file2.txt
  Overwrite all? [y/N]
[!] Saved 0 of 2 files … 2 files kept (use --overwrite)
[i] [E013] Kept your local copies — nothing was overwritten.
```
Verified: `y` overwrites (exit 0, new content on disk), Enter/`n` keep (exit 13, old content on disk), EOF after the accept prompt still prints "No input to answer the prompt — keeping your local copies." and exits 13.

## Overwrite prompt — 7 conflicts (truncated: `l` offered, legend in the dim line)

After:
```
  7 files differ from your local copies:
    file1.txt
    …
    file5.txt
    … and 2 more — l lists all 7
  Overwrite all? [y/N/l] l
    file1.txt
    …
    file7.txt
  Overwrite all? [y/N/l] x
  Please answer y or n (or l to list all).
  Overwrite all? [y/N/l] n
```

## Code-vs-file ambiguity prompt

Before:
```
  "abc-defg-jkm" matches a code AND is a local file.
  [s]end this file, or [r]eceive with this code? (r):
```

After (typo re-asks, bare Enter takes the receive default):
```
  "abc-defg-jkm" matches a code AND is a local file.
  Send this file, or receive with this code? [s/R] x
  Please answer s or r.
  Send this file, or receive with this code? [s/R]
```
Verified: `s` starts a send (code issued; Ctrl-C exits 130), `r` and Enter receive, EOF still exits 24 with the existing "pass --receive (or --send)" message. Answers accepted are unchanged (`s`/`send`, `r`/`receive`/empty, case-insensitive via readLine).

## Password prompt indent

Before (pre-connect prompt at column 0, unlike the in-transfer one):
```
Password for this transfer:
```
After:
```
  Password for this transfer:
```

## Ctrl-C at the password prompts (stray blank line)

Before (sender suggestion prompt — note the blank line):
```
  Press Enter to use it, or type your own: ^C
[i] Cancelling — press Ctrl-C again to force quit.

[i] [E026] Cancelled.
```
After:
```
  Press Enter to use it, or type your own: ^C
[i] Cancelling — press Ctrl-C again to force quit.
[i] [E026] Cancelled.
```
Echo restored after Ctrl-C at the hidden prompt (termios ECHO on), exit 130 in all cases. Under `--quiet` (reachable on the send side only — receive `--quiet` without `--yes` is rejected up front) the prompt-side newline is kept, since signalContext prints nothing there.

Note: the hidden pre-connect prompt sometimes still shows E026 glued to the prompt line — that's the pre-existing race where the process exits before signalContext's notice lands (its `\n` is what breaks the line). Deliberately left to the signalContext side; this PR only removes the second, duplicate line break, matching how readLineCtx-based prompts already behave.

## Sender password taken verbatim (Finding B)

Sender typed `hunter2 ` (trailing space) at the prompt; receiver ran with `FSEND_PASSWORD='hunter2 '`:
- pre: `[FAIL] [E021] Wrong password. Transfer aborted.` — nothing saved
- post: `[OK] Saved secret.txt … 8 B` — exit 0

The in-transfer wrong-then-correct password retry flow was also exercised live and still works (prompt at attempt 2/3, then saved, exit 0).

## Tests

- `go test ./cmd/fsend` and `go vet ./...` pass.
- `password_test.go` extended: typed input is verbatim past the line terminator (trailing/leading spaces kept, CRLF trimmed, spaces-only is a password) and bare Enter still accepts the shown suggestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)