### PR TITLE
fix(transfer): bound the receiver's password prompt loop

### DIFF
--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -602,6 +602,62 @@ func TestEngine_PasswordExhaustedAborts(t *testing.T) {
 	}
 }
 
+// A hostile sender that keeps re-challenging past its own PasswordAttempts cap
+// must not hold the receiver in an endless prompt: the receiver stops at the
+// same cap and returns ErrWrongPassword.
+func TestEngine_ReceiverPasswordPromptBounded(t *testing.T) {
+	ctrlA, ctrlB := net.Pipe()
+	dataA, dataB := net.Pipe()
+	sender := &Streams{Control: ctrlA, Data: dataA}
+	receiver := &Streams{Control: ctrlB, Data: dataB}
+
+	// Fake sender: HELLO with a password gate, then re-challenge forever,
+	// rejecting every response — never honouring the PasswordAttempts cap.
+	go func() {
+		defer sender.Close()
+		_ = wire.WriteControl(sender.Control, wire.TypeHello, &wire.SenderHello{
+			ProtocolVersion: wire.ProtocolVersion, HasPassword: true, Mode: wire.ModeFiles,
+		})
+		var rh wire.ReceiverHello
+		if _, err := wire.ReadControl(sender.Control, &rh); err != nil {
+			return
+		}
+		for {
+			var nonce [32]byte
+			if err := wire.WriteControl(sender.Control, wire.TypePasswordChallenge, &wire.PasswordChallenge{Nonce: nonce}); err != nil {
+				return
+			}
+			if _, _, err := wire.ReadControlRaw(sender.Control); err != nil {
+				return
+			}
+			if err := wire.WriteControl(sender.Control, wire.TypeError, &wire.ErrorFrame{
+				Code: wire.ErrCodeWrongPassword, Message: "wrong password",
+			}); err != nil {
+				return
+			}
+		}
+	}()
+
+	prompts := 0
+	re := Recv(context.Background(), receiver, RecvOptions{
+		TargetDir: t.TempDir(),
+		PromptPass: func(int) (string, error) {
+			prompts++
+			if prompts > PasswordAttempts+2 {
+				t.Fatalf("receiver kept prompting past the cap (%d)", prompts)
+			}
+			return "nope", nil
+		},
+	})
+	receiver.Close()
+	if !errors.Is(re, fserrors.ErrWrongPassword) {
+		t.Fatalf("recv err = %v, want ErrWrongPassword", re)
+	}
+	if prompts != PasswordAttempts {
+		t.Errorf("receiver prompted %d times, want %d (the cap)", prompts, PasswordAttempts)
+	}
+}
+
 // A fixed password (--password / FSEND_PASSWORD) can't change between tries,
 // so a mismatch aborts after one attempt on both sides.
 func TestEngine_PasswordFixedWrongSingleAttempt(t *testing.T) {

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -901,9 +901,11 @@ func mapPeerError(ef wire.ErrorFrame) error {
 // mismatch the sender issues a fresh challenge (up to PasswordAttempts), so
 // an interactively-prompted receiver can retry a typo without burning the
 // one-shot code. A fixed password (--password / FSEND_PASSWORD) gets one
-// try — resending the same value can't succeed.
+// try — resending the same value can't succeed. The loop is bounded by the
+// same PasswordAttempts cap the sender enforces, so a hostile sender can't
+// hold the receiver in an endless password prompt.
 func receiverPasswordHandshake(s *Streams, opts RecvOptions) error {
-	for attempt := 1; ; attempt++ {
+	for attempt := 1; attempt <= PasswordAttempts; attempt++ {
 		var ch wire.PasswordChallenge
 		ft, err := wire.ReadControl(s.Control, &ch)
 		if err != nil {
@@ -954,4 +956,7 @@ func receiverPasswordHandshake(s *Streams, opts RecvOptions) error {
 			return fmt.Errorf("%w: expected PASSWORD_VERIFIED, got %v", fserrors.ErrProtocolError, ft)
 		}
 	}
+	// Exhausted the attempt cap without a verified verdict (a sender that keeps
+	// re-challenging past its own limit): the honest outcome is a bad password.
+	return fserrors.ErrWrongPassword
 }


### PR DESCRIPTION
## Problem

`receiverPasswordHandshake` looped `for attempt := 1; ; attempt++` — it kept answering challenges and re-prompting for as long as the peer kept sending `PASSWORD_CHALLENGE` frames. The `PasswordAttempts` (3) cap was enforced only on the sender. A hostile sender that ignores its own cap could re-challenge indefinitely and hold an interactive receiver in an endless "wrong password — try again" prompt.

## Fix

Bound the receiver loop by the same `PasswordAttempts` cap the sender enforces, and return `ErrWrongPassword` on exhaustion. Honest transfers are unchanged: the sender already closes the stream after `PasswordAttempts` wrong tries, so the receiver never reaches the new bound in normal use.

## Validation

- New `TestEngine_ReceiverPasswordPromptBounded` drives the receiver against a hand-rolled sender that re-challenges forever. **Confirmed it fails without the fix** (receiver prompts past the cap — 6+ and climbing) and passes with it (exactly `PasswordAttempts` prompts, then `ErrWrongPassword`).
- Existing password tests unchanged: `TestEngine_PasswordRetriesWithinCap` (typo then success on the same session), `TestEngine_PasswordExhaustedAborts`, `TestEngine_PasswordFixedWrongSingleAttempt` all still pass.
- Full `internal/transfer` package green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)