### PR TITLE
fix(transfer): never chmod through a receiver-side symlink in the receive slot

### DIFF
--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -655,6 +655,41 @@ func TestEngine_DirModePreserved(t *testing.T) {
 	}
 }
 
+// A receiver-side symlink standing where an incoming directory would go is a
+// kept conflict (no --overwrite): the transfer must leave it and, crucially,
+// must not chmod the link's target — which lives outside the receive tree and
+// carries a sender-controlled mode.
+func TestEngine_DirModeDoesNotFollowKeptSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows has no Unix directory permission bits")
+	}
+	outside := t.TempDir()
+	if err := os.Chmod(outside, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src, dst := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(src, "d", "f.txt"), []byte("x"))
+	if err := os.Chmod(filepath.Join(src, "d"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	// Receiver already has dst/d as its own symlink to a dir outside the tree.
+	if err := os.Symlink(outside, filepath.Join(dst, "d")); err != nil {
+		t.Fatal(err)
+	}
+
+	// No --overwrite, so the conflict is kept.
+	if se, re := fileTransfer(t, []string{filepath.Join(src, "d")}, dst, nil); se != nil || re != nil {
+		t.Fatalf("send=%v recv=%v", se, re)
+	}
+
+	if st, err := os.Lstat(filepath.Join(dst, "d")); err != nil || st.Mode()&os.ModeSymlink == 0 {
+		t.Fatalf("receiver symlink not left intact: mode=%v err=%v", st.Mode(), err)
+	}
+	if st, _ := os.Stat(outside); st.Mode()&os.ModePerm != 0o755 {
+		t.Errorf("outside dir chmod'd through symlink: %o, want 0755", st.Mode()&os.ModePerm)
+	}
+}
+
 // A chmod on a source directory propagates on an identical re-send, matching
 // the file behavior — the dir is otherwise never re-created.
 func TestEngine_DirModePropagatesOnIdenticalResend(t *testing.T) {

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -632,7 +632,11 @@ func restoreDirModes(plans []entryPlan) {
 			continue
 		}
 		want := os.FileMode(p.entry.Mode) & os.ModePerm
-		if st, err := os.Stat(p.target); err == nil && st.IsDir() && st.Mode()&os.ModePerm != want {
+		// Lstat, not Stat: if a receiver-side symlink sits in the slot (a kept
+		// dir↔symlink conflict), Stat would follow it and chmod the link's
+		// target anywhere on disk. Lstat reports the link itself, so IsDir is
+		// false and we skip it — we only ever chmod a real directory we own.
+		if st, err := os.Lstat(p.target); err == nil && st.IsDir() && st.Mode()&os.ModePerm != want {
 			_ = os.Chmod(p.target, want)
 		}
 	}
@@ -647,7 +651,8 @@ func repairIdenticalMode(p *entryPlan) {
 		return
 	}
 	want := os.FileMode(p.entry.Mode) & os.ModePerm
-	if st, err := os.Stat(p.target); err == nil && st.Mode()&os.ModePerm != want {
+	// Lstat, not Stat: never chmod through a symlink swapped into the slot.
+	if st, err := os.Lstat(p.target); err == nil && st.Mode().IsRegular() && st.Mode()&os.ModePerm != want {
 		_ = os.Chmod(p.target, want)
 	}
 }


### PR DESCRIPTION
## Problem

`restoreDirModes` (added in #143) used `os.Stat`, which follows symlinks. When a receiver-side symlink sits where an incoming directory would go, it's a kept `dir`↔`symlink` conflict (no `--overwrite`) — nothing is written to it. But the post-transfer mode-restore pass still `os.Stat`'d the slot, **followed the link**, and applied the *sender-controlled* directory mode to the link's target anywhere on the filesystem.

Impact: a sender can chmod an arbitrary directory the receiver's symlink points at — `0000` locks the user out of their own directory, `0777` exposes a private one — with no bytes transferred and the receiver correctly reporting the conflict as kept.

Note: this is not about wire symlinks (the sender always dereferences symlinks and `classify` rejects any symlink entry on the wire). The dangerous link is one already on the receiver's disk, placed there by the local user.

## Fix

Switch both mode-restore paths (`restoreDirModes` and `repairIdenticalMode`) to `os.Lstat`, so they operate on the link itself and never its target. `Lstat` of a symlink is not a directory / not a regular file, so it's skipped. For a real directory or regular file — the only slots we actually own — behaviour is unchanged.

## Validation

- New regression test `TestEngine_DirModeDoesNotFollowKeptSymlink` reproduces the escape: receiver has `dst/d -> outside` (0755), sender offers dir `d` (0700), kept conflict → `outside` must stay 0755. **Confirmed the test fails without the fix** (target chmod'd to 700) and passes with it.
- Existing `TestEngine_DirModePreserved` and `TestEngine_DirModePropagatesOnIdenticalResend` still pass — legitimate dir-mode preservation/propagation is untouched.
- Full `internal/transfer` package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)