### PR TITLE
fix(cli): give the Homebrew-managed refusal its own honest error (E039)

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -457,6 +457,30 @@ func TestRenderError_UnsendableSymlink(t *testing.T) {
 	}
 }
 
+// A Homebrew-managed refusal renders as E039 with the brew command on the
+// detail line and no contradictory "remove by hand"/"reinstall" boilerplate.
+func TestRenderError_HomebrewManaged(t *testing.T) {
+	err := fmt.Errorf("%w: uninstall it with: brew uninstall fsend", fserrors.ErrHomebrewManaged)
+	var code int
+	got := captureStderr(t, func() { code = renderError(err, false) })
+	if code != 39 {
+		t.Errorf("exit code = %d, want 39", code)
+	}
+	for _, want := range []string{
+		"[E039] This fsend is managed by Homebrew.",
+		"uninstall it with: brew uninstall fsend",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in:\n%s", want, got)
+		}
+	}
+	for _, unwanted := range []string{"Remove the binary by hand", "reinstall", "path is printed above"} {
+		if strings.Contains(got, unwanted) {
+			t.Errorf("contradictory boilerplate %q leaked in:\n%s", unwanted, got)
+		}
+	}
+}
+
 // A broken pipe on a stdout payload path (`--preview | head`, `--out - | ...`)
 // exits silently with the shell convention 128+SIGPIPE.
 func TestRenderError_BrokenPipeExitsSilently141(t *testing.T) {

--- a/cmd/fsend/main.go
+++ b/cmd/fsend/main.go
@@ -143,6 +143,7 @@ func renderError(err error, debug bool) int {
 		errors.Is(err, fserrors.ErrServerStartup) ||
 		errors.Is(err, fserrors.ErrUpdateFailed) ||
 		errors.Is(err, fserrors.ErrUninstallFailed) ||
+		errors.Is(err, fserrors.ErrHomebrewManaged) ||
 		errors.Is(err, fserrors.ErrManifestWriteFailed)) {
 		if extra := extractDetail(err.Error()); extra != "" {
 			detail = extra

--- a/cmd/fsend/selfupdate.go
+++ b/cmd/fsend/selfupdate.go
@@ -37,7 +37,7 @@ func runUpdate() error {
 	// the Cellar file would diverge from the formula's metadata and the
 	// next `brew upgrade` would fight it. Checked before any network work.
 	if managedByHomebrew(binPath) {
-		return fmt.Errorf("%w: this fsend was installed with Homebrew — update it with: brew upgrade fsend", fserrors.ErrUpdateFailed)
+		return fmt.Errorf("%w: update it with: brew upgrade fsend", fserrors.ErrHomebrewManaged)
 	}
 
 	fmt.Fprintln(os.Stderr, "  Checking the latest release...")

--- a/cmd/fsend/uninstall.go
+++ b/cmd/fsend/uninstall.go
@@ -26,7 +26,7 @@ func runUninstall(f *flags) error {
 			binPath = resolved
 		}
 		if managedByHomebrew(binPath) {
-			return fmt.Errorf("%w: this fsend was installed with Homebrew — uninstall it with: brew uninstall fsend", fserrors.ErrUninstallFailed)
+			return fmt.Errorf("%w: uninstall it with: brew uninstall fsend", fserrors.ErrHomebrewManaged)
 		}
 	}
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -363,6 +363,7 @@ failure. For what to *do* about a given error, see
 | `36`  | `E036` — a symlink in the send set can't be followed (missing or unreadable target, or a link cycle). |
 | `37`  | `E037` — the server's relay spent its daily byte budget; forwarding is paused until 00:00 UTC. |
 | `38`  | `E038` — files received, but the `--manifest` record could not be written. |
+| `39`  | `E039` — `fsend --update`/`--uninstall` on a Homebrew-managed binary; use `brew upgrade`/`brew uninstall fsend`. |
 | `99`  | `E099` — unexpected error. Run with `--debug` and file an issue. |
 | `130` | `E026` — cancelled by user (Ctrl-C / SIGTERM). |
 | `141` | The output pipe closed early (e.g. `fsend <code> --out - \| head`). Shell convention (128+SIGPIPE); nothing is printed. |

--- a/internal/fserrors/fserrors.go
+++ b/internal/fserrors/fserrors.go
@@ -133,6 +133,11 @@ var (
 	// only the sidecar CSV is missing, so the fix is the manifest path —
 	// not --out.
 	ErrManifestWriteFailed = errors.New("manifest write failed")
+	// E039 — `fsend --update`/`--uninstall` on a Homebrew-managed binary.
+	// A deliberate refusal (brew owns the binary, so self-modifying it would
+	// fight the next `brew` run), not a failure — distinct from E033/E035 so
+	// the message points at brew instead of "reinstall"/"remove by hand".
+	ErrHomebrewManaged = errors.New("managed by Homebrew")
 )
 
 // Entry is one row of the user-facing error catalog.
@@ -448,6 +453,12 @@ var catalog = map[error]Entry{
 		Code: "E038", Exit: 38,
 		Message: "Files received, but the --manifest record could not be written.",
 		Action:  "Check that the --manifest path is writable.",
+	},
+	// The specific brew command rides the wrapped detail (upgrade vs
+	// uninstall), so the Action is left empty rather than contradicting it.
+	ErrHomebrewManaged: {
+		Code: "E039", Exit: 39,
+		Message: "This fsend is managed by Homebrew.",
 	},
 }
 

--- a/internal/fserrors/fserrors_test.go
+++ b/internal/fserrors/fserrors_test.go
@@ -119,6 +119,7 @@ func TestNewSentinels_LookupAndExit(t *testing.T) {
 		{ErrRelayIdleTimeout, "E029", 29},
 		{ErrRelayBudgetExhausted, "E037", 37},
 		{ErrManifestWriteFailed, "E038", 38},
+		{ErrHomebrewManaged, "E039", 39},
 	}
 	for _, c := range cases {
 		entry, ok := Lookup(c.err)
@@ -132,6 +133,19 @@ func TestNewSentinels_LookupAndExit(t *testing.T) {
 		if entry.Exit != c.exit {
 			t.Errorf("%v: exit = %d, want %d", c.err, entry.Exit, c.exit)
 		}
+	}
+}
+
+// The Homebrew-managed entry carries no Action: the specific brew command
+// (upgrade vs uninstall) rides the wrapped detail, so a generic Action line
+// would only contradict it.
+func TestHomebrewManaged_NoAction(t *testing.T) {
+	entry, ok := Lookup(ErrHomebrewManaged)
+	if !ok {
+		t.Fatal("expected catalog match for ErrHomebrewManaged")
+	}
+	if entry.Action != "" {
+		t.Errorf("Action should be empty so the brew detail isn't contradicted, got %q", entry.Action)
 	}
 }
 


### PR DESCRIPTION
## Problem

`fsend --update` / `--uninstall` on a Homebrew-managed binary refused by reusing `ErrUpdateFailed` (E033) / `ErrUninstallFailed` (E035). Those catalog entries carry generic Action lines that **contradict** the brew instruction the refusal prints:

```
[FAIL] [E035] fsend was not fully uninstalled.
  this fsend was installed with Homebrew — uninstall it with: brew uninstall fsend
  Remove the binary by hand (the path is printed above), possibly with sudo.
```

"uninstall it with brew" immediately followed by "remove the binary by hand" — and no path is printed on this code path (the path list only prints inside `confirmUninstall`, which the refusal skips). The `--update` variant similarly appended E033's "Check your internet connection… or reinstall". A brew refusal also isn't a *failure*; it's a deliberate "brew owns this binary" outcome.

## Fix

Add a dedicated `ErrHomebrewManaged` (E039) with a coherent Message and an **empty Action** — the specific brew command (`brew upgrade` vs `brew uninstall`) rides the wrapped detail line, so there's nothing to contradict. Both call sites (`selfupdate.go`, `uninstall.go`) return it, `renderError` extracts its detail, and the exit-code table in `docs/usage.md` documents it.

New output:

```
[FAIL] [E039] This fsend is managed by Homebrew.
  uninstall it with: brew uninstall fsend
```

## Validation

- Verified end-to-end against a binary placed on a `…/homebrew/bin/…` path: both `--uninstall` and `--update` (versioned build, past the dev-build gate) render E039 cleanly, exit 39.
- `TestRenderError_HomebrewManaged` asserts the E039 line + brew detail render and that "Remove the binary by hand" / "reinstall" / "path is printed above" do **not** leak.
- `TestHomebrewManaged_NoAction` locks in the empty Action; `TestNewSentinels_LookupAndExit` covers E039/39; `TestCatalog_UniqueCodes` confirms no code/exit collision.
- `managedByHomebrew` detection unchanged; full `cmd/fsend` + `internal/fserrors` suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)