### PR TITLE
fix(transfer,cli): close ancestor-symlink escape and honest retry/kept counts

### DIFF
--- a/cmd/fsend/helpers_test.go
+++ b/cmd/fsend/helpers_test.go
@@ -972,6 +972,43 @@ func TestFinishReceive_KeptFilesGetHonestSummary(t *testing.T) {
 	}
 }
 
+// A transient drop mid-transfer retries with the same receiverUI. The retry
+// reclassifies against disk and re-fires the tally callbacks, so without a
+// reset the counts accumulate across attempts and the headline lies ("Saved 3
+// of 7" for a 4-file offer). resetAttemptCounts must leave the final attempt's
+// view as the whole truth.
+func TestFinishReceive_CountsResetAcrossRetry(t *testing.T) {
+	ui := newReceiverUI(context.Background(), &flags{}, "/tmp", false, mustLANInfo())
+	h := wire.SenderHello{Mode: wire.ModeFiles, DisplayName: "4 files"}
+	ui.hello = &h
+
+	// Attempt 1: two files land, one differing file kept, then a drop.
+	ui.onFileDone("a.bin")
+	ui.onFileDone("e.txt")
+	ui.onConflictKept("c.bin")
+
+	// Retry: the loop resets before re-running the transfer.
+	ui.resetAttemptCounts()
+
+	// Attempt 2 (succeeds): the two already-landed files are now identical, the
+	// interrupted one lands, the differing one is kept again.
+	ui.onSkip(0)
+	ui.onSkip(1)
+	ui.onFileDone("zz.bin")
+	ui.onConflictKept("c.bin")
+
+	got := captureStderr(t, func() {
+		if err := finishReceive(ui.f, ui, time.Second); !errors.Is(err, fserrors.ErrTargetExists) {
+			t.Errorf("finishReceive error = %v, want ErrTargetExists", err)
+		}
+	})
+	// 1 saved this attempt, of 4 total (1 saved + 2 identical + 1 kept) — not
+	// the accumulated "1 of 7".
+	if want := "Saved 1 of 4 files"; !strings.Contains(got, want) {
+		t.Errorf("summary missing %q:\n%s", want, got)
+	}
+}
+
 func TestDifferVerb(t *testing.T) {
 	if got := differVerb(1); got != "differs" {
 		t.Errorf("differVerb(1) = %q", got)

--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -442,6 +442,9 @@ func runReceiverQUICOver(ctx context.Context, f *flags, pc net.PacketConn, code 
 	}
 	if err := retry.WithBackoff(ctx, opts, nil,
 		func(attempt int) error {
+			if attempt > 1 {
+				ui.resetAttemptCounts()
+			}
 			return runReceiverOneAttempt(ctx, tr, f, ui, code)
 		}); err != nil {
 		// A Ctrl-C at an interactive prompt cancels ctx but surfaces as a

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -144,6 +144,9 @@ func runReceive(f *flags, c string) error {
 	current := first
 	if err := retry.WithBackoff(ctx, opts, nil,
 		func(attempt int) error {
+			if attempt > 1 {
+				ui.resetAttemptCounts()
+			}
 			if current == nil {
 				res, err := quicconn.Dial(ctx, addr, c)
 				if err != nil {

--- a/cmd/fsend/receiverui.go
+++ b/cmd/fsend/receiverui.go
@@ -374,6 +374,19 @@ func (ui *receiverUI) onFileDone(path string) {
 	ui.mu.Unlock()
 }
 
+// resetAttemptCounts drops the file tallies before a retry re-runs the
+// transfer. A fresh attempt reclassifies against disk and re-fires these
+// callbacks, so keeping the prior attempt's counts would double them (a file
+// saved then reclassified as identical would show as both). Byte counters
+// (prev/total/skipped) are keyed per file and self-correct, so they persist.
+func (ui *receiverUI) resetAttemptCounts() {
+	ui.mu.Lock()
+	ui.files = ui.files[:0]
+	ui.skippedSame = 0
+	ui.kept = 0
+	ui.mu.Unlock()
+}
+
 func (ui *receiverUI) bytes() (total, moved int64) {
 	ui.mu.Lock()
 	defer ui.mu.Unlock()

--- a/cmd/fsend/send.go
+++ b/cmd/fsend/send.go
@@ -314,7 +314,7 @@ type senderStats struct {
 // bar. Returns close, progress, onResume, onSkip, a stats getter, and
 // onStreamingEOF (latches the bar total once a stream EOFs). All callbacks
 // run on the single send-loop goroutine, so the counters need no locking.
-func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn func(uint32, uint64), onResume func(uint32, uint64, uint64), onSkip func(uint32, bool), stats func() senderStats, onStreamingEOF func(uint32, uint64)) {
+func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn func(uint32, uint64), onResume func(uint32, uint64, uint64), onSkip func(uint32, bool), stats func() senderStats, onStreamingEOF func(uint32, uint64), resetCounts func()) {
 	prev := make(map[uint32]uint64)
 	var s senderStats
 	var bar *uxlog.Progress
@@ -373,7 +373,14 @@ func newSenderProgress(f *flags, plan *sendPlan) (closeFn func(), progressFn fun
 			}
 		},
 		func() senderStats { return s },
-		func(_ uint32, finalBytes uint64) { bar.SetTotal(int64(finalBytes), true) }
+		func(_ uint32, finalBytes uint64) { bar.SetTotal(int64(finalBytes), true) },
+		func() {
+			// A retry reclassifies against the receiver and re-fires onSkip, so
+			// the file tallies must start fresh; moved bytes are keyed per file
+			// (prev map) and self-correct, so they persist.
+			s.skippedFiles = 0
+			s.keptFiles = 0
+		}
 }
 
 // resumeNotice renders the "Resuming from 141 MB (71%)" clause.

--- a/cmd/fsend/sendpair.go
+++ b/cmd/fsend/sendpair.go
@@ -720,7 +720,7 @@ func runSenderTransferOverInternet(ctx context.Context, f *flags, plan *sendPlan
 // both paths in this helper keeps the two transfer entry points purely
 // declarative.
 func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathInfo connpath.Info, firstRes *quicconn.AcceptResult, reaccept func(context.Context) (*quicconn.AcceptResult, error)) error {
-	closeProg, progressFn, onResume, onSkip, stats, onStreamingEOF := newSenderProgress(f, plan)
+	closeProg, progressFn, onResume, onSkip, stats, onStreamingEOF, resetCounts := newSenderProgress(f, plan)
 	defer closeProg()
 
 	// The receiver may sit at its accept prompt for a while; the spinner
@@ -774,6 +774,9 @@ func runSenderTransferLoop(ctx context.Context, f *flags, plan *sendPlan, pathIn
 	}
 	err := retry.WithBackoff(ctx, opts, classify,
 		func(attempt int) error {
+			if attempt > 1 {
+				resetCounts()
+			}
 			if current == nil {
 				res, err := reaccept(ctx)
 				if err != nil {

--- a/internal/transfer/classify.go
+++ b/internal/transfer/classify.go
@@ -33,6 +33,11 @@ type entryPlan struct {
 	disp         disposition
 	resumeOffset uint64
 	imohash      [ImohashSize]byte
+	// blockedAncestor marks a target reachable only by traversing a
+	// receiver-side symlink in its path. Such an entry is kept untouched (never
+	// sent, materialized, or chmod'd) even under --overwrite, so a write or
+	// mode change can't escape the receive tree through the link.
+	blockedAncestor bool
 }
 
 // needsConsent reports a destructive disagreement requiring --overwrite.
@@ -101,9 +106,39 @@ func classify(entries []wire.ListingEntry, targetDir string, checksum bool) ([]e
 				return nil, fserrors.ErrPathTraversal
 			}
 		}
-		plans = append(plans, classifyOne(e, target, targetDir, checksum))
+		p := classifyOne(e, target, targetDir, checksum)
+		p.blockedAncestor = symlinkAncestor(target, targetDir)
+		plans = append(plans, p)
 	}
 	return plans, nil
+}
+
+// symlinkAncestor reports whether any path component of target between
+// targetDir (exclusive) and target (exclusive) is a symlink. Lstat on the full
+// target only inspects the leaf — an intermediate link is silently followed —
+// so each ancestor is Lstat'd in turn, where it is itself the leaf. A
+// receiver-planted link on the path would let a later write or chmod traverse
+// out of the receive tree; callers must refuse to act on such a target.
+func symlinkAncestor(target, targetDir string) bool {
+	rootAbs, err := filepath.Abs(targetDir)
+	if err != nil {
+		return false
+	}
+	cur, err := filepath.Abs(filepath.Dir(target))
+	if err != nil {
+		return false
+	}
+	for cur != rootAbs {
+		if st, err := os.Lstat(cur); err == nil && st.Mode()&os.ModeSymlink != 0 {
+			return true
+		}
+		parent := filepath.Dir(cur)
+		if parent == cur {
+			break // reached the filesystem root without meeting targetDir
+		}
+		cur = parent
+	}
+	return false
 }
 
 // ancestorBlocked reports whether target can't be placed because the nearest
@@ -238,8 +273,13 @@ func summarize(plans []entryPlan) classifySummary {
 				s.BytesToRecv += p.entry.Size - p.resumeOffset
 			}
 		case dispDiffers, dispConflict:
-			s.Differing++
-			s.DifferingBytes += p.entry.Size
+			// A directory isn't a user-facing "file"; excluding it keeps the
+			// "N differ" header and the --overwrite warning agreeing with the
+			// per-file row count and the sender's kept tally.
+			if p.entry.Type != wire.EntryDir {
+				s.Differing++
+				s.DifferingBytes += p.entry.Size
+			}
 		}
 		// Directories aren't files the user thinks about; mirror CountFiles
 		// so the preview's row count matches the headline's file count.

--- a/internal/transfer/engine_test.go
+++ b/internal/transfer/engine_test.go
@@ -794,6 +794,81 @@ func TestEngine_DirModeDoesNotFollowKeptSymlink(t *testing.T) {
 	if st, _ := os.Stat(outside); st.Mode()&os.ModePerm != 0o755 {
 		t.Errorf("outside dir chmod'd through symlink: %o, want 0755", st.Mode()&os.ModePerm)
 	}
+	// The child must not have been written through the link either.
+	if _, err := os.Lstat(filepath.Join(outside, "f.txt")); err == nil {
+		t.Errorf("child file escaped through the kept symlink into %s", outside)
+	}
+}
+
+// Like the kept-symlink case above, but the receiver's symlink is an ancestor
+// of the incoming files rather than the entry itself. Lstat on the full target
+// follows an intermediate link, so guarding only the leaf leaves an escape:
+// content written and dir modes chmod'd outside the receive tree.
+func TestEngine_NoWriteThroughAncestorSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows has no Unix symlink/permission semantics")
+	}
+	run := func(t *testing.T, overwrite bool) {
+		outside := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(outside, "b"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		src, dst := t.TempDir(), t.TempDir()
+		writeFile(t, filepath.Join(src, "a", "b", "f.txt"), []byte("payload"))
+		if err := os.Chmod(filepath.Join(src, "a", "b"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		// Receiver's own symlink sits where the incoming "a" directory would go.
+		if err := os.Symlink(outside, filepath.Join(dst, "a")); err != nil {
+			t.Fatal(err)
+		}
+		mutate := func(o *RecvOptions) {
+			if overwrite {
+				o.Overwrite = true
+			}
+		}
+		if se, re := fileTransfer(t, []string{filepath.Join(src, "a")}, dst, mutate); se != nil || re != nil {
+			t.Fatalf("send=%v recv=%v", se, re)
+		}
+		if _, err := os.Lstat(filepath.Join(outside, "b", "f.txt")); err == nil {
+			t.Errorf("overwrite=%v: file materialized outside the receive tree", overwrite)
+		}
+		if st, _ := os.Stat(filepath.Join(outside, "b")); st != nil && st.Mode()&os.ModePerm != 0o755 {
+			t.Errorf("overwrite=%v: outside/b chmod'd through ancestor symlink: %o, want 0755", overwrite, st.Mode()&os.ModePerm)
+		}
+		// Without overwrite the link is kept as-is; with overwrite it's the
+		// conflicting entry itself, so it may be replaced by the real directory
+		// (the link is removed, never followed) — either way nothing escapes.
+		if !overwrite {
+			if st, err := os.Lstat(filepath.Join(dst, "a")); err != nil || st.Mode()&os.ModeSymlink == 0 {
+				t.Errorf("receiver symlink not left intact: mode=%v err=%v", st.Mode(), err)
+			}
+		}
+	}
+	t.Run("kept", func(t *testing.T) { run(t, false) })
+	t.Run("overwrite", func(t *testing.T) { run(t, true) })
+}
+
+// A directory that conflicts with a receiver-side non-directory is kept, but a
+// directory isn't a user-facing "file": it must not be counted in the kept
+// tally, matching the sender (send.go) and the identical-skip path.
+func TestEngine_KeptDirNotCountedAsFile(t *testing.T) {
+	src, dst := t.TempDir(), t.TempDir()
+	writeFile(t, filepath.Join(src, "d", "f.txt"), []byte("hi"))
+	// Receiver has a plain file where the incoming directory "d" would go.
+	writeFile(t, filepath.Join(dst, "d"), []byte("occupied"))
+
+	var keptPaths []string
+	_, re := fileTransfer(t, []string{filepath.Join(src, "d")}, dst, func(o *RecvOptions) {
+		o.OnConflictKept = func(p string) { keptPaths = append(keptPaths, p) }
+	})
+	if re != nil {
+		t.Fatalf("recv=%v", re)
+	}
+	// Only the blocked child file is a kept "file"; the directory entry is not.
+	if len(keptPaths) != 1 || keptPaths[0] == "d" {
+		t.Errorf("kept files = %v, want just the child file (not the directory)", keptPaths)
+	}
 }
 
 // A chmod on a source directory propagates on an identical re-send, matching

--- a/internal/transfer/recv.go
+++ b/internal/transfer/recv.go
@@ -634,7 +634,7 @@ func materialize(s *Streams, p *entryPlan, approveOverwrite bool, opts RecvOptio
 func restoreDirModes(plans []entryPlan) {
 	for i := len(plans) - 1; i >= 0; i-- {
 		p := &plans[i]
-		if p.entry.Type != wire.EntryDir {
+		if p.entry.Type != wire.EntryDir || p.blockedAncestor {
 			continue
 		}
 		want := os.FileMode(p.entry.Mode) & os.ModePerm
@@ -653,7 +653,7 @@ func restoreDirModes(plans []entryPlan) {
 // hash under --checksum) would otherwise skip it and never pick up the new
 // mode. Best-effort; a chmod failure isn't worth failing the transfer.
 func repairIdenticalMode(p *entryPlan) {
-	if p.entry.Type != wire.EntryFile {
+	if p.entry.Type != wire.EntryFile || p.blockedAncestor {
 		return
 	}
 	want := os.FileMode(p.entry.Mode) & os.ModePerm
@@ -667,6 +667,17 @@ func repairIdenticalMode(p *entryPlan) {
 // notifications (skip / conflict-kept).
 func planToDecision(p *entryPlan, approveOverwrite bool, opts RecvOptions) wire.Decision {
 	d := wire.Decision{Index: p.entry.Index}
+	// A target reachable only through a receiver-side symlink is kept untouched
+	// regardless of overwrite — sending or materializing it would write through
+	// the link, out of the receive tree.
+	if p.blockedAncestor {
+		d.Action = wire.DecisionSkip
+		d.Kept = true
+		if opts.OnConflictKept != nil && p.entry.Type != wire.EntryDir {
+			opts.OnConflictKept(p.entry.RelativePath)
+		}
+		return d
+	}
 	switch p.disp {
 	case dispIdentical:
 		d.Action = wire.DecisionSkip
@@ -688,7 +699,10 @@ func planToDecision(p *entryPlan, approveOverwrite bool, opts RecvOptions) wire.
 		} else {
 			d.Action = wire.DecisionSkip
 			d.Kept = true
-			if opts.OnConflictKept != nil {
+			// Count only files/symlinks as kept — a kept directory isn't a
+			// user-facing file, and counting it would inflate the tally past
+			// the sender's (which excludes dirs the same way).
+			if opts.OnConflictKept != nil && p.entry.Type != wire.EntryDir {
 				opts.OnConflictKept(p.entry.RelativePath)
 			}
 		}


### PR DESCRIPTION
Three findings from the pre-v1.10.0 regression audit, each with a revert-verified test.

## Major — ancestor-symlink write/chmod escape (completes #166)
#166 swapped `Stat`→`Lstat` in the receive path but only guarded the **leaf** component. `Lstat` still follows intermediate components, so a receiver's *own* pre-existing symlink one or more levels up the path is traversed:

- Receiver has `dst/a -> /outside` (their own link); sender sends a normal `a/b/f.txt`.
- `MkdirAll`/`rename` write the file into `/outside/b/f.txt`, and `restoreDirModes` chmods `/outside/b` to the **sender's** dir mode — both outside the chosen receive directory.

The symlink is never on the wire (the sender dereferences links; the receiver rejects symlink entries), so neither of those defenses covers it. `classify` now flags any target reachable through such a link (`blockedAncestor`) and keeps it untouched — never sent, materialized, or chmod'd — **even under `--overwrite`** (the link is the conflicting entry itself there, so it may be replaced by the real dir, but is never followed).

## Major — retry counters accumulate across attempts
A transient mid-transfer drop retries with the same progress state. The retry reclassifies against disk and re-fires the tally callbacks, so `files`/`skipped`/`kept` accumulated across attempts — e.g. **"Saved 3 of 7" for a 4-file offer**, with matching wrong `--json` `files_*` and `--manifest` rows. The per-attempt file tallies now reset at the start of each retry on both sender and receiver; byte counters are keyed per file (via the `prev` map) and self-correct, so they persist.

## Medium — directory conflicts counted as kept "files"
The receiver counted a kept directory conflict in `files_kept` and the "N differ" header, while the sender (and the identical-skip path) exclude directories — so the two sides disagreed and the receiver's offer math inflated ("Saved 0 of 2" for a 1-file offer). Directories are now excluded on the receiver too.

## Tests / validation
- New regression tests for each finding; all three **fail on the pre-fix source** (confirmed by stashing only the source hunks) and pass with the fix.
- Strengthened #166's existing test to also assert the child file doesn't leak through a kept symlink.
- Full suite green, 19/19 packages with `-race`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)