### PR TITLE
docs(readme): drop the install-prefix line

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,6 @@ irm https://getfsend.alzina.dev/windows | iex
 
 All three verify the release's SHA-256 checksum before installing.
 
-Install somewhere else: pipe into `PREFIX=~/.local/bin sh` instead of `sh`, or set `$env:FSEND_PREFIX` before the `irm` line.
-
 <details>
 <summary>Other install methods</summary>
 


### PR DESCRIPTION
Removes the "Install somewhere else: …" line added in #157 — the PREFIX/FSEND_PREFIX knobs remain self-documented in the install scripts' usage text; the README keeps only the happy-path commands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)