### PR TITLE
fix(release): migrate signing to cosign v3 Sigstore bundles

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,16 +97,18 @@ checksum:
   algorithm: sha256
 
 signs:
+  # cosign 3.x dropped the detached --output-signature/--output-certificate in
+  # favour of a single Sigstore bundle (sig + cert + tlog proof). install.sh /
+  # install.ps1 verify it with `cosign verify-blob --bundle`.
   - cmd: cosign
-    signature: "${artifact}.sig"
-    certificate: "${artifact}.pem"
+    signature: "${artifact}.bundle"
     args:
       - sign-blob
       - "--yes"
-      - "--output-signature=${signature}"
-      - "--output-certificate=${certificate}"
+      - "--bundle=${signature}"
       - "${artifact}"
     artifacts: checksum
+    output: true
 
 snapshot:
   version_template: '{{ incpatch .Version }}-snapshot'

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -110,10 +110,8 @@ function Verify-Signature($sums, $base, $dir) {
         Write-Host '  install cosign for full authenticity, or set FSEND_REQUIRE_SIGNATURE=1 to require it.' -ForegroundColor Yellow
         return
     }
-    $sig = Join-Path $dir 'checksums.txt.sig'
-    $pem = Join-Path $dir 'checksums.txt.pem'
-    Download "$base/checksums.txt.sig" $sig
-    Download "$base/checksums.txt.pem" $pem
+    $bundle = Join-Path $dir 'checksums.txt.bundle'
+    Download "$base/checksums.txt.bundle" $bundle
     # Windows PowerShell 5.1 turns a native command's redirected stderr into a
     # terminating error under EAP=Stop — and cosign prints "Verified OK" to
     # stderr even on success, which would abort a good verification. Relax EAP
@@ -121,8 +119,7 @@ function Verify-Signature($sums, $base, $dir) {
     $prevEAP = $ErrorActionPreference
     $ErrorActionPreference = 'Continue'
     & cosign verify-blob `
-        --certificate $pem `
-        --signature $sig `
+        --bundle $bundle `
         --certificate-identity-regexp $CosignIdentityRegexp `
         --certificate-oidc-issuer $CosignIssuer `
         $sums 2>$null | Out-Null

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -219,11 +219,9 @@ verify_signature() {
         warn "  install cosign for full authenticity, or set FSEND_REQUIRE_SIGNATURE=1 to require it."
         return 0
     fi
-    download "${_base}/checksums.txt.sig" "${_dir}/checksums.txt.sig"
-    download "${_base}/checksums.txt.pem" "${_dir}/checksums.txt.pem"
+    download "${_base}/checksums.txt.bundle" "${_dir}/checksums.txt.bundle"
     cosign verify-blob \
-        --certificate "${_dir}/checksums.txt.pem" \
-        --signature "${_dir}/checksums.txt.sig" \
+        --bundle "${_dir}/checksums.txt.bundle" \
         --certificate-identity-regexp "$COSIGN_IDENTITY_REGEXP" \
         --certificate-oidc-issuer "$COSIGN_ISSUER" \
         "$_sums" >/dev/null 2>&1 \


### PR DESCRIPTION
## Problem
The `v1.10.0` release ([run 28701191717](https://github.com/polius/fsend/actions/runs/28701191717)) failed at signing:

```
Error: signing dist/checksums.txt: create bundle file: open : no such file or directory
```

`cosign-installer` v4 (bumped in #135) installs **cosign 3.x**, which removed the detached `--output-signature`/`--output-certificate` from `sign-blob`. cosign 3.x signs to a single **Sigstore bundle** (signature + certificate + Rekor proof) via `--bundle`, and `verify-blob` reads it back with `--bundle`. The old `.sig`/`.pem` config no longer works.

Per maintainer decision we move **forward to cosign v3** (rather than pinning back to v2).

## Changes
- **`.goreleaser.yml`** — `sign-blob --bundle=checksums.txt.bundle` instead of the detached `--output-signature`/`--output-certificate`.
- **`install.sh` / `install.ps1`** — download `checksums.txt.bundle` and verify with `cosign verify-blob --bundle …`, keeping the same keyless `--certificate-identity-regexp` / `--certificate-oidc-issuer` checks (and install.ps1's PS 5.1 EAP handling from #174).
- `fsend --update` re-runs the installer, so it inherits the change. No Go changes; `docs/security.md` stays accurate (it describes signing conceptually, not the artifact format).

## Validation (local, cosign v3.1.1)
- `goreleaser release --snapshot` produces `dist/checksums.txt.bundle` and registers it as a `Signature` artifact (so it's uploaded to the release).
- `cosign verify-blob --bundle checksums.txt.bundle checksums.txt` → **Verified OK** via the exact install-script mechanism.
- A tampered blob is **rejected** (`invalid signature`).
- `goreleaser check` passes; `sh -n scripts/install.sh` passes.

## Note for consumers
Releases are now signed with the cosign v3 bundle format. Users verifying manually need a recent cosign (v2's `--bundle` predates the default new-bundle format; v3 is recommended).

## Re-release
After merge, the `v1.10.0` tag must be re-pointed at the fixed commit (nothing was published — goreleaser died before the release step) to re-trigger the workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)