### PR TITLE
fix(transfer): count empty files as saved on the receiver

### DIFF
--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -133,6 +133,28 @@ func TestEngine_PreservesModTimeEnablingSkip(t *testing.T) {
 	}
 }
 
+// An empty file is written to disk, so it must fire OnFileDone (which backs
+// the receiver's files_saved count and the "Saved N of M" headline) just like
+// a non-empty file does.
+func TestEngine_EmptyFileFiresOnFileDone(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(src, "empty.txt"), nil)
+
+	var done []string
+	se, re := fileTransfer(t, []string{filepath.Join(src, "empty.txt")}, dst, func(o *RecvOptions) {
+		o.OnFileDone = func(p string) { done = append(done, p) }
+	})
+	if se != nil || re != nil {
+		t.Fatalf("send=%v recv=%v", se, re)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "empty.txt")); err != nil {
+		t.Fatalf("empty file not written: %v", err)
+	}
+	if len(done) != 1 {
+		t.Fatalf("OnFileDone fired %d times for a saved empty file, want 1", len(done))
+	}
+}
+
 func TestEngine_Directory(t *testing.T) {
 	src, dst := t.TempDir(), t.TempDir()
 	files := map[string][]byte{

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -178,7 +178,7 @@ func recvFiles(ctx context.Context, s *Streams, hello *wire.SenderHello, opts Re
 			expected++
 			continue
 		}
-		if err := materialize(s, p, approveOverwrite); err != nil {
+		if err := materialize(s, p, approveOverwrite, opts); err != nil {
 			return err
 		}
 	}
@@ -583,7 +583,7 @@ func (rf *recvFile) finalize(s *Streams, root [32]byte, opts RecvOptions) error 
 }
 
 // materialize creates a structural entry (dir / symlink / empty file).
-func materialize(s *Streams, p *entryPlan, approveOverwrite bool) error {
+func materialize(s *Streams, p *entryPlan, approveOverwrite bool, opts RecvOptions) error {
 	target := p.target
 	if p.needsConsent() && approveOverwrite {
 		_ = os.RemoveAll(target) // clear the slot (approved)
@@ -615,6 +615,12 @@ func materialize(s *Streams, p *entryPlan, approveOverwrite bool) error {
 		if p.entry.ModTimeSec > 0 {
 			t := time.Unix(p.entry.ModTimeSec, 0)
 			_ = os.Chtimes(target, t, t)
+		}
+		// An empty file is a saved file too — fire OnFileDone like finalize
+		// does for non-empty ones, so it's counted in the receiver's saved-file
+		// tally (files_saved / the "Saved N of M" headline).
+		if opts.OnFileDone != nil {
+			opts.OnFileDone(target)
 		}
 		return nil
 	}


### PR DESCRIPTION
## Problem

The receiver's saved-file tally is driven by the `OnFileDone` callback. But `materialize()` — which handles the empty-regular-file case — created the file on disk and never called `OnFileDone`; only `finalize()` (non-empty files) and the stream path did.

So an empty file landed on disk yet went uncounted. This was invisible until the recent audit PRs added consumers of that count (#146/#150/#155):

- `--json` emitted `"files_saved":0` for a transfer that saved an empty file.
- The headline read `Saved 0 of N`.
- Worst case — an empty file plus a differing file the receiver kept — the summary claimed **nothing** was saved (`Saved 0 of 1`, `"files_saved":0`) while `empty.txt` sat on disk.

## Fix

Fire `OnFileDone(target)` in the empty-file branch of `materialize()`, exactly as `finalize()` does for non-empty files. Empty (`Size == 0`) and non-empty (`Size > 0`) files are routed to disjoint code paths at classify time, so there is no double count.

## Validation

- New `TestEngine_EmptyFileFiresOnFileDone`: sends an empty file, asserts it's on disk **and** `OnFileDone` fired exactly once. **Confirmed it fails without the fix** ("fired 0 times") and passes with it.
- `cmd/fsend/receiverui.go`: `onFileDone` → `ui.files`, and both `FilesSaved` (`len(files)`) and the `Saved %d of %s` headline derive from it, so the fix reaches both surfaces.
- Full `internal/transfer` package green; build + vet clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)