### PR TITLE
fix(cli): honest --json for stdin streams and valued --json=true flag

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -582,6 +582,37 @@ func TestDebugRequested(t *testing.T) {
 	}
 }
 
+// argsHaveFlag honours the bare and valued (--json=true) spellings, stops at
+// --, and — like pflag — lets the last occurrence win when a flag repeats.
+func TestArgsHaveFlag(t *testing.T) {
+	savedArgs := os.Args
+	t.Cleanup(func() { os.Args = savedArgs })
+
+	for _, tc := range []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"absent", []string{"fsend", "file.txt"}, false},
+		{"bare", []string{"fsend", "--json"}, true},
+		{"valued true", []string{"fsend", "--json=true"}, true},
+		{"valued 1", []string{"fsend", "--json=1"}, true},
+		{"valued false", []string{"fsend", "--json=false"}, false},
+		{"valued garbage", []string{"fsend", "--json=maybe"}, false},
+		{"past --", []string{"fsend", "--", "--json"}, false},
+		{"last wins false", []string{"fsend", "--json", "--json=false"}, false},
+		{"last wins true", []string{"fsend", "--json=false", "--json"}, true},
+		{"not a prefix match", []string{"fsend", "--jsonx"}, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			os.Args = tc.args
+			if got := argsHaveFlag("--json"); got != tc.want {
+				t.Errorf("argsHaveFlag(--json) with %v = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
 // ---------------------------------------------------------------------------
 // root.go applyEnvFallbacks
 // ---------------------------------------------------------------------------

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 	"os"
 	"os/signal"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -254,15 +255,20 @@ func debugRequested() bool {
 	return argsHaveFlag("--debug")
 }
 
-// argsHaveFlag scans os.Args for a literal flag token. Used by the error
-// renderer, which runs after cobra state is gone.
+// argsHaveFlag reports whether a boolean flag is present and truthy on the
+// command line, honouring both the bare (--json) and valued (--json=true)
+// spellings. Used by the error renderer, which runs after cobra state is gone.
 func argsHaveFlag(name string) bool {
 	for _, a := range os.Args[1:] {
+		if a == "--" {
+			break
+		}
 		if a == name {
 			return true
 		}
-		if a == "--" {
-			break
+		if v, ok := strings.CutPrefix(a, name+"="); ok {
+			b, err := strconv.ParseBool(v)
+			return err == nil && b
 		}
 	}
 	return false

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -258,18 +258,20 @@ func debugRequested() bool {
 // argsHaveFlag reports whether a boolean flag is present and truthy on the
 // command line, honouring both the bare (--json) and valued (--json=true)
 // spellings. Used by the error renderer, which runs after cobra state is gone.
+// Last occurrence wins, matching pflag when a flag is repeated.
 func argsHaveFlag(name string) bool {
+	found := false
 	for _, a := range os.Args[1:] {
 		if a == "--" {
 			break
 		}
-		if a == name {
-			return true
-		}
-		if v, ok := strings.CutPrefix(a, name+"="); ok {
-			b, err := strconv.ParseBool(v)
-			return err == nil && b
+		switch {
+		case a == name:
+			found = true
+		case strings.HasPrefix(a, name+"="):
+			b, err := strconv.ParseBool(a[len(name)+1:])
+			found = err == nil && b
 		}
 	}
-	return false
+	return found
 }

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -818,8 +818,12 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 	s := stats()
 	printSendSummary(f, int64(plan.totalBytes), s, elapsed, pathInfo)
 	ev := jsonDoneEvent{Ok: true, Role: "sender",
-		BytesTotal: ptr64(int64(plan.totalBytes)), BytesMoved: ptr64(s.moved),
-		DurationMS: msPtr(elapsed), Route: jsonRoute(pathInfo.Kind)}
+		BytesMoved: ptr64(s.moved), DurationMS: msPtr(elapsed), Route: jsonRoute(pathInfo.Kind)}
+	// A piped stdin stream has no known size; per the JSON contract an omitted
+	// bytes_total means "not known", so don't emit a bogus 0.
+	if !(plan.mode == wire.ModeStream && !plan.isText) {
+		ev.BytesTotal = ptr64(int64(plan.totalBytes))
+	}
 	if plan.mode == wire.ModeFiles {
 		ev.FilesSent = ptrInt(plan.totalFiles - s.skippedFiles)
 		ev.FilesSkipped = ptrInt(s.skippedFiles - s.keptFiles)

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -821,7 +821,7 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 		BytesMoved: ptr64(s.moved), DurationMS: msPtr(elapsed), Route: jsonRoute(pathInfo.Kind)}
 	// A piped stdin stream has no known size; per the JSON contract an omitted
 	// bytes_total means "not known", so don't emit a bogus 0.
-	if !(plan.mode == wire.ModeStream && !plan.isText) {
+	if plan.mode != wire.ModeStream || plan.isText {
 		ev.BytesTotal = ptr64(int64(plan.totalBytes))
 	}
 	if plan.mode == wire.ModeFiles {

--- a/test/e2e/json_test.go
+++ b/test/e2e/json_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 // jsonLines parses stdout as NDJSON, failing on any non-JSON line — the
@@ -124,5 +125,55 @@ func TestJSON_UsageErrorEmitsDone(t *testing.T) {
 	ev := jsonLines(t, stdout)
 	if len(ev) != 1 || ev[0]["event"] != "done" || ev[0]["ok"] != false || ev[0]["error"] != "E024" {
 		t.Errorf("usage failure should emit a done event: %v", ev)
+	}
+}
+
+// The guaranteed done-event on a cobra parse error (cobra state is gone, so
+// the emitter falls back to scanning os.Args) must fire for the --json=true
+// spelling too, not only the bare --json token. An unknown flag forces the
+// parse-error path.
+func TestJSON_ParseErrorEmitsDoneValuedFlag(t *testing.T) {
+	requireE2E(t)
+	src := t.TempDir()
+	srcFile := filepath.Join(src, "p.bin")
+	writeRandom(t, srcFile, 1024)
+	stdout, _, exit := h.runFsend(t, h.newXDG(t), srcFile, "--json=true", "--frobnicate")
+	if exit != 24 {
+		t.Fatalf("exit = %d, want 24", exit)
+	}
+	ev := jsonLines(t, stdout)
+	if len(ev) != 1 || ev[0]["event"] != "done" || ev[0]["ok"] != false || ev[0]["error"] != "E024" {
+		t.Errorf("--json=true parse error should still emit a done event: %v", ev)
+	}
+}
+
+// A piped stdin stream has no known size, so its done event must omit
+// bytes_total (the "not known" signal) rather than report a bogus 0, while
+// still reporting the bytes it moved.
+func TestJSON_StdinStreamOmitsBytesTotal(t *testing.T) {
+	requireE2E(t)
+	dst := t.TempDir()
+	xdg := h.newXDG(t)
+
+	s := h.startSenderStdin(t, xdg, "streamed-over-stdin\n", "--json", "-")
+	t.Cleanup(func() { _ = s.cmd.Process.Kill() })
+	code := s.waitForCode(t, 5*time.Second)
+
+	_, _, exit := h.runFsendIn(t, xdg, dst, "--yes", code)
+	s.wait(t, 5*time.Second)
+	if exit != 0 {
+		t.Fatalf("receiver exit = %d", exit)
+	}
+
+	ev := jsonLines(t, s.stdout.String())
+	done := ev[len(ev)-1]
+	if done["event"] != "done" || done["ok"] != true || done["role"] != "sender" {
+		t.Fatalf("last sender event is not a successful done: %v", done)
+	}
+	if _, present := done["bytes_total"]; present {
+		t.Errorf("stdin stream must omit bytes_total, got %v", done["bytes_total"])
+	}
+	if bm, ok := done["bytes_moved"].(float64); !ok || bm == 0 {
+		t.Errorf("stdin stream should still report bytes_moved, got %v", done["bytes_moved"])
 	}
 }


### PR DESCRIPTION
Two JSON-contract gaps surfaced by the post-merge audit.

## 1. `bytes_total: 0` on a piped stdin stream

A piped stdin stream (`… | fsend -`) has no known size, yet the sender's `done` event reported `"bytes_total":0`. The `--json` contract is that an omitted field means "not known" — and #163 already latched the *human* summary for exactly this case, but the JSON path was missed. Now the sender omits `bytes_total` for a size-unknown stream (non-text `ModeStream`) while still reporting `bytes_moved`. Text streams and file transfers have known sizes and are unchanged.

## 2. `--json=true` lost its guaranteed parse-error event

The done-event-on-cobra-parse-error emitter runs after cobra state is gone, so it falls back to scanning `os.Args` via `argsHaveFlag`. That matched only the bare `--json` token, so `fsend … --json=true --frobnicate` (unknown flag → parse error) emitted **nothing** on stdout. `argsHaveFlag` now understands the valued boolean spelling using `strconv.ParseBool` (pflag's own parser), so `--json=true`/`--json=1` are honoured — and `--json=false` / `--send=false` / `--debug=false` are correctly treated as *off*.

## Validation

- `TestJSON_StdinStreamOmitsBytesTotal`: pipes stdin with `--json`, asserts the done event omits `bytes_total` but reports non-zero `bytes_moved`. **Fails without the fix** (`got 0`).
- `TestJSON_ParseErrorEmitsDoneValuedFlag`: `--json=true` + an unknown flag, asserts the E024 done event still lands on stdout. **Fails without the fix** (empty stdout). Uses an unknown flag so it genuinely exercises the `argsHaveFlag` fallback (a flag-*conflict* like `--preview` parses fine and takes the dispatch path where json is already known-enabled).
- Full `cmd/fsend` and `test/e2e` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)