### PR TITLE
fix(transfer): map interrupt-time errors to the right catalog entries

### DIFF
--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -445,12 +445,22 @@ func senderQUICAccept(ctx context.Context, pc net.PacketConn, code string) (*qui
 // Stdin/--text transfers can't replay their reader, so they fail as
 // before instead of re-pairing.
 func runSendParallel(ctx context.Context, f *flags, plan *sendPlan, code string, cfg *config.Config, waitSpin *uxlog.Spinner) error {
+	transferDropped := false
 	for {
 		err := runSendOnce(ctx, f, plan, code, cfg, waitSpin)
 		if err == nil || ctx.Err() != nil || plan.consumable() ||
 			(!errors.Is(err, fserrors.ErrTransientFailure) && !isReceiverClose(err)) {
+			// A re-pair round failing with "server unreachable" after a
+			// transfer already dropped is a mid-transfer connection loss,
+			// not a pairing failure: E001's copy suggests switching servers
+			// and omits that the receiver's partial is preserved. E020's
+			// resume framing is what actually happened.
+			if transferDropped && errors.Is(err, fserrors.ErrServerUnreachable) {
+				return fmt.Errorf("%w: %v", fserrors.ErrTransientFailure, err)
+			}
 			return err
 		}
+		transferDropped = true
 		if !f.quiet {
 			// A deliberate close (Ctrl-C, clean exit) may genuinely re-run
 			// and reconnect. A death (kill, crash, network gone) surfaces
@@ -472,9 +482,18 @@ func runSendParallel(ctx context.Context, f *flags, plan *sendPlan, code string,
 // receiver will never re-dial the current pairing, so the re-accept
 // grace would be a dead wait. Network drops and kills surface as idle
 // timeouts instead and keep the grace.
+//
+// A remote stream cancel is the same close seen earlier: the receiver's
+// teardown cancels its data-stream read (STOP_SENDING) just before the
+// connection close, and an in-flight chunk write can surface the stream
+// error before the connection-level one.
 func isReceiverClose(err error) bool {
 	var appErr *quic.ApplicationError
-	return errors.As(err, &appErr) && appErr.Remote
+	if errors.As(err, &appErr) && appErr.Remote {
+		return true
+	}
+	var streamErr *quic.StreamError
+	return errors.As(err, &streamErr) && streamErr.Remote
 }
 
 // runSendOnce runs one pair-then-transfer round. It races the two pair

--- a/cmd/fsend/sendpair_test.go
+++ b/cmd/fsend/sendpair_test.go
@@ -320,4 +320,16 @@ func TestIsReceiverClose(t *testing.T) {
 	if isReceiverClose(nil) {
 		t.Error("nil must not classify as receiver close")
 	}
+
+	// The receiver's teardown cancels its data-stream read (STOP_SENDING)
+	// just before the connection close; an in-flight chunk write can see
+	// the stream cancel first. Same deliberate close, same verdict —
+	// without this it escaped to the E099 catchall.
+	remoteStream := &quic.StreamError{StreamID: 3, ErrorCode: 0, Remote: true}
+	if !isReceiverClose(fmt.Errorf("wire: writing chunk payload: %w", remoteStream)) {
+		t.Error("remote stream cancel should classify as receiver close")
+	}
+	if isReceiverClose(&quic.StreamError{StreamID: 3, ErrorCode: 0, Remote: false}) {
+		t.Error("local stream cancel must not classify as receiver close")
+	}
 }

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -187,6 +187,12 @@ func IsTransient(err error) bool {
 	// QUIC stream tears down, so they're already caught by the terminal
 	// sentinel check above and never reach this fallback.
 	//
+	// "canceled by remote" is quic-go's StreamError: the peer's teardown
+	// cancels its data-stream read (STOP_SENDING) just before the
+	// connection close, and an in-flight write can surface the stream
+	// cancel instead of the "Application error" above — same abrupt
+	// close, same transient verdict.
+	//
 	// "failed to write STUN message to ICE connection" is pion/ice's
 	// sentinel from its STUN/data demux guard: ice.Conn.Write refuses any
 	// app packet that stun.IsMessage flags (len>=20 && bytes[4:8]==magic
@@ -199,6 +205,7 @@ func IsTransient(err error) bool {
 		strings.Contains(s, "connection reset by peer") ||
 		strings.Contains(s, "use of closed network connection") ||
 		strings.Contains(s, "Application error 0x") ||
+		strings.Contains(s, "canceled by remote") ||
 		strings.Contains(s, "failed to write STUN message to ICE connection") {
 		return true
 	}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -156,6 +156,15 @@ func TestIsTransient_Classification(t *testing.T) {
 		{"quic_application_error_with_message_transient",
 			errors.New("Application error 0x100 (remote): peer left"), true},
 
+		// The peer's teardown cancels its data-stream read (STOP_SENDING)
+		// just before the connection close; an in-flight write can surface
+		// the stream cancel instead of the application error above. Same
+		// abrupt close, same verdict. This is the exact field string.
+		{"quic_stream_cancel_remote_transient",
+			errors.New("wire: writing chunk payload: stream 3 canceled by remote with error code 0"), true},
+		{"quic_stream_cancel_local_not_transient",
+			errors.New("stream 3 canceled by local with error code 0"), false},
+
 		// pion/ice STUN-demux false positive: a QUIC datagram's encrypted
 		// bytes 4..7 randomly matched the STUN magic cookie, so
 		// ice.Conn.Write rejected it. Never a real network fault; a re-dial


### PR DESCRIPTION
Fixes two P2 findings from the third CLI UX audit: sender-side error classification when a transfer is interrupted mid-flight.

## Finding A: receiver Ctrl-C intermittently drove the sender into E099

The receiver's teardown cancels its data-stream read (`uniInCloser.Close` → `CancelRead(0)`, i.e. STOP_SENDING) just before the connection-level close. A sender blocked in a chunk write races between the two: usually it observes the remote `*quic.ApplicationError` (already classified by `isReceiverClose`), but sometimes the remote `*quic.StreamError` wins — and neither `isReceiverClose` nor `retry.IsTransient` recognized it, so it fell through to the E099 catchall.

**Before** (reproduced 1/15 on a 400 MB urandom send over the relay path, `kill -INT` on the receiver mid-flight):

```
[OK] Receiver connected  ·  relayed via 127.0.0.1:19111
[*] Waiting for them to accept
[FAIL] [E099] Unexpected error: wire: writing chunk payload: stream 3 canceled by remote with error code 0
  Re-run with --debug and include the output when filing the issue:
    https://github.com/polius/fsend/issues
```

**Fix**: `isReceiverClose` now also matches a remote `*quic.StreamError` — the same deliberate close, seen one packet earlier. `retry.IsTransient` learns the `"canceled by remote"` string alongside the existing `"Application error 0x"` match, so the one-attempt stdin/`--text` path degrades to E020 instead of E099. No wire-level cancel signaling added — purely classification.

**After**: 12/12 runs of the same kill loop land on the wait path:

```
[i] Receiver disconnected — waiting for them to reconnect.
```

and an interrupted receive re-run with the same code resumes and completes (`[i] Resuming from 65 MB (15%)`, sha256 identical on both ends: `67555c00…af67`).

Note: the ~20% race is timing-dependent — it only fired on the relay path in my environment, and 1/15 pre-fix is a thin sample. The error string itself is deterministic (`quic.StreamError`, remote, code 0), so the classification fix is pinned by unit tests in `sendpair_test.go` and `retry_test.go` rather than by the loop alone.

## Finding B: server killed mid-transfer (relay path) exited E001 on the sender

After a transfer drops, `runSendParallel` loops back to re-pair; with the server dead, `pairOverInternet` fails with `ErrServerUnreachable` and the sender exited 1 with E001 — pairing-failure copy ("Check your internet connection, or use a different server") that omits that the receiver's partial is preserved — while the receiver correctly exited 20/E020.

**Before** (3 runs, `--mode relay`, `kill -9` on the server with >30 MB confirmed moved; 2 clean repros, 1 run poisoned by an unrelated concurrent process sending SIGINT — see caveats):

```
[i] Lost contact with the receiver — waiting for a new connection on the same code.
[*] Waiting for receiver
[FAIL] [E001] Could not reach the server (timeout).
  Server: 127.0.0.1:19110
  Check your internet connection, or use a different server:
    fsend --connect <host:port>
```

**Fix**: `runSendParallel` tracks that a transfer round already dropped (`transferDropped`) and rewraps a subsequent re-pair `ErrServerUnreachable` into `ErrTransientFailure`, so the sender gets E020's resume framing. The gate is only set once a round ends in a mid-transfer drop, so pairing-time failures are untouched.

**After** (3/3):

```
[i] Lost contact with the receiver — waiting for a new connection on the same code.
[*] Waiting for receiver
[FAIL] [E020] Transfer was interrupted and retries did not recover.
  Check your network connection and try again — fsend will resume
  from where it left off.
```

sender exit 20, receiver exit 20 — both sides now agree.

**Control** (must not change): server `kill -9` during pairing still yields `[E014]` exit 14 on both sides (4 runs; one run where the kill landed before the receiver's Join gave E001/E001, the pre-existing behavior for a server that is down before pairing — the `transferDropped` gate cannot affect pairing-time errors).

## Validation

- Local server (`FSEND_SERVER_ADDR=:19110 FSEND_RELAY_ADDR=:19111`), 400 MB `/dev/urandom` payload, sender forced through the relay with the hidden `--mode relay`.
- Normal end-to-end transfer unaffected: full send/receive completes, sha256 matches on both ends, exit 0 both sides.
- `go test ./cmd/fsend ./internal/transfer ./internal/fserrors ./internal/wire ./internal/retry` all green; unit tests extended for both classifiers (remote/local `StreamError` in `TestIsReceiverClose`, exact field string in `TestIsTransient_Classification`).
- No user-facing strings changed; the exit-code table in `docs/usage.md` is untouched (E001 remains "server unreachable" for pairing-time failures, E020 copy unchanged).

Caveat on the test environment: other fsend test sessions were running on the same machine during validation (shared scratchpad, overlapping `pkill fsend-test` patterns). Runs contaminated by them (clients silently pairing against a foreign server on :19120, stray SIGINTs) were detected via the relay-address chip in the logs, discarded, and re-run with namespaced configs and a uniquely named binary; all evidence quoted above is from clean runs whose logs show `relayed via 127.0.0.1:19111` (my server).

🤖 Generated with [Claude Code](https://claude.com/claude-code)