### PR TITLE
fix(uxlog): progress-rendering edge cases from the audit

### DIFF
--- a/internal/uxlog/progress_test.go
+++ b/internal/uxlog/progress_test.go
@@ -205,6 +205,18 @@ func TestProgress_PlainModePercentClamped(t *testing.T) {
 	}
 }
 
+// A negative running total (a caller under-accounting) must clamp to 0%, not
+// print a "-N%" line.
+func TestProgress_PlainModePercentClampedLow(t *testing.T) {
+	var buf bytes.Buffer
+	p := &plainProgress{w: &buf, total: 1000, start: time.Now().Add(-2 * time.Second), lastLine: time.Now().Add(-2 * time.Second)}
+	p.add(-50)
+	out := buf.String()
+	if !strings.HasPrefix(strings.TrimSpace(out), "0%") {
+		t.Errorf("negative progress must clamp to 0%%: %q", out)
+	}
+}
+
 // truncateName keeps the tail (extension) visible with a middle ellipsis
 // and leaves short names untouched.
 func TestTruncateName(t *testing.T) {
@@ -217,5 +229,12 @@ func TestTruncateName(t *testing.T) {
 	}
 	if !strings.HasSuffix(got, ".tar.gz") || !strings.Contains(got, "…") {
 		t.Errorf("truncation must keep the tail and show an ellipsis: %q", got)
+	}
+	// Degenerate caps must not panic on the r[:max-tail-1] slice.
+	for _, max := range []int{-1, 0, 1, 2, 3} {
+		got := truncateName("abcdef", max) // len 6 > every max here, so it truncates
+		if r := []rune(got); len(r) > max && max > 0 {
+			t.Errorf("truncateName(_, %d) = %q (%d runes), exceeds cap", max, got, len(r))
+		}
 	}
 }

--- a/internal/uxlog/uxlog.go
+++ b/internal/uxlog/uxlog.go
@@ -67,10 +67,10 @@ func (p *plainProgress) add(n int64) {
 	}
 	p.lastLine = time.Now()
 	if p.total > 0 {
-		// Clamp: a percentage past 100 is never correct output, whatever
-		// the caller's accounting did.
+		// Clamp to 0..100: a percentage outside that range is never correct
+		// output, whatever the caller's accounting did.
 		line := fmt.Sprintf("%d%%  %s / %s",
-			min(100, p.current*100/p.total), HumanBytes(p.current), HumanBytes(p.total))
+			max(0, min(100, p.current*100/p.total)), HumanBytes(p.current), HumanBytes(p.total))
 		if p.label != "" {
 			line += "  ·  " + p.label
 		}
@@ -250,6 +250,9 @@ func New(totalBytes int64, showNames bool) *Progress {
 		decor.Name("  "),
 		counters,
 	}
+	// The plain (un-dimmed) stalled marker; decor.Meta colors it below while
+	// mpb measures the bar width off this ANSI-free form.
+	const stalledChip = "  ·  stalled"
 	if showRate {
 		appendDecs = append(appendDecs,
 			// Rate: hidden when the figure would be misleading (start
@@ -258,23 +261,36 @@ func New(totalBytes int64, showNames bool) *Progress {
 			// This decorator also feeds the window each refresh frame.
 			// A stall says "stalled" rather than letting the windowed
 			// rate decay through fictional values.
-			decor.Any(func(s decor.Statistics) string {
-				if s.Completed || s.Aborted || s.Current == 0 {
-					return ""
-				}
-				now := time.Now()
-				r := win.observe(now, s.Current)
-				if s.Current < rateThreshold {
-					return ""
-				}
-				if win.stalled(now) {
-					return "  ·  " + Dim("stalled")
-				}
-				if r <= 0 {
-					return ""
-				}
-				return "  ·  " + HumanBytes(int64(r)) + "/s"
-			}),
+			decor.Meta(
+				decor.Any(func(s decor.Statistics) string {
+					if s.Completed || s.Aborted || s.Current == 0 {
+						return ""
+					}
+					now := time.Now()
+					r := win.observe(now, s.Current)
+					if s.Current < rateThreshold {
+						return ""
+					}
+					if win.stalled(now) {
+						return stalledChip
+					}
+					// Below 1 B/s the figure rounds to "0 B/s"; show nothing
+					// rather than a rate that reads as stalled.
+					if r < 1 {
+						return ""
+					}
+					return "  ·  " + HumanBytes(int64(r)) + "/s"
+				}),
+				// Dim only the stalled marker. Measuring width off the plain
+				// string above keeps mpb from counting the ANSI escapes — a
+				// colorized decor.Any costs ~6 columns of bar during a stall.
+				func(str string) string {
+					if str == stalledChip {
+						return Dim(str)
+					}
+					return str
+				},
+			),
 			// ETA: needs a known total, non-zero progress, and at least
 			// 1 s elapsed so the projection isn't dominated by handshake
 			// time. Hidden on completion and during a stall (a projection
@@ -379,6 +395,9 @@ func truncateName(s string, max int) string {
 	r := []rune(s)
 	if len(r) <= max {
 		return s
+	}
+	if max <= 0 {
+		return "" // nothing fits; avoids a negative slice bound below
 	}
 	tail := min(8, max/2)
 	return string(r[:max-tail-1]) + "…" + string(r[len(r)-tail:])


### PR DESCRIPTION
Four small rendering fixes surfaced by the post-merge audit. All low-severity; two were latent.

## 1. "stalled" chip shrinks the bar (~6 columns on narrow terminals)
The dimmed `stalled` marker was `"  ·  " + Dim("stalled")` inside a `decor.Any`. mpb measures decorator width with `runewidth.StringWidth`, which counts the ANSI escape bytes — so during a stall the bar lost ~6 columns (and could push a following chip into premature truncation). Now the decorator returns the **plain** marker and `decor.Meta` applies the dim styling, so mpb measures width off the ANSI-free string. Wide terminals were unaffected either way.

## 2. "0 B/s" on a crawling transfer
A transfer advancing <1 B/s (never tripping the 3 s stall threshold) rounded to `0 B/s`, which reads as stalled. The guard is now `r < 1` → show nothing rather than a misleading zero.

## 3. `truncateName(s, max<=0)` panic (latent)
`r[:max-tail-1]` is a negative slice bound at `max=0`. Unreachable today (the only caller passes `max>0`), but guarded so the trap can't be armed by a future caller.

## 4. Plain-mode percent not clamped below 0 (latent)
The high end clamped to 100 but a negative running total printed `-N%`. Now clamped to `0..100`.

## Validation

- `TestProgress_PlainModePercentClampedLow`: a negative add must print `0%`. **Confirmed it fails without the fix** (`-5%`).
- `TestTruncateName` extended with degenerate caps (`-1,0,1,2,3`). **Confirmed it panics without the guard.**
- F1/F2 are TTY-render behaviors (verified by construction + the full `internal/uxlog` suite, which passes). `decor.Meta` is mpb's documented mechanism for colorized decorators.
- Build + vet + full `internal/uxlog` suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)