### PR TITLE
fix(cli): don't guess a --send positional is a misplaced password

### DIFF
--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -459,8 +459,8 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	// --password followed by a non-file, non-code word is very likely a misplaced
 	// inline password (`fsend --password secret file`). Point at the = form rather
 	// than failing later with a bare "no such file". With explicit --send the
-	// positional is unambiguously a path, so skip the guess and let the honest
-	// "no such file" (E025) stand.
+	// positional is unambiguously a path, so skip the guess and let the real
+	// error (the missing source, or the bare-password prompt) stand.
 	if cmd.Flags().Changed("password") && f.passArg == passPromptSentinel &&
 		!cmd.Flags().Changed("text") && !f.forceReceive && !f.forceSend {
 		for _, a := range f.posArgs {

--- a/cmd/fsend/root.go
+++ b/cmd/fsend/root.go
@@ -458,9 +458,11 @@ func dispatch(cmd *cobra.Command, f *flags) error {
 	// An inline password now rides the flag as `--password=secret`, so a bare
 	// --password followed by a non-file, non-code word is very likely a misplaced
 	// inline password (`fsend --password secret file`). Point at the = form rather
-	// than failing later with a bare "no such file".
+	// than failing later with a bare "no such file". With explicit --send the
+	// positional is unambiguously a path, so skip the guess and let the honest
+	// "no such file" (E025) stand.
 	if cmd.Flags().Changed("password") && f.passArg == passPromptSentinel &&
-		!cmd.Flags().Changed("text") && !f.forceReceive {
+		!cmd.Flags().Changed("text") && !f.forceReceive && !f.forceSend {
 		for _, a := range f.posArgs {
 			if a == "-" || code.IsCode(a) || code.LooksLikeCode(a) {
 				continue

--- a/cmd/fsend/root_test.go
+++ b/cmd/fsend/root_test.go
@@ -194,6 +194,36 @@ func TestRootCmd_RejectsInvalidFlagCombinations(t *testing.T) {
 	}
 }
 
+// The misplaced-password hint ("…if it's the password, use --password=…") is
+// a guess for the ambiguous `fsend --password secret file` case. Under an
+// explicit --send the positional is unambiguously a path, so the guess must
+// be suppressed and the honest missing-file error stand.
+func TestRootCmd_PasswordHintSkippedUnderSend(t *testing.T) {
+	const hint = "if it's the password"
+
+	// Without --send the hint fires (the trap this guard exists for).
+	plain := rootCmd()
+	plain.SetArgs([]string{"--password", "secret", "report.pdf"})
+	plain.SetOut(io.Discard)
+	plain.SetErr(io.Discard)
+	if err := plain.Execute(); err == nil || !strings.Contains(err.Error(), hint) {
+		t.Fatalf("plain --password: got %v, want the misplaced-password hint", err)
+	}
+
+	// With --send the positional is a path: no hint, and still an ErrUsage.
+	forced := rootCmd()
+	forced.SetArgs([]string{"--send", "--password", "secret", "report.pdf"})
+	forced.SetOut(io.Discard)
+	forced.SetErr(io.Discard)
+	err := forced.Execute()
+	if err == nil || !errors.Is(err, fserrors.ErrUsage) {
+		t.Fatalf("--send --password: got %v, want an ErrUsage", err)
+	}
+	if strings.Contains(err.Error(), hint) {
+		t.Errorf("--send must not guess the positional is a password: %q", err.Error())
+	}
+}
+
 // --uninstall --yes is documented (skip the confirmation), so the guard
 // must exempt it — unlike --update, where --yes answers nothing.
 func TestMaintenanceGuard_AllowsYesForUninstall(t *testing.T) {


### PR DESCRIPTION
## Problem

The heuristic behind "…`if it's the password, use --password=<x>`" disambiguates the genuinely ambiguous `fsend --password secret file` case (a bare `--password` followed by a non-file, non-code word is probably a misplaced inline password). It exempted `--receive` but **not** `--send`.

Under an explicit `--send`, the positional is unambiguously a source path, so a missing file should produce the honest "no such file" — not a suggestion that the filename might actually be the password. The same misdirection hit a typo'd second path in a multi-file send.

## Fix

Add `&& !f.forceSend` to the guard, mirroring the existing `--receive` exemption. With `--send`, the misplaced-password guess is skipped and the honest error stands.

## Validation

- New `TestRootCmd_PasswordHintSkippedUnderSend` asserts both directions: without `--send` the hint still fires (the trap the guard exists for), and with `--send` the error wraps `ErrUsage` but does **not** contain the "if it's the password" guess. **Confirmed it fails without the fix** (the hint leaks under `--send`).
- Full `cmd/fsend` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)