### PR TITLE
fix(cli): outcome truth and copy fixes from the third CLI UX audit

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -957,8 +957,11 @@ func TestPromptAccept_YesWarnsAboutKeptDiffers(t *testing.T) {
 
 // A text payload with no trailing newline must not let the stderr summary
 // butt against it when both streams share a sink (2>&1, CI logs) — the line
-// break goes to stderr, keeping the piped stdout bytes exact.
-func TestPrintTextPayload_BreaksLineForPipedStdout(t *testing.T) {
+// break goes to stderr, keeping the piped stdout bytes exact. When stderr is
+// a different sink (the terminal), that break would only render as a stray
+// blank line before the summary, so it must stay away.
+func TestPrintTextPayload_BreaksLineForSharedSinkOnly(t *testing.T) {
+	// Separate sinks: exact stdout bytes, silent stderr.
 	var stdout string
 	stderr := captureStderr(t, func() {
 		stdout = captureStdout(t, func() {
@@ -970,11 +973,33 @@ func TestPrintTextPayload_BreaksLineForPipedStdout(t *testing.T) {
 	if stdout != "no-newline" {
 		t.Errorf("piped stdout must carry the exact bytes, got %q", stdout)
 	}
-	if stderr != "\n" {
-		t.Errorf("expected a line break on stderr, got %q", stderr)
+	if stderr != "" {
+		t.Errorf("separate stderr must stay silent, got %q", stderr)
 	}
 
-	// A newline-terminated payload needs no break.
+	// Shared sink (2>&1): the break lands after the payload.
+	shared := filepath.Join(t.TempDir(), "sink")
+	f, err := os.OpenFile(shared, os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldOut, oldErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = f, f
+	perr := printTextPayload("no-newline")
+	os.Stdout, os.Stderr = oldOut, oldErr
+	_ = f.Close()
+	if perr != nil {
+		t.Fatalf("printTextPayload: %v", perr)
+	}
+	b, err := os.ReadFile(shared)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(b) != "no-newline\n" {
+		t.Errorf("shared sink must get the break, got %q", string(b))
+	}
+
+	// A newline-terminated payload needs no break anywhere.
 	stderr = captureStderr(t, func() {
 		_ = captureStdout(t, func() { _ = printTextPayload("clean\n") })
 	})

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -961,20 +961,32 @@ func TestPromptAccept_YesWarnsAboutKeptDiffers(t *testing.T) {
 // a different sink (the terminal), that break would only render as a stray
 // blank line before the summary, so it must stay away.
 func TestPrintTextPayload_BreaksLineForSharedSinkOnly(t *testing.T) {
-	// Separate sinks: exact stdout bytes, silent stderr.
-	var stdout string
-	stderr := captureStderr(t, func() {
-		stdout = captureStdout(t, func() {
-			if err := printTextPayload("no-newline"); err != nil {
-				t.Errorf("printTextPayload: %v", err)
-			}
-		})
-	})
-	if stdout != "no-newline" {
-		t.Errorf("piped stdout must carry the exact bytes, got %q", stdout)
+	// Separate sinks: exact stdout bytes, silent stderr. Real files, not
+	// os.Pipe: Windows pipes carry no file IDs, so two distinct pipes
+	// compare as the same sink (see the sameSink comment).
+	dir := t.TempDir()
+	outF, err := os.Create(filepath.Join(dir, "out"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if stderr != "" {
-		t.Errorf("separate stderr must stay silent, got %q", stderr)
+	errF, err := os.Create(filepath.Join(dir, "err"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	oldOut, oldErr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = outF, errF
+	perr := printTextPayload("no-newline")
+	os.Stdout, os.Stderr = oldOut, oldErr
+	_ = outF.Close()
+	_ = errF.Close()
+	if perr != nil {
+		t.Fatalf("printTextPayload: %v", perr)
+	}
+	if b, _ := os.ReadFile(outF.Name()); string(b) != "no-newline" {
+		t.Errorf("piped stdout must carry the exact bytes, got %q", string(b))
+	}
+	if b, _ := os.ReadFile(errF.Name()); string(b) != "" {
+		t.Errorf("separate stderr must stay silent, got %q", string(b))
 	}
 
 	// Shared sink (2>&1): the break lands after the payload.
@@ -983,9 +995,9 @@ func TestPrintTextPayload_BreaksLineForSharedSinkOnly(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	oldOut, oldErr := os.Stdout, os.Stderr
+	oldOut, oldErr = os.Stdout, os.Stderr
 	os.Stdout, os.Stderr = f, f
-	perr := printTextPayload("no-newline")
+	perr = printTextPayload("no-newline")
 	os.Stdout, os.Stderr = oldOut, oldErr
 	_ = f.Close()
 	if perr != nil {
@@ -1000,7 +1012,7 @@ func TestPrintTextPayload_BreaksLineForSharedSinkOnly(t *testing.T) {
 	}
 
 	// A newline-terminated payload needs no break anywhere.
-	stderr = captureStderr(t, func() {
+	stderr := captureStderr(t, func() {
 		_ = captureStdout(t, func() { _ = printTextPayload("clean\n") })
 	})
 	if stderr != "" {

--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -1126,6 +1126,68 @@ func TestResolveOutDir(t *testing.T) {
 	})
 }
 
+// With zero bytes moved the elapsed figure is prompt dwell or connection
+// wall time, not a transfer duration — it must not render.
+func TestSummaryParts_ZeroMovedOmitsDuration(t *testing.T) {
+	parts := strings.Join(summaryParts(4096, 0, "sent", 5800*time.Millisecond, mustLANInfo()), "  ·  ")
+	if strings.Contains(parts, "5.8s") {
+		t.Errorf("0 B moved must not show a duration: %s", parts)
+	}
+	if !strings.Contains(parts, "4.1 KB (0 B sent)") {
+		t.Errorf("size clause changed shape: %s", parts)
+	}
+}
+
+// An all-skipped send (receiver already had everything) must mirror the
+// receiver's "Already up to date", not the self-contradictory
+// "Sent · (0 B sent)". Kept files still win over the up-to-date headline.
+func TestPrintSendSummary_AllSkippedReadsUpToDate(t *testing.T) {
+	got := captureStderr(t, func() {
+		printSendSummary(&flags{}, 4096, senderStats{skippedFiles: 1}, time.Millisecond, mustLANInfo())
+	})
+	if !strings.Contains(got, "Already up to date") || !strings.Contains(got, "1 file unchanged") {
+		t.Errorf("all-skipped summary must read up to date, got %q", got)
+	}
+	if strings.Contains(got, "Sent") || strings.Contains(got, "0 B") {
+		t.Errorf("no byte counter on an up-to-date no-op: %q", got)
+	}
+
+	// Kept files: still the "Nothing sent" warning path.
+	got = captureStderr(t, func() {
+		printSendSummary(&flags{}, 4096, senderStats{skippedFiles: 1, keptFiles: 1}, time.Millisecond, mustLANInfo())
+	})
+	if !strings.Contains(got, "Nothing sent") || !strings.Contains(got, "kept by receiver") {
+		t.Errorf("kept-file summary changed shape: %q", got)
+	}
+}
+
+// Kept files render as a count only — the --overwrite remedy already
+// appears once elsewhere (the --yes warning or E013's action line), and
+// after an explicit "n" it must not appear at all. The glyph tracks who
+// decided: warn for the silent auto-keep, info for the user's own "n".
+func TestPrintRecvSummary_KeptCarriesNoFlagAdvice(t *testing.T) {
+	autoKept := captureStderr(t, func() {
+		printRecvSummary(&flags{}, "Saved 0 of 1 file to /tmp", 0, 0, 1, 0, false, time.Second, mustLANInfo())
+	})
+	if strings.Contains(autoKept, "--overwrite") {
+		t.Errorf("summary must not repeat the --overwrite advice: %q", autoKept)
+	}
+	if !strings.Contains(autoKept, "1 file kept") || !strings.Contains(autoKept, uxlog.Warn()) {
+		t.Errorf("auto-kept summary must warn with a kept count: %q", autoKept)
+	}
+
+	byChoice := captureStderr(t, func() {
+		printRecvSummary(&flags{}, "Saved 0 of 1 file to /tmp", 0, 0, 1, 0, true, time.Second, mustLANInfo())
+	})
+	if strings.Contains(byChoice, "--overwrite") || !strings.Contains(byChoice, uxlog.Info()) {
+		t.Errorf("kept-by-choice must render as the user's decision: %q", byChoice)
+	}
+	// Prompt dwell must not masquerade as a transfer duration.
+	if strings.Contains(byChoice, "1s") {
+		t.Errorf("0 B moved must not show a duration: %q", byChoice)
+	}
+}
+
 // A stream's total is 0 until EOF; the summary must report the moved
 // bytes as the size, not "0 B".
 func TestSummaryParts_UnknownTotalUsesMoved(t *testing.T) {

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -79,11 +79,12 @@ var joinRetryBudget = 15 * time.Second
 // controlled), fall back to relay on failure.
 //
 // connSpin, when non-nil, is the "Connecting" spinner the caller
-// started. We keep it animating through Join + ICE/relay setup and stop
-// it just before printPath — the first user-visible status line. This
-// replaces what used to be a sequence of brief spinner flashes that read
-// as glitchy. The deferred Stop covers error returns; Stop is idempotent
-// (sync.Once), so explicit stops before printPath don't double-close.
+// started. We keep it animating through Join + ICE/relay setup, then
+// hand it to runReceiverQUICOver, which retitles it for classification
+// and stops it at the accept prompt. This replaces what used to be a
+// sequence of brief spinner flashes that read as glitchy. The deferred
+// Stop covers error returns; Stop is idempotent (sync.Once), so the
+// earlier stops don't double-close.
 func runReceiveOverInternet(ctx context.Context, f *flags, c string, cfg *config.Config, connSpin *uxlog.Spinner) error {
 	client, _ := signalingClient(cfg)
 	defer connSpin.Stop()
@@ -106,11 +107,11 @@ func runReceiveOverInternet(ctx context.Context, f *flags, c string, cfg *config
 	}, false /* controlled */, f.debug)
 	if iceErr == nil {
 		defer func() { _ = iceConn.Close() }()
-		// Stop the spinner; the receive UX is owned by runReceiverQUICOver
-		// from here (no standalone path line — the prompt block carries
-		// path info as a chip and the summary names it again).
-		connSpin.Stop()
-		return runReceiverQUICOver(ctx, f, iceConn, c, icePath)
+		// Hand the spinner to runReceiverQUICOver: it keeps animating
+		// through classification and stops at the accept prompt (no
+		// standalone path line — the prompt block carries path info as a
+		// chip and the summary names it again).
+		return runReceiverQUICOver(ctx, f, iceConn, c, icePath, connSpin)
 	}
 	if f.debug {
 		fmt.Fprintln(os.Stderr, "DEBUG: ICE failed:", iceErr)
@@ -135,9 +136,8 @@ func runReceiveOverInternet(ctx context.Context, f *flags, c string, cfg *config
 		return fmt.Errorf("%w: %v", fserrors.ErrConnectFailed, err)
 	}
 	defer func() { _ = relayConn.Close() }()
-	connSpin.Stop()
 	return classifyRelayDrop(ctx, client, joined.SessionID, joined.RoleToken,
-		runReceiverQUICOver(ctx, f, relayConn, c, connpath.FromRelay(alloc.RelayAddr)))
+		runReceiverQUICOver(ctx, f, relayConn, c, connpath.FromRelay(alloc.RelayAddr), connSpin))
 }
 
 // classifyRelayDrop probes the relay-status endpoint when a relay-path
@@ -410,12 +410,17 @@ func dialRelay(alloc *server.RelayAllocateResponse) (net.PacketConn, error) {
 // runReceiverQUICOver runs the receiver's QUIC + transfer flow over an
 // already-established net.PacketConn.
 //
+// spin is the caller's "Connecting" spinner (nil under --quiet); it is
+// retitled and kept alive through classification — with --checksum the
+// pre-prompt hashing scales with the data already on disk — and stopped
+// by the accept prompt (or ui.close on error).
+//
 // Symmetric retry: a transient error tears down the current QUIC
 // session, sleeps, and re-Dials on the same PacketConn. The receiver's
 // .fsend-partial sidecar plus its imohash fingerprint let the next
 // attempt resume mid-file — the sender verifies the prefix, seeks past
 // it, and streams the remainder.
-func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code string, pathInfo connpath.Info) error {
+func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code string, pathInfo connpath.Info, spin *uxlog.Spinner) error {
 	tr := quicconn.NewTransport(pc)
 	defer func() { _ = tr.Close() }()
 
@@ -424,12 +429,14 @@ func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code 
 		return err
 	}
 	ui := newReceiverUI(ctx, f, outDir, sink, pathInfo)
+	spin.SetMessage("Checking existing files")
+	ui.spin = spin
 	defer ui.close()
 
 	start := time.Now()
 	// Sink mode gets one attempt: emitted bytes can't be reconciled, so
 	// a retry would duplicate output.
-	opts := retry.Options{OnRetry: retryNoticeFor(f)}
+	opts := retry.Options{OnRetry: ui.retryNotice()}
 	if sink {
 		opts.Attempts = 1
 	}

--- a/cmd/fsend/jsonout.go
+++ b/cmd/fsend/jsonout.go
@@ -22,7 +22,7 @@ import (
 //     summary path when the transfer reached one (rich: bytes/files/route),
 //     or from renderError otherwise (ok/error/exit only).
 //
-// jsonOut is package-level state, mirroring errorRoleSender: renderError
+// jsonOut is package-level state, mirroring errorRole: renderError
 // runs after the transfer stack has unwound, and the once-guard is what
 // lets the rich summary event win over the generic failure event.
 var jsonOut struct {
@@ -62,12 +62,13 @@ type jsonCodeEvent struct {
 }
 
 // jsonDoneEvent is the terminal event. Omitted fields mean "not known at
-// this exit path" (a failure before the summary has no byte counts).
+// this exit path" (a failure before the summary has no byte counts; a
+// flag-parse failure has no role yet — documented in docs/usage.md).
 type jsonDoneEvent struct {
 	V          int    `json:"v"`
 	Event      string `json:"event"`
 	Ok         bool   `json:"ok"`
-	Role       string `json:"role"`
+	Role       string `json:"role,omitempty"`
 	Error      string `json:"error,omitempty"` // catalog code, e.g. "E013"
 	Exit       int    `json:"exit"`
 	BytesTotal *int64 `json:"bytes_total,omitempty"`
@@ -109,11 +110,10 @@ func jsonEmitDone(ev jsonDoneEvent) {
 
 // jsonDoneFromErr builds the generic failure event renderError emits when
 // no summary ran. err == nil is a clean exit some caller narrated itself.
-func jsonDoneFromErr(err error, exit int, sender bool) jsonDoneEvent {
-	ev := jsonDoneEvent{Ok: err == nil && exit == 0, Role: "receiver", Exit: exit}
-	if sender {
-		ev.Role = "sender"
-	}
+// role is errorRole — "" (field omitted) when the run failed before a
+// send/receive path was entered, e.g. a flag-parse error.
+func jsonDoneFromErr(err error, exit int, role string) jsonDoneEvent {
+	ev := jsonDoneEvent{Ok: err == nil && exit == 0, Role: role, Exit: exit}
 	if err != nil {
 		entry, _ := fserrors.Lookup(err)
 		ev.Error = entry.Code

--- a/cmd/fsend/jsonout_test.go
+++ b/cmd/fsend/jsonout_test.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/polius/fsend/internal/fserrors"
+)
+
+// A failure before any transfer path is entered (flag-parse error) has no
+// role; the done event must omit the field rather than fabricate "receiver".
+func TestJSONDoneFromErr_RoleOmittedWhenUnknown(t *testing.T) {
+	b, err := json.Marshal(jsonDoneFromErr(fserrors.ErrUsage, 24, ""))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(b), `"role"`) {
+		t.Errorf("undetermined role must be omitted, got %s", b)
+	}
+	if !strings.Contains(string(b), `"error":"E024"`) {
+		t.Errorf("catalog code missing: %s", b)
+	}
+
+	b, err = json.Marshal(jsonDoneFromErr(fserrors.ErrCodeNotFound, 2, "receiver"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(b), `"role":"receiver"`) {
+		t.Errorf("determined role must be present, got %s", b)
+	}
+}

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -24,9 +24,11 @@ import (
 	"github.com/polius/fsend/internal/uxlog"
 )
 
-// errorRoleSender is set by runSend so renderError can pick sender-side
-// wording for errors mirrored from the receiver (E009, E013, E021).
-var errorRoleSender bool
+// errorRole is set by runSend ("sender") / runReceive ("receiver") so
+// renderError can pick sender-side wording for errors mirrored from the
+// receiver (E009, E013, E021) and stamp the --json done event. Empty until
+// a transfer path is entered — a flag-parse failure has no role.
+var errorRole string
 
 func main() {
 	// Normalise --connect arguments before cobra parses. We use
@@ -117,7 +119,7 @@ func renderError(err error, debug bool) int {
 		err = fserrors.ErrUserCancelled
 	}
 	entry, known := fserrors.Lookup(err)
-	if known && errorRoleSender {
+	if known && errorRole == "sender" {
 		entry = entry.ForSender()
 	}
 
@@ -159,7 +161,7 @@ func renderError(err error, debug bool) int {
 		glyph = uxlog.Warn()
 	case errors.Is(err, fserrors.ErrUserCancelled),
 		errors.Is(err, errKeptByChoice),
-		!errorRoleSender && errors.Is(err, fserrors.ErrReceiverDeclined):
+		errorRole != "sender" && errors.Is(err, fserrors.ErrReceiverDeclined):
 		glyph = uxlog.Info()
 	}
 
@@ -222,7 +224,7 @@ func renderError(err error, debug bool) int {
 		}
 	}
 	// No-op if the summary already emitted the rich done event.
-	jsonEmitDone(jsonDoneFromErr(err, entry.Exit, errorRoleSender))
+	jsonEmitDone(jsonDoneFromErr(err, entry.Exit, errorRole))
 	return entry.Exit
 }
 

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -75,9 +75,9 @@ func runReceive(f *flags, c string) error {
 	q, err := landisc.Query(ctx, c, 300*time.Millisecond)
 	if err != nil {
 		// LAN miss → internet path. A single "Connecting" spinner runs
-		// from here through Join + ICE/relay setup, replacing what used
-		// to be a sequence of brief flashes. runReceiveOverInternet
-		// owns its lifetime and stops it just before printPath.
+		// from here through Join + ICE/relay setup and classification,
+		// replacing what used to be a sequence of brief flashes.
+		// runReceiveOverInternet owns its lifetime.
 		cfg := loadConfig(f.quiet)
 		var spin *uxlog.Spinner
 		if !f.quiet {
@@ -122,6 +122,13 @@ func runReceive(f *flags, c string) error {
 	}
 
 	ui := newReceiverUI(ctx, f, outDir, sink, connpath.FromLAN())
+	// --checksum hashes the files already on disk before the accept prompt —
+	// a silence that scales with the existing data. Cover it with a spinner
+	// (stopped by the prompt). Without --checksum classification is stat-only
+	// and near-instant; a spinner would just flash.
+	if f.checksum && !f.quiet {
+		ui.spin = uxlog.StartSpinner("Checking existing files")
+	}
 	defer ui.close()
 
 	start := time.Now()
@@ -130,7 +137,7 @@ func runReceive(f *flags, c string) error {
 	// itself so a mid-stream drop can re-dial and resume from the
 	// receiver's partial. Sink mode gets one attempt: emitted bytes
 	// can't be reconciled, so a retry would duplicate output.
-	opts := retry.Options{OnRetry: retryNoticeFor(f)}
+	opts := retry.Options{OnRetry: ui.retryNotice()}
 	if sink {
 		opts.Attempts = 1
 	}

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -410,7 +410,7 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 				return err
 			}
 		}
-		printRecvSummary(f, "Received text", total, moved, kept, 0, elapsed, ui.pathInfo)
+		printRecvSummary(f, "Received text", total, moved, kept, 0, keptByChoice, elapsed, ui.pathInfo)
 	} else {
 		headline := ui.headline(h, files)
 		// With kept-back files the peer-supplied display name ("2 files") would
@@ -419,7 +419,7 @@ func finishReceive(f *flags, ui *receiverUI, elapsed time.Duration) error {
 			headline = fmt.Sprintf("Saved %d of %s to %s",
 				len(files), uxlog.CountNoun(len(files)+skippedSame+kept, "file"), displayPath(ui.outDir))
 		}
-		printRecvSummary(f, headline, total, moved, kept, skippedSame, elapsed, ui.pathInfo)
+		printRecvSummary(f, headline, total, moved, kept, skippedSame, keptByChoice, elapsed, ui.pathInfo)
 	}
 	// manifestErr is set by onManifest, which runs on this goroutine before we
 	// return, so no lock is needed. The transfer succeeded; the failure is only
@@ -512,13 +512,18 @@ func (ui *receiverUI) headline(h *wire.SenderHello, files []string) string {
 }
 
 // printRecvSummary renders the post-transfer outcome line. Kept-back files
-// make it a partial success: warn glyph, matching the E013 exit that follows.
-func printRecvSummary(f *flags, headline string, total, moved int64, kept, skippedSame int, elapsed time.Duration, path connpath.Info) {
+// make it a partial success: warn glyph, matching the E013 exit that follows —
+// unless the user chose to keep them at the prompt, which is their decision,
+// not a warning (info glyph, matching renderError's errKeptByChoice).
+func printRecvSummary(f *flags, headline string, total, moved int64, kept, skippedSame int, keptByChoice bool, elapsed time.Duration, path connpath.Info) {
 	if f.quiet {
 		return
 	}
 	glyph := uxlog.Check()
-	if kept > 0 {
+	switch {
+	case kept > 0 && keptByChoice:
+		glyph = uxlog.Info()
+	case kept > 0:
 		glyph = uxlog.Warn()
 	}
 	if headline == "" {
@@ -537,8 +542,11 @@ func printRecvSummary(f *flags, headline string, total, moved int64, kept, skipp
 	if skippedSame > 0 {
 		parts = append(parts, fmt.Sprintf("%s up to date", uxlog.CountNoun(skippedSame, "file")))
 	}
+	// No "(use --overwrite)" here: the remedy already appears once — the
+	// upfront --yes warning or E013's action line — and after an explicit
+	// "n" at the prompt it must not appear at all.
 	if kept > 0 {
-		parts = append(parts, fmt.Sprintf("%s kept (use --overwrite)", uxlog.CountNoun(kept, "file")))
+		parts = append(parts, fmt.Sprintf("%s kept", uxlog.CountNoun(kept, "file")))
 	}
 	fmt.Fprintf(os.Stderr, "%s %s  ·  %s\n", glyph, headline, strings.Join(parts, "  ·  "))
 	printUpdateNotice(f)

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -355,12 +355,14 @@ func (ui *receiverUI) bytes() (total, moved int64) {
 // printCancelKeptHint tells a Ctrl-C'd receiver that its partial data
 // survives and how the transfer resumes. E026 itself is context-free
 // ("Cancelled.") — only the UI knows whether bytes had already landed.
+// Self-service leads: the still-running sender re-registers the same
+// code, so the receiver can resume without involving the other person.
 func printCancelKeptHint(f *flags, ui *receiverUI) {
 	if f.quiet {
 		return
 	}
 	if _, moved := ui.bytes(); moved > 0 {
-		fmt.Fprintf(os.Stderr, "%s Partial data kept — when the sender runs fsend again, the transfer resumes here.\n", uxlog.Info())
+		fmt.Fprintf(os.Stderr, "%s Partial data kept — run the same fsend <code> again to resume while the sender is still waiting.\n", uxlog.Info())
 	}
 }
 

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -31,6 +31,10 @@ type receiverUI struct {
 	outDir   string
 	sink     bool
 	pathInfo connpath.Info
+	// spin animates the pre-prompt phase (connect/classify); set before the
+	// transfer starts, stopped by the first prompt or close(). Stop is
+	// idempotent and nil-safe.
+	spin *uxlog.Spinner
 
 	mu           sync.Mutex
 	hello        *wire.SenderHello
@@ -101,12 +105,19 @@ func (ui *receiverUI) recvOptions(hostname string) transfer.RecvOptions {
 		Checksum:       ui.f.checksum,
 		Accept:         ui.accept,
 		Password:       ui.f.passArg,
-		PromptPass:     receiverPasswordPrompt(ui.ctx, ui.f),
 		ProgressFn:     ui.progress,
 		OnResume:       ui.onResume,
 		OnSkip:         ui.onSkip,
 		OnFileDone:     ui.onFileDone,
 		OnConflictKept: ui.onConflictKept,
+	}
+	// The password prompt fires before classification; the spinner must not
+	// animate under the hidden-input line.
+	if pp := receiverPasswordPrompt(ui.ctx, ui.f); pp != nil {
+		o.PromptPass = func(attempt int) (string, error) {
+			ui.spin.Stop()
+			return pp(attempt)
+		}
 	}
 	if ui.sink {
 		o.Sink = os.Stdout
@@ -124,6 +135,8 @@ func (ui *receiverUI) recvOptions(hostname string) transfer.RecvOptions {
 
 // accept records the HELLO, then runs the accept prompt with the breakdown.
 func (ui *receiverUI) accept(h wire.SenderHello, summary transfer.ClassifySummary) bool {
+	// Classification is done — the prompt block owns the terminal from here.
+	ui.spin.Stop()
 	ui.mu.Lock()
 	cp := h
 	ui.hello = &cp
@@ -368,6 +381,7 @@ func printCancelKeptHint(f *flags, ui *receiverUI) {
 
 func (ui *receiverUI) close() {
 	ui.closeOnce.Do(func() {
+		ui.spin.Stop()
 		ui.mu.Lock()
 		bar := ui.bar
 		ui.mu.Unlock()
@@ -375,6 +389,19 @@ func (ui *receiverUI) close() {
 			bar.Done()
 		}
 	})
+}
+
+// retryNotice wraps retryNoticeFor so the pre-prompt spinner is stopped
+// before a notice prints — otherwise the spinner's redraw garbles the line.
+func (ui *receiverUI) retryNotice() func(int, time.Duration, error) {
+	notice := retryNoticeFor(ui.f)
+	if notice == nil {
+		return nil
+	}
+	return func(attempt int, wait time.Duration, lastErr error) {
+		ui.spin.Stop()
+		notice(attempt, wait, lastErr)
+	}
 }
 
 // finishReceive runs the post-transfer epilogue. When differing files were
@@ -481,14 +508,24 @@ func printTextPayload(text string) error {
 	if text[len(text)-1] != '\n' {
 		if term.IsTerminal(int(os.Stdout.Fd())) {
 			fmt.Println()
-		} else {
+		} else if sameSink(os.Stdout, os.Stderr) {
 			// stdout is piped, so its bytes must stay exact — but when
 			// stderr shares the sink (2>&1, CI logs) the summary line would
 			// butt against the payload. Break the line on stderr instead.
+			// When stderr is elsewhere (the terminal), this newline would
+			// only render as a stray blank line before the summary.
 			fmt.Fprintln(os.Stderr)
 		}
 	}
 	return nil
+}
+
+// sameSink reports whether two files point at the same underlying sink
+// (same dev+inode), e.g. stdout and stderr under 2>&1.
+func sameSink(a, b *os.File) bool {
+	ai, err1 := a.Stat()
+	bi, err2 := b.Stat()
+	return err1 == nil && err2 == nil && os.SameFile(ai, bi)
 }
 
 // headline names what landed where for the summary line.

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -521,7 +521,11 @@ func printTextPayload(text string) error {
 }
 
 // sameSink reports whether two files point at the same underlying sink
-// (same dev+inode), e.g. stdout and stderr under 2>&1.
+// (same dev+inode), e.g. stdout and stderr under 2>&1. Windows caveat:
+// pipes carry no file IDs there, so two *distinct* pipes compare equal —
+// worst case a stray line break on a separately-piped stderr log.
+// Consoles vs pipes vs disk files still compare correctly (filetype and
+// real file IDs), which covers the cases that matter.
 func sameSink(a, b *os.File) bool {
 	ai, err1 := a.Stat()
 	bi, err2 := b.Stat()

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -609,6 +609,7 @@ func applyEnvFallbacks(f *flags, cmd *cobra.Command) {
 // so `fsend <code> --exclude '*.log'` fails fast instead of silently
 // ignoring the flag.
 func startReceive(f *flags, c string) error {
+	errorRole = "receiver"
 	if len(f.excludes) > 0 {
 		return errExcludeMisuse()
 	}

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -381,11 +381,20 @@ func resumeNotice(offset, total uint64) string {
 
 // printSendSummary renders the post-transfer outcome line. Files the receiver
 // kept (differing, no --overwrite there) make it a warning, not a success —
-// the sender must not read "✓ Sent" when nothing was delivered. Skips without
-// the kept flag stay the neutral "skipped": an old receiver doesn't report
-// the distinction (wire.Decision.Kept), so "up to date" would overclaim.
+// the sender must not read "✓ Sent" when nothing was delivered. Partial skips
+// without the kept flag stay the neutral "skipped": an old receiver doesn't
+// report the distinction (wire.Decision.Kept), so "up to date" would overclaim.
 func printSendSummary(f *flags, total int64, s senderStats, elapsed time.Duration, path connpath.Info) {
 	if f.quiet {
+		return
+	}
+	// Everything skipped, nothing kept: the receiver already had it all and
+	// says "Already up to date" — "Sent · (0 B sent)" would contradict
+	// itself. Mirror the receiver's headline.
+	if s.moved == 0 && s.keptFiles == 0 && s.skippedFiles > 0 {
+		fmt.Fprintf(os.Stderr, "%s Already up to date  ·  %s unchanged  ·  %s\n",
+			uxlog.Check(), uxlog.CountNoun(s.skippedFiles, "file"), path.Tag())
+		printUpdateNotice(f)
 		return
 	}
 	glyph, headline := uxlog.Check(), "Sent"
@@ -422,7 +431,13 @@ func summaryParts(total, moved int64, verb string, elapsed time.Duration, path c
 	if moved < total {
 		size += " (" + uxlog.HumanBytes(moved) + " " + verb + ")"
 	}
-	parts := []string{size, uxlog.HumanDuration(elapsed)}
+	parts := []string{size}
+	// With zero bytes moved, elapsed is prompt dwell or connection wall
+	// time, not a transfer duration — "0 B · 5.8s" reads as a slow
+	// transfer. Omit it (HumanRate already suppresses the rate).
+	if moved > 0 {
+		parts = append(parts, uxlog.HumanDuration(elapsed))
+	}
 	if r := uxlog.HumanRate(moved, elapsed); r != "" {
 		parts = append(parts, r)
 	}

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -42,7 +42,7 @@ func (p *sendPlan) consumable() bool { return p.mode == wire.ModeStream }
 
 // runSend executes the send-side flow.
 func runSend(f *flags, paths []string) error {
-	errorRoleSender = true
+	errorRole = "sender"
 	if f.textArg != "" && len(paths) > 0 {
 		return fmt.Errorf("%w: --text cannot be combined with positional arguments", fserrors.ErrUsage)
 	}

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -33,7 +33,7 @@ What to try:
 | Code | Meaning | Fix |
 |---|---|---|
 | `E004` | The code isn't a valid `abc-defg-jkm` shape | Re-type it; codes use only `a–z` minus `i`, `l`, `o`. |
-| `E002` | No such code on the server | It expired, was mistyped, or the sender stopped. Have the sender run again for a fresh code. |
+| `E002` | No such code on the server | It expired, was mistyped, the sender stopped, or another receiver already claimed it. Have the sender run again for a fresh code. |
 | `E003` | Someone already claimed this code | Codes are one-shot. Have the sender run again and share the new code. |
 
 Codes can't be reused — a new send always produces a new code to share.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,8 +156,10 @@ If a transfer is interrupted, fsend keeps what it already received in a
 `.fsend-partial` file and continues from there next time — only the
 missing bytes transfer.
 
-Share codes are **one-shot**, so resuming isn't "rerun with the same
-code." It's a fresh send with a new code:
+While the sender's fsend is **still running**, just rerun the same
+`fsend <code>` — the sender re-registers the code and the transfer
+resumes. Once the sender has exited, codes are **one-shot** and resuming
+is a fresh send with a new code:
 
 1. **Sender** runs the original command again. fsend issues a *new* code.
 2. **Share the new code** with the receiver (the old one no longer works).

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -203,7 +203,9 @@ Fields of `done`:
 | Field | Meaning |
 | --- | --- |
 | `ok` / `error` / `exit` | Outcome; `error` is the catalog code (e.g. `"E013"`) and matches the exit code table below |
-| `bytes_total` / `bytes_moved` | Offered size vs. bytes that crossed the wire (a re-send of unchanged files moves 0) |
+| `role` | `"sender"` or `"receiver"`; omitted when the command fails before either path is entered (e.g. a flag-parse error) |
+| `bytes_total` | Per role: the sender reports the full offered size; the receiver reports the bytes it accepted for writing (up-to-date and kept files count 0) — the two sides can differ for the same session |
+| `bytes_moved` | Bytes that crossed the wire this run (a re-send of unchanged files moves 0) |
 | `files_sent`, `files_skipped`, `files_kept` | Sender counts (`files_skipped` = receiver-declined for an unknown reason — old receivers don't report the distinction) |
 | `files_saved`, `files_up_to_date`, `files_kept` | Receiver counts |
 | `duration_ms`, `route` | Timed from the first byte; `route` is `local`, `direct`, or `relay` |
@@ -211,8 +213,10 @@ Fields of `done`:
 | `text` | Receiver: a `--text` payload rides here instead of raw stdout |
 
 On a failure before any summary exists (bad code, unreachable server),
-the `done` event carries only `ok`/`error`/`exit`. Fields are only ever
-**added** to this schema; `v` bumps on the first breaking change.
+the `done` event carries only `ok`/`error`/`exit` — plus `role` when the
+failure happened after a send or receive path was entered. Fields are
+only ever **added** to this schema; `v` bumps on the first breaking
+change.
 
 `--json` is rejected with `--preview` (already CSV) and with `--out -`
 (stdout carries the received bytes).

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -210,7 +210,8 @@ var catalog = map[error]Entry{
 	ErrCodeNotFound: {
 		Code: "E002", Exit: 2,
 		Message: "That code was not found.",
-		Action:  "Double-check the code with the sender and make sure their fsend is still running.",
+		Action: "Double-check the code with the sender and make sure their fsend is\n" +
+			"  still running — or another receiver may have already claimed this code.",
 	},
 	ErrCodeAlreadyClaimed: {
 		Code: "E003", Exit: 3,
@@ -316,11 +317,13 @@ var catalog = map[error]Entry{
 	ErrTransientFailure: {
 		Code: "E020", Exit: 20,
 		Message: "Transfer was interrupted and retries did not recover.",
-		// Receiver wording: share codes are one-shot, so rerunning the
-		// same `fsend <code>` yields E002 — resume needs a fresh code
-		// from the sender.
-		Action: "Ask the sender to run fsend again, then use the new code — the\n" +
-			"  transfer will resume in this same directory.",
+		// Receiver wording: while the sender's fsend is still up it re-enters
+		// pairing and re-registers the same code, so rerunning the same
+		// `fsend <code>` resumes. Once the sender is gone the code is dead
+		// (one-shot) and resume needs a fresh one.
+		Action: "If the sender is still running, run the same fsend command again to\n" +
+			"  resume. Otherwise ask the sender to run fsend again, then use the new\n" +
+			"  code — the transfer will resume in this same directory.",
 		SenderAction: "Check your network connection and try again — fsend will resume\n" +
 			"  from where it left off.",
 	},

--- a/test/e2e/signal_test.go
+++ b/test/e2e/signal_test.go
@@ -55,18 +55,20 @@ func TestSignal_SenderSIGINTMidTransfer(t *testing.T) {
 	s.wait(t, 5*time.Second)
 
 	// Generous bound: the receiver may walk its full retry budget
-	// (3 × 10s QUIC handshake) when SIGINT lands at certain stream
-	// positions before giving up. We only care that it eventually
-	// surfaces a non-zero exit; the duration is bounded by retry config.
+	// (3 × 10s QUIC handshake plus backoff waits ≈ 33s) when SIGINT
+	// lands at certain stream positions before giving up — already past
+	// a 30s bound before any runner load, which is why 30s flaked on
+	// loaded CI. We only care that it eventually surfaces a non-zero
+	// exit; the duration is bounded by retry config.
 	select {
 	case err := <-rDone:
 		if err == nil {
 			t.Fatalf("receiver returned 0 after sender SIGINT — should be non-zero")
 		}
-	case <-time.After(30 * time.Second):
+	case <-time.After(60 * time.Second):
 		_ = rCmd.Process.Kill()
 		<-rDone
-		t.Fatalf("receiver did not exit within 30s")
+		t.Fatalf("receiver did not exit within 60s")
 	}
 
 	if fi, err := os.Stat(filepath.Join(dst, "big.bin")); err == nil {
@@ -301,8 +303,11 @@ func TestSignal_ReceiverSIGINTRerunSameCode(t *testing.T) {
 		t.Errorf("no partial-kept resume hint after mid-transfer SIGINT\n--- recv1 stderr ---\n%s", r1Err.String())
 	}
 
-	// The sender must go back to waiting rather than exit.
-	if !waitForStderr(s, "Receiver disconnected", 30*time.Second) {
+	// The sender must go back to waiting rather than exit. 60s: a pure
+	// upper bound costs nothing when healthy, and 30s flaked on loaded
+	// runners (the sender can sit in a QUIC handshake attempt before
+	// classifying the drop).
+	if !waitForStderr(s, "Receiver disconnected", 60*time.Second) {
 		t.Fatalf("sender never re-entered pairing\n--- sender stderr ---\n%s", s.stderr.String())
 	}
 


### PR DESCRIPTION
Fixes findings A–H from the third CLI UX audit: summaries that contradict themselves, copy that oversells or misdirects, a fabricated `--json` field, and a silent classify phase. No wire changes; sender exit 0 on kept files, E013's exit 13, and the `--yes`-doesn't-mean-overwrite semantics are untouched.

## A (P2) — all-skipped send says "Sent · (0 B sent)"

**Before** (sender, identical re-send): `[OK] Sent · 4.1 KB (0 B sent) · 0ms · Direct on local network · 1 file skipped`
**After**: `[OK] Already up to date · 1 file unchanged · Direct on local network` — mirroring the receiver's headline. Exit stays 0; `--json` unchanged (`bytes_moved:0`, sender `files_skipped:1`, receiver `files_up_to_date:1` verified). Partial skips (some bytes moved) keep the neutral "N files skipped" clause, including the old-receiver case that can't report the kept distinction.

## B (P2) — kept-file flow oversold --overwrite

**Before** (`--yes`, differing file): three `--overwrite` advisories in four lines, and after an explicit "n" at the prompt the summary still said `1 file kept (use --overwrite)` one line above E013's "Kept your local copies — nothing was overwritten."
**After**: the summary renders `1 file kept` with no flag advice for everyone; the `--yes` flow keeps exactly the upfront warning plus E013's action line, and the prompt-"n" flow (driven on a pty) shows the info glyph and zero advice. With 0 B moved the dwell-time duration is omitted (`0 B · Direct on local network` instead of `0 B · 5.7s · …`). Exits verified: receiver 13, sender 0.

## C (P3) — `--json` fabricated `"role":"receiver"` on flag-parse errors

**Before**: `fsend --json --frobnicate` → `{"v":1,"event":"done","ok":false,"role":"receiver","error":"E024","exit":24}`
**After**: the same command omits `role` (`{"v":1,"event":"done","ok":false,"error":"E024","exit":24}`); `errorRoleSender` became `errorRole` set at the top of `runSend`/`startReceive`, so real transfer failures still carry it (verified: E002 → `"role":"receiver"`, E025 → `"role":"sender"`). Chose `omitempty` over an empty-string enum; docs/usage.md documents the field and when it's absent. Additive-only `v:1` note kept.

## D (P3) — `done.bytes_total` means different things per role

Documented what the code actually does rather than unifying: the sender reports the full offered size, the receiver reports bytes accepted for writing (up-to-date/kept files count 0), so the sides legitimately differ for a kept-file session. Unifying on offered-bytes would have silently changed receiver semantics under the additive-only promise.

## E (P3) — receiver-cancel copy ignored same-code self-service

Verified end-to-end: Ctrl-C mid-transfer, wait for the sender to re-enter pairing (~seconds), rerun the same `fsend <code>` → `Resuming from 48.2 MB (3%)` → completed, sha256 match. The Ctrl-C hint now leads with self-service ("run the same fsend <code> again to resume while the sender is still waiting") and E020's action prepends the same-code option before the fresh-code fallback. Caveat observed while validating: a rerun in the first ~seconds after the drop can race the sender's teardown/re-pair window and land E002 — hence "while the sender is still waiting", not "always". usage.md's resume section was synced (it flatly claimed same-code rerun never works).

## F (P3) — second receiver on a LAN-paired code gets a misleading E002

E002's action now ends "— or another receiver may have already claimed this code." Exit stays 2. Verified with two receivers on one LAN code; troubleshooting.md row synced.

## G (P3) — `--text` stray blank line; size in banner skipped (wire)

The payload line-break went to stderr whenever stdout was piped, rendering as a stray blank between `[i] Accepting (--yes)` and the summary when stderr was the terminal. It now fires only when stderr actually shares stdout's sink (dev+inode via `os.SameFile`) — the 2>&1 case it was written for. Verified both ways on a pty.
**Banner size skipped**: `wire.SenderHello` carries no length for a text stream (`IsText`/`DisplayName` only), so the size is genuinely unknown pre-transfer and adding it would be a wire change, which is out of scope.

## H (P3) — silent classify/hash phase on receive

The internet path's "Connecting" spinner is now handed through to the transfer and retitled "Checking existing files" through classification, stopped at the accept prompt; the LAN path starts one when `--checksum` is set (stat-only classify is near-instant — a spinner would just flash, which this codebase deliberately avoids). The password prompt and retry notices stop it before writing. Verified on a pty: 1.5 GB `--checksum` re-receive shows ~5 s of spinner frames then the banner (pre-fix: dead silence); internet path shows `Connecting → Checking existing files → banner`. Non-TTY keeps the usual single static line.

## Validation

- Local server on 19140/19141, fresh `XDG_CONFIG_HOME` per client, `/dev/urandom` payloads, `FSEND_NO_UPDATE_CHECK=1`; every finding reproduced pre-fix and re-run post-fix (pty via `script` for prompt/spinner cases).
- Regression: 1.5 GB file (with mid-transfer cancel + same-code resume) and a 3-file nested folder, both sha256-verified end to end.
- `go test ./cmd/fsend ./internal/transfer` and `go vet ./...` clean; each of the four commits builds standalone. New unit tests: send/recv summary rendering, `summaryParts` zero-moved, `jsonDoneFromErr` role omission, `printTextPayload` shared-sink split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)