### PR TITLE
fix(install): don't let a good cosign verify abort install on PowerShell 5.1

### DIFF
--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -114,12 +114,19 @@ function Verify-Signature($sums, $base, $dir) {
     $pem = Join-Path $dir 'checksums.txt.pem'
     Download "$base/checksums.txt.sig" $sig
     Download "$base/checksums.txt.pem" $pem
+    # Windows PowerShell 5.1 turns a native command's redirected stderr into a
+    # terminating error under EAP=Stop — and cosign prints "Verified OK" to
+    # stderr even on success, which would abort a good verification. Relax EAP
+    # just for this call; correctness is judged by $LASTEXITCODE, not stderr.
+    $prevEAP = $ErrorActionPreference
+    $ErrorActionPreference = 'Continue'
     & cosign verify-blob `
         --certificate $pem `
         --signature $sig `
         --certificate-identity-regexp $CosignIdentityRegexp `
         --certificate-oidc-issuer $CosignIssuer `
         $sums 2>$null | Out-Null
+    $ErrorActionPreference = $prevEAP
     if ($LASTEXITCODE -ne 0) {
         Err 'cosign signature verification failed for checksums.txt - refusing to install'
     }


### PR DESCRIPTION
## Problem

`scripts/install.ps1` runs under `$ErrorActionPreference = 'Stop'`. In **Windows PowerShell 5.1** — the documented baseline ("PowerShell 5.1+ … is the only requirement") — redirecting a native command's stderr (`2>$null`) wraps each stderr line in an `ErrorRecord`, and EAP=Stop turns the first one into a *terminating* error (the well-known PowerShell/PowerShell#3996 behavior).

`cosign verify-blob` prints **"Verified OK" to stderr on success**. So a user who *has* cosign installed could see the installer abort mid-verification with a confusing `NativeCommandError` — on both fresh installs and `fsend --update` (which re-runs this script). PowerShell 7 is unaffected.

## Fix

Relax `$ErrorActionPreference` to `'Continue'` for just the cosign call, restoring the previous value immediately after. Verification correctness is already judged by `$LASTEXITCODE`, which stderr output doesn't affect. The reviewer's suggested remedy.

The only other native-command stderr redirect in the script — `& $dst --version 2>$null` — is safe: `fsend --version` writes to stdout only (confirmed: 0 bytes on stderr), so it produces no `ErrorRecord`.

## Validation

- Structural check: braces balanced (37/37); EAP saved and restored around the call.
- Confirmed `fsend --version` emits nothing on stderr, so line 208 needs no change.
- **Note:** I could not execute this on a Windows PowerShell 5.1 host from the dev environment (no `pwsh`/`powershell` available). The fix is the standard, well-understood remedy for this EAP + native-stderr interaction and is low-risk, but a 2-minute confirmation on a real PS 5.1 box before release is worthwhile. The POSIX `install.sh` equivalent (`2>/dev/null`) is unaffected — `sh` has no EAP concept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)