### PR TITLE
fix(cli): progress-bar rendering artifacts from the third CLI UX audit

### DIFF
--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -360,7 +360,10 @@ func printCancelKeptHint(f *flags, ui *receiverUI) {
 		return
 	}
 	if _, moved := ui.bytes(); moved > 0 {
-		fmt.Fprintf(os.Stderr, "%s Partial data kept — when the sender runs fsend again, the transfer resumes here.\n", uxlog.Info())
+		// Via uxlog.Println: the aborted bar is still live here (ui.close
+		// runs on a defer), and its next refresh frame would erase a raw
+		// stderr write.
+		uxlog.Println(fmt.Sprintf("%s Partial data kept — when the sender runs fsend again, the transfer resumes here.", uxlog.Info()))
 	}
 }
 
@@ -379,6 +382,15 @@ func (ui *receiverUI) close() {
 // kept (no consent) it returns E013 so scripts get a non-zero exit, after
 // showing the summary; a --manifest write failure surfaces the same way.
 func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
+	// Unknown-total bars (stream/text: bytesHint 0) never reach Completed on
+	// their own, so Done() would keep them — the keep-the-bar policy is meant
+	// for aborts, and this is the success path. Latch the total so the bar
+	// erases itself, mirroring the sender's onStreamingEOF.
+	ui.mu.Lock()
+	if ui.bar != nil && ui.bytesHint == 0 {
+		ui.bar.SetTotal(ui.total+ui.skipped, true)
+	}
+	ui.mu.Unlock()
 	ui.close()
 
 	ui.mu.Lock()

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -454,10 +454,13 @@ func signalContext(quiet bool) (context.Context, context.CancelFunc) {
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-ch
-		cancel()
+		// Notice before cancel(), and via uxlog.Println: a live progress
+		// bar's next refresh frame would erase a raw stderr write, and
+		// cancel() races the bar's teardown.
 		if !quiet {
-			fmt.Fprintf(os.Stderr, "\n%s Cancelling — press Ctrl-C again to force quit.\n", uxlog.Info())
+			uxlog.Println(fmt.Sprintf("%s Cancelling — press Ctrl-C again to force quit.", uxlog.Info()))
 		}
+		cancel()
 		signal.Stop(ch)
 	}()
 	return ctx, cancel

--- a/internal/uxlog/progress_test.go
+++ b/internal/uxlog/progress_test.go
@@ -172,6 +172,27 @@ func TestProgress_PlainModeLabelInLine(t *testing.T) {
 	}
 }
 
+// etaLabel rounds projections up to whole seconds — never milliseconds —
+// so the bar's tail doesn't flicker "ETA 943ms" at 10 Hz.
+func TestETALabel(t *testing.T) {
+	cases := []struct {
+		secs float64
+		want string
+	}{
+		{0.042, "1s"}, // sub-second rounds up, never "42ms"
+		{0.943, "1s"},
+		{1.2, "2s"},
+		{9.01, "10s"},
+		{59.5, "1m00s"},
+		{90, "1m30s"},
+	}
+	for _, c := range cases {
+		if got := etaLabel(c.secs); got != c.want {
+			t.Errorf("etaLabel(%v) = %q, want %q", c.secs, got, c.want)
+		}
+	}
+}
+
 // truncateName keeps the tail (extension) visible with a middle ellipsis
 // and leaves short names untouched.
 func TestTruncateName(t *testing.T) {

--- a/internal/uxlog/rate.go
+++ b/internal/uxlog/rate.go
@@ -10,14 +10,22 @@ import (
 // speed change shows within seconds.
 const rateWindowSpan = 5 * time.Second
 
+// stallThreshold is how long the window may see no new bytes before the
+// bar names the condition. Deliberately shorter than rateWindowSpan:
+// during a stall the windowed rate decays through fictional values (the
+// span grows while the byte delta doesn't), so the switch to "stalled"
+// must happen before that decay plays out.
+const stallThreshold = 3 * time.Second
+
 // rateWindow measures throughput over the last rateWindowSpan of samples
 // so the bar's rate and ETA track current conditions instead of the
 // lifetime mean, which a slow handshake or a speed change would skew for
 // the rest of the transfer. Fed once per refresh frame by the rate
 // decorator; the ETA decorator reads it.
 type rateWindow struct {
-	mu      sync.Mutex
-	samples []rateSample
+	mu          sync.Mutex
+	samples     []rateSample
+	lastAdvance time.Time // when cum last increased; zero before any sample
 }
 
 type rateSample struct {
@@ -30,6 +38,9 @@ type rateSample struct {
 func (w *rateWindow) observe(now time.Time, cum int64) float64 {
 	w.mu.Lock()
 	defer w.mu.Unlock()
+	if len(w.samples) == 0 || cum > w.samples[len(w.samples)-1].cum {
+		w.lastAdvance = now
+	}
 	w.samples = append(w.samples, rateSample{now, cum})
 	// Drop samples older than the window, but keep the newest of them as
 	// the baseline so the measured span stays ~window wide instead of
@@ -49,6 +60,14 @@ func (w *rateWindow) rate() float64 {
 	w.mu.Lock()
 	defer w.mu.Unlock()
 	return w.rateLocked()
+}
+
+// stalled reports whether observe has seen no byte advance for more than
+// stallThreshold. False before the first sample.
+func (w *rateWindow) stalled(now time.Time) bool {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return !w.lastAdvance.IsZero() && now.Sub(w.lastAdvance) > stallThreshold
 }
 
 func (w *rateWindow) rateLocked() float64 {

--- a/internal/uxlog/rate_test.go
+++ b/internal/uxlog/rate_test.go
@@ -43,6 +43,32 @@ func TestRateWindow_StallDecaysToZero(t *testing.T) {
 	}
 }
 
+// TestRateWindow_Stalled: the stall marker trips only after stallThreshold
+// with no byte advance, never before the first sample, and recovers as
+// soon as bytes move again.
+func TestRateWindow_Stalled(t *testing.T) {
+	w := &rateWindow{}
+	t0 := time.Now()
+	if w.stalled(t0) {
+		t.Error("stalled before any sample")
+	}
+	w.observe(t0, 1000)
+	if w.stalled(t0.Add(stallThreshold - time.Second)) {
+		t.Error("stalled before the threshold elapsed")
+	}
+	// Frames keep arriving with the same cumulative count (a real stall):
+	// they must not reset the clock.
+	w.observe(t0.Add(2*time.Second), 1000)
+	if !w.stalled(t0.Add(stallThreshold + time.Second)) {
+		t.Error("not stalled after threshold with no byte advance")
+	}
+	// Bytes move again: recovered.
+	w.observe(t0.Add(stallThreshold+2*time.Second), 2000)
+	if w.stalled(t0.Add(stallThreshold + 2*time.Second)) {
+		t.Error("still stalled after bytes advanced")
+	}
+}
+
 // TestRateWindow_NoDivideByZero: empty and degenerate windows must return
 // 0, never divide by a zero span.
 func TestRateWindow_NoDivideByZero(t *testing.T) {

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -16,6 +16,7 @@ package uxlog
 import (
 	"fmt"
 	"io"
+	"math"
 	"os"
 	"sync"
 	"sync/atomic"
@@ -247,26 +248,35 @@ func New(totalBytes int64, showNames bool) *Progress {
 			// Rate: hidden when the figure would be misleading (start
 			// of transfer, sub-MB movement — HumanRate's noise floor —
 			// or on completion; the summary carries the final figure).
-			// This decorator also feeds the window each refresh frame,
-			// so a stall shows up as a decaying rate and a growing ETA.
+			// This decorator also feeds the window each refresh frame.
+			// A stall says "stalled" rather than letting the windowed
+			// rate decay through fictional values.
 			decor.Any(func(s decor.Statistics) string {
 				if s.Completed || s.Aborted || s.Current == 0 {
 					return ""
 				}
-				r := win.observe(time.Now(), s.Current)
-				if r <= 0 || s.Current < rateThreshold {
+				now := time.Now()
+				r := win.observe(now, s.Current)
+				if s.Current < rateThreshold {
+					return ""
+				}
+				if win.stalled(now) {
+					return "  ·  " + Dim("stalled")
+				}
+				if r <= 0 {
 					return ""
 				}
 				return "  ·  " + HumanBytes(int64(r)) + "/s"
 			}),
 			// ETA: needs a known total, non-zero progress, and at least
 			// 1 s elapsed so the projection isn't dominated by handshake
-			// time. Hidden on completion.
+			// time. Hidden on completion and during a stall (a projection
+			// off a decaying rate only inflates).
 			decor.Any(func(s decor.Statistics) string {
 				if s.Completed || s.Aborted || s.Total <= 0 || s.Current == 0 {
 					return ""
 				}
-				if time.Since(start) < time.Second {
+				if time.Since(start) < time.Second || win.stalled(time.Now()) {
 					return ""
 				}
 				rate := win.rate()
@@ -277,7 +287,7 @@ func New(totalBytes int64, showNames bool) *Progress {
 				if remainingSecs <= 0 {
 					return ""
 				}
-				return "  ·  ETA " + HumanDuration(time.Duration(remainingSecs*float64(time.Second)))
+				return "  ·  ETA " + etaLabel(remainingSecs)
 			}),
 		)
 	}
@@ -305,6 +315,22 @@ func New(totalBytes int64, showNames bool) *Progress {
 		mpb.AppendDecorators(appendDecs...),
 	)
 	return p
+}
+
+// etaLabel renders an ETA projection, rounding up to whole seconds: at
+// 10 Hz refresh a sub-second projection would flicker millisecond values
+// ("ETA 943ms", "ETA 42ms") through the tail of a transfer. Sub-minute
+// values are formatted here rather than via HumanDuration, whose ms and
+// decimal precision is calibrated for measured elapsed times.
+func etaLabel(remainingSecs float64) string {
+	secs := int64(math.Ceil(remainingSecs))
+	if secs < 1 {
+		secs = 1
+	}
+	if secs < 60 {
+		return fmt.Sprintf("%ds", secs)
+	}
+	return HumanDuration(time.Duration(secs) * time.Second)
 }
 
 // Add increments the bar by n bytes.

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -194,9 +194,15 @@ func New(totalBytes int64, showNames bool) *Progress {
 		mpb.WithRefreshRate(100*time.Millisecond), // spec: ≥10 Hz
 	)
 
+	hasTotal := totalBytes > 0
 	// The ━/╸/─ trio gives a calm, modern look without the "=====>"
-	// telegraph aesthetic the default style carries.
-	style := mpb.BarStyle().Lbound(" ").Rbound(" ").Filler("━").Tip("╸").Padding("─")
+	// telegraph aesthetic the default style carries. Unknown totals get
+	// no track at all: it could never fill, and a full-width ─ line at
+	// 0% reads as "stalled" — the counter/rate decorators carry the line.
+	var style mpb.BarFillerBuilder = mpb.BarStyle().Lbound(" ").Rbound(" ").Filler("━").Tip("╸").Padding("─")
+	if !hasTotal {
+		style = mpb.NopStyle()
+	}
 
 	// Track elapsed locally — decor.Statistics doesn't carry it. Only the
 	// ETA's ≥1 s warm-up gate uses it; the rate itself comes from win, a
@@ -205,7 +211,6 @@ func New(totalBytes int64, showNames bool) *Progress {
 	// summary line still reports the lifetime figure — that one is correct.
 	start := time.Now()
 	win := &rateWindow{}
-	hasTotal := totalBytes > 0
 	// Rate needs no total — a multi-GB stdin stream is exactly where the
 	// user wants throughput. HumanRate's own noise floor keeps it hidden
 	// until ~1 MB has moved, covering the small-stream case; ETA stays


### PR DESCRIPTION
Fixes five rendering findings from the third CLI UX audit. All scenarios were driven under a real pty (python pty helper, 100/80 cols) against a local server, with raw captures replayed through an ANSI screen interpreter to get the literal final screen. Payloads were /dev/urandom.

## A (P2): live bar erased the Ctrl-C notices and left a duplicate stale bar line

`printCancelKeptHint` and `signalContext`'s cancel notice wrote raw `fmt.Fprintf(os.Stderr, …)` while the mpb bar was live; the bar's next refresh frame (cursor-up + erase-down) destroyed them. Both now route through `uxlog.Println`, which hands foreign lines to mpb so they land above the bar (the same mechanism retry/resume notices already use). The notice also moved before `cancel()` so it can't race the bar's teardown. There is no second-Ctrl-C message (the handler reverts to the default disposition), and no other raw stderr write can fire while a bar is live — prompts and artifact blocks all run before the bar exists.

Pre-fix final screen (Ctrl-C mid 300 MB TTY receive) — hint destroyed, duplicate bar line:

```
  6|    6%    ━╸────────────────    19.9 MB / 314.6 MB  ·  33.8 MB/s   ← stale duplicate
  8|ℹ Cancelling — press Ctrl-C again to force quit.
  9|    6%    ━╸────────────────    19.9 MB / 314.6 MB
 10|ℹ [E026] Cancelled.
```

Post-fix — both notices present, exactly one frozen bar line:

```
  6|ℹ Cancelling — press Ctrl-C again to force quit.
  7|ℹ Partial data kept — when the sender runs fsend again, the transfer resumes here.
  8|    7%    ━━╸───────────────    22 MB / 314.6 MB
  9|ℹ [E026] Cancelled.
```

## B (P2): successful unknown-total receives left an orphan bar line

Stream/text receives have `bytesHint == 0`, so the bar never reached `Completed()` and `Done()` took the `Abort(false)` keep-the-bar branch — a policy meant for aborts, applied to a success. `finishReceive` (only reached on success) now latches `SetTotal(actual, true)` for zero-hint bars before closing, mirroring the sender's `onStreamingEOF`, so `BarRemoveOnComplete` erases it.

Pre-fix `--text` receive final screen kept `  ...     ─────────────    80 KB` above the summary; post-fix it is gone. Verified unchanged: a normal file receive still erases its completed bar, and an aborted receive still keeps its partial bar (screen A above).

## C (P3): millisecond ETA flicker at the tail

The ETA projection now rounds up to whole seconds (`etaLabel`, unit-tested). Pre-fix capture showed 8 tail frames of `ETA 988ms` … `ETA 394ms` at 10 Hz; post-fix the distinct ETA renderings across a 300 MB run are `ETA 1s` … `ETA 59s`, `ETA 1m21s`, … — zero ms, zero decimals. `HumanDuration` itself is untouched (it renders measured elapsed times elsewhere).

## D (P3): stalls decayed through fictional rates while ETA inflated

`rateWindow` now tracks when the cumulative count last advanced; after >3 s with no new bytes the rate chip renders a dim `stalled` and the ETA chip hides. No new goroutines — the existing decorator frames drive it.

Evidence (SIGSTOP the receiver ~4 s mid 300 MB flight, then SIGCONT):
- Pre-fix: rate decays 13.5 → 1.4 MB/s over the stop with zero bytes moving; ETA inflates to `10m12s`.
- Post-fix: 22 frames of `21%    ━━━━━━━╸────────    66.8 MB / 314.6 MB  ·  stalled` with no ETA; after SIGCONT the chip recovers to real figures (47–48 MB/s) and the transfer completes intact.

## E (P3, last commit — separable): unknown-total bars drew a never-filling track

`cat big.bin | fsend -` rendered a full-width `─` track stuck at 0% that reads as "stalled". Unknown-total bars now use `mpb.NopStyle()`: just the `...` prefix, counter, and rate.

- Pre-fix frame: `...     ──────────────────────────────────────    82.6 MB  ·  55.4 MB/s`
- Post-fix frame: `...       76.8 MB  ·  50.6 MB/s`
- Known-total bars are byte-identical pre/post: max track width 23 at 80 cols and 38 at 100 cols in both binaries.

This commit (`fix(cli): drop the never-filling track on unknown-total progress bars`) can be dropped in review without touching A–D.

## Tests

- New unit tests: `TestRateWindow_Stalled` (threshold, no-reset on same-count frames, recovery) and `TestETALabel` (sub-second rounds up to `1s`, `59.5 → 1m00s`).
- `go test ./internal/uxlog ./cmd/fsend` and `go vet ./...` pass.

Deliberately not touched (audit's standing rejections): SIGWINCH handling, ASCII-bar fallback, and the keep-aborted-bars-on-failure policy — only the success path changed in B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)