### PR TITLE
fix(transfer): fail when a source shrinks mid-send instead of truncating

### DIFF
--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -155,6 +155,34 @@ func TestEngine_EmptyFileFiresOnFileDone(t *testing.T) {
 	}
 }
 
+// A source that shrinks between the walk and the read must fail the transfer,
+// not hand the receiver a truncated file that hashes clean and lands as a
+// "success". The sender reports ErrReadFailed and nothing is written.
+func TestEngine_SourceShrinksMidSend(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+	sp := filepath.Join(src, "growing.bin")
+	writeFile(t, sp, randBytes(3*wire.MaxChunkSize))
+	sources, err := Walk([]string{sp}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Truncate on disk after the walk recorded the larger size.
+	if err := os.Truncate(sp, wire.MaxChunkSize); err != nil {
+		t.Fatal(err)
+	}
+
+	se, re := runTransfer(t, SendOptions{Mode: wire.ModeFiles, Sources: sources}, RecvOptions{TargetDir: dst})
+	if !errors.Is(se, fserrors.ErrReadFailed) {
+		t.Fatalf("send err = %v, want ErrReadFailed", se)
+	}
+	if !errors.Is(re, fserrors.ErrReadFailed) {
+		t.Fatalf("recv err = %v, want ErrReadFailed (sender reason relayed)", re)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "growing.bin")); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("a truncated file must not land as success")
+	}
+}
+
 func TestEngine_Directory(t *testing.T) {
 	src, dst := t.TempDir(), t.TempDir()
 	files := map[string][]byte{

--- a/internal/transfer/send.go
+++ b/internal/transfer/send.go
@@ -298,6 +298,12 @@ func sendOneFile(ctx context.Context, s *Streams, packer *chunkPacker, src *Sour
 			}
 		}
 		if rerr == io.EOF {
+			// EOF before the declared size means the source shrank since the
+			// walk. Finishing here would hand the receiver a truncated file
+			// that hashes clean and lands as a "success"; fail instead.
+			if sent < src.Entry.Size {
+				return fmt.Errorf("%w: %s shrank during send (%d of %d bytes)", fserrors.ErrReadFailed, src.AbsPath, sent, src.Entry.Size)
+			}
 			break
 		}
 		if rerr != nil {


### PR DESCRIPTION
## Problem

`sendOneFile` looped `for sent < src.Entry.Size` and `break`'d on `io.EOF` **even when `sent < Size`** — i.e. when the source file shrank between the walk (which recorded `Entry.Size`) and the read. It then computed the BLAKE3 root and called `endFile`. Because the root hash covers only the bytes actually sent, the truncated stream hashed clean, the receiver's integrity check passed, and it renamed the short file into place as a **success**.

The `Send` wrapper's comment already listed "shrunk" among the sources of `ErrReadFailed`, but that path was never taken.

## Fix

On EOF with `sent < Size`, return `ErrReadFailed`. `Send` maps it to `ErrCodeReadFailed`, so the receiver gets the real reason and discards its in-flight partial instead of finalizing a truncated copy. The growth case is unaffected (the read is already capped to `Size`, so EOF can't arrive early there).

## Validation

- New `TestEngine_SourceShrinksMidSend`: walks a 3-chunk file, truncates it to one chunk on disk, then transfers. Asserts the sender returns `ErrReadFailed`, the receiver relays it (`ErrReadFailed`, "sender: …"), and **no file lands**. **Confirmed it fails without the fix** (`send err = <nil>`) and passes with it.
- Full `internal/transfer` package green (existing grow/resume/integrity tests unaffected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)