### PR TITLE
fix(release): pin cosign to v2 so sign-blob keeps emitting .sig/.pem

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,13 @@ jobs:
           go-version: "1.26"
           cache: true
       - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the cosign binary to v2: our goreleaser sign-blob config emits
+          # detached .sig/.pem (which install.sh/install.ps1 verify), and
+          # cosign 3.x's sign-blob switched to bundles. The v4 installer
+          # otherwise defaults to cosign 3.x. Migrating to v3 is a separate,
+          # deliberate change to both the signing config and the verify side.
+          cosign-release: v2.5.2
       - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7
         with:
           distribution: goreleaser


### PR DESCRIPTION
## Problem
The `v1.10.0` release run ([28701191717](https://github.com/polius/fsend/actions/runs/28701191717)) failed at the cosign signing step:

```
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
```

## Root cause
PR #135 bumped `sigstore/cosign-installer` 3.9.1 → 4.1.2. The v4 installer defaults to installing **cosign v3.0.6**, whose `sign-blob` emits a Sigstore *bundle* instead of the detached `.sig` + `.pem` our `.goreleaser.yml` `signs:` config produces (`--output-signature`/`--output-certificate`). goreleaser + cosign 3.x then try to write a bundle to an empty path → the error above. Every prior release used the v3 installer, which defaulted to cosign **v2.5.2**, so no release hit this until now.

Nothing was published — goreleaser failed *before* the release/publish step (no `v1.10.0` GitHub release, Homebrew tap still on v1.9.0).

## Fix
Pin the cosign **binary** to `v2.5.2` via the installer's `cosign-release` input, keeping the SHA-pinned v4 installer action. This restores the exact known-good signing toolchain and keeps the `.sig`/`.pem` artifacts that `install.sh` and `install.ps1` verify against (unchanged, including #174's PS 5.1 fix).

Migrating to cosign v3 is a deliberate follow-up: it changes the signature artifact format and requires updating both the signing config and the install-script verification, tested end-to-end.

## Re-release
After merge, the `v1.10.0` tag must be re-pointed at the fixed commit (delete + recreate) to re-trigger the release with the corrected workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)