### PR TITLE
fix(cli,install): Windows 10s connect stall and installer mojibake

### DIFF
--- a/cmd/fsend/internet.go
+++ b/cmd/fsend/internet.go
@@ -63,12 +63,12 @@ func isLocalAddr(addr string) bool {
 }
 
 // joinRetryBudget caps how long the receiver waits for the sender to
-// register the code on the pairing server. With the sender's short
-// LAN-only window (~5s) plus a Create round-trip, the sender should
-// always be registered within a couple of seconds of starting. But the
-// human is in the loop — the receiver may have typed the code while
-// the sender is still in its LAN window, so we give Join a budget to
-// outlast that race instead of failing instantly with E002.
+// register the code on the pairing server. The sender Creates its
+// session the moment it starts (LAN and internet pairing run in
+// parallel), so the code is normally registered long before a human
+// can type it. The budget covers the races around that: a receiver
+// beating a slow Create, or re-joining a stale claimed slot the sender
+// is about to recycle — so neither fails instantly with E002.
 //
 // Var (not const) so tests can shrink it.
 var joinRetryBudget = 15 * time.Second

--- a/cmd/fsend/receive.go
+++ b/cmd/fsend/receive.go
@@ -70,8 +70,9 @@ func runReceive(f *flags, c string) error {
 
 	// LAN discovery is a 300 ms probe — short enough that showing a
 	// spinner only flashes a line that immediately gets cleared on miss,
-	// which reads as glitchy. Stay silent through the probe; only show a
-	// spinner once we know we're going down the longer internet path.
+	// which reads as glitchy. Stay silent through the probe; a spinner
+	// starts once we know we're on a longer path (the LAN dial below, or
+	// the internet fallback).
 	q, err := landisc.Query(ctx, c, 300*time.Millisecond)
 	if err != nil {
 		// LAN miss → internet path. A single "Connecting" spinner runs
@@ -97,37 +98,49 @@ func runReceive(f *flags, c string) error {
 		return err
 	}
 
-	// First LAN dial sits outside the retry loop. If it fails before
-	// pairing, mDNS responded (cached, stale, or racing the sender's
-	// de-announce) but the sender's LAN listener is gone — almost
-	// always because the sender's internet path won the pair race or
-	// the LAN listener was never really up. Fall through to the
-	// internet path instead of reporting E003, which used to mislead
-	// users in single-receiver scenarios and produced a flaky
-	// TestReceive_Overwrite under -race.
-	first, err := quicconn.Dial(ctx, addr, c)
+	// First LAN dial sits outside the retry loop. A failure means mDNS
+	// responded but the listener is unreachable — a stale announce, or a
+	// firewall silently dropping the port (Windows Defender blocks the
+	// listener by default while its built-in 5353 rule lets discovery
+	// work). Fall through to the internet path instead of reporting E003.
+	//
+	// RTT-scale budget, not the 10 s HandshakeTimeout: a real same-LAN
+	// handshake takes milliseconds, and a false timeout just reaches the
+	// same host↔host pair via ICE.
+	const lanFirstDialTimeout = 2 * time.Second
+
+	// The dial is user-visible wait; on miss runReceiveOverInternet
+	// takes ownership of the spinner.
+	var spin *uxlog.Spinner
+	if !f.quiet {
+		spin = uxlog.StartSpinner("Connecting")
+	}
+	dialCtx, cancelDial := context.WithTimeout(ctx, lanFirstDialTimeout)
+	first, err := quicconn.Dial(dialCtx, addr, c)
+	cancelDial()
 	if err != nil {
 		// Debug-only: the transfer may still end up "Direct on local
-		// network" via the server-paired race, so surfacing this notice
-		// by default reads as the tool contradicting itself.
+		// network" via ICE, so this notice by default reads as the tool
+		// contradicting itself. Spinner restart keeps the line clean.
 		if f.debug && !f.quiet {
+			spin.Stop()
 			fmt.Fprintln(os.Stderr, uxlog.Info(), "Local sender unreachable — falling back to server.")
+			spin = uxlog.StartSpinner("Connecting")
 		}
 		cfg := loadConfig(f.quiet)
-		var connSpin *uxlog.Spinner
-		if !f.quiet {
-			connSpin = uxlog.StartSpinner("Connecting")
-		}
-		return runReceiveOverInternet(ctx, f, c, cfg, connSpin)
+		return runReceiveOverInternet(ctx, f, c, cfg, spin)
 	}
 
 	ui := newReceiverUI(ctx, f, outDir, sink, connpath.FromLAN())
 	// --checksum hashes the files already on disk before the accept prompt —
-	// a silence that scales with the existing data. Cover it with a spinner
-	// (stopped by the prompt). Without --checksum classification is stat-only
-	// and near-instant; a spinner would just flash.
+	// a silence that scales with the existing data. Keep the spinner alive
+	// for it (stopped by the prompt); otherwise classification is stat-only
+	// and near-instant.
 	if f.checksum && !f.quiet {
-		ui.spin = uxlog.StartSpinner("Checking existing files")
+		spin.SetMessage("Checking existing files")
+		ui.spin = spin
+	} else {
+		spin.Stop()
 	}
 	defer ui.close()
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -5,7 +5,7 @@
 .DESCRIPTION
   Downloads the latest fsend release, verifies its SHA-256 checksum, and
   installs fsend.exe into a directory on your PATH. PowerShell 5.1+ (in-box
-  on Windows 10/11) is the only requirement — no Git Bash needed.
+  on Windows 10/11) is the only requirement - no Git Bash needed.
 
   Quick install:
     irm https://getfsend.alzina.dev/windows | iex
@@ -43,14 +43,17 @@ $Binary = 'fsend.exe'
 $CosignIdentityRegexp = "^https://github.com/$Repo/.github/workflows/release.yml@refs/tags/v.*$"
 $CosignIssuer = 'https://token.actions.githubusercontent.com'
 
-function Info($m) { Write-Host "› $m" -ForegroundColor Cyan }
-function Ok($m)   { Write-Host "✓ $m" -ForegroundColor Green }
+# ASCII markers only: PowerShell 5.1 mangles Unicode on both delivery
+# paths (`irm` decodes the charset-less release asset as ISO-8859-1;
+# a BOM-less .ps1 file parses as ANSI), printing glyphs as mojibake.
+function Info($m) { Write-Host "> $m" -ForegroundColor Cyan }
+function Ok($m)   { Write-Host "OK $m" -ForegroundColor Green }
 
 # throw, not exit: the install one-liner runs via `irm ... | iex` *in the
 # user's own session*, so `exit` would close their terminal. throw halts,
 # shows the message in red, leaves an interactive window open, and still
 # yields a non-zero exit code under `powershell -File install.ps1`.
-function Err($m)  { Write-Host "✗ $m" -ForegroundColor Red; throw }
+function Err($m)  { Write-Host "x $m" -ForegroundColor Red; throw }
 
 function Show-Usage {
     Write-Host @'
@@ -75,7 +78,7 @@ Source: https://github.com/polius/fsend/blob/main/scripts/install.ps1
 if ($Help) { Show-Usage; return }
 
 # Windows releases cover amd64/arm64/386 only. PROCESSOR_ARCHITECTURE reports
-# the *process* arch, so a 32-bit PowerShell on 64-bit Windows would read x86 —
+# the *process* arch, so a 32-bit PowerShell on 64-bit Windows would read x86 -
 # PROCESSOR_ARCHITEW6432 carries the true machine arch in that case.
 function Get-Arch {
     $a = $env:PROCESSOR_ARCHITECTURE
@@ -113,7 +116,7 @@ function Verify-Signature($sums, $base, $dir) {
     $bundle = Join-Path $dir 'checksums.txt.bundle'
     Download "$base/checksums.txt.bundle" $bundle
     # Windows PowerShell 5.1 turns a native command's redirected stderr into a
-    # terminating error under EAP=Stop — and cosign prints "Verified OK" to
+    # terminating error under EAP=Stop - and cosign prints "Verified OK" to
     # stderr even on success, which would abort a good verification. Relax EAP
     # just for this call; correctness is judged by $LASTEXITCODE, not stderr.
     $prevEAP = $ErrorActionPreference
@@ -145,7 +148,7 @@ try {
         # Resolve "latest" through the release-asset redirect, not the GitHub
         # API (unauthenticated API is capped at 60/hr per IP). checksums.txt is
         # needed anyway, and the version is recovered from the archive names in
-        # it — tags are always v-prefixed.
+        # it - tags are always v-prefixed.
         Info 'looking up latest release...'
         Download "https://github.com/$Repo/releases/latest/download/checksums.txt" $checksums
         $line = Get-Content $checksums | Where-Object { $_ -match 'fsend_([^_]+)_' } | Select-Object -First 1
@@ -159,7 +162,7 @@ try {
         Download "https://github.com/$Repo/releases/download/$Version/checksums.txt" $checksums
     }
 
-    # %LOCALAPPDATA%\Programs (per-user, no admin) — deliberately NOT under
+    # %LOCALAPPDATA%\Programs (per-user, no admin) - deliberately NOT under
     # %LOCALAPPDATA%\fsend, which is the config dir: `fsend --uninstall`
     # RemoveAll's the config dir, and Windows can't delete a running .exe
     # nested inside it ("Access is denied"). Keep the two trees separate.

--- a/test/e2e/lan_blackhole_test.go
+++ b/test/e2e/lan_blackhole_test.go
@@ -1,0 +1,84 @@
+package e2e
+
+import (
+	"bytes"
+	"net"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/polius/fsend/internal/landisc"
+)
+
+// TestReceive_LANBlackholeFallsBackFast reproduces the Windows Defender
+// failure mode: mDNS discovery works (Windows ships a built-in allow
+// rule for UDP 5353) but the sender's LAN QUIC port silently drops
+// inbound packets. The receiver's first LAN dial must be bounded at an
+// RTT-scale budget and fall back to the server path — not burn the full
+// 10 s HandshakeTimeout staring at a black hole.
+func TestReceive_LANBlackholeFallsBackFast(t *testing.T) {
+	requireE2E(t)
+
+	xdg := h.newXDG(t)
+	src := t.TempDir()
+	payload := filepath.Join(src, "payload.bin")
+	writeRandom(t, payload, 64*1024)
+
+	// --mode direct: internet path only, so the mDNS announce below is
+	// the only one for this code.
+	s := h.startSender(t, xdg, "--mode", "direct", payload)
+	t.Cleanup(func() { _ = s.cmd.Process.Kill() })
+	code := s.waitForCode(t, 5*time.Second)
+
+	// Blackhole the code-derived LAN port: bind it, read, drop.
+	port := landisc.PortForCode(code)
+	pc, err := net.ListenUDP("udp4", &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: port})
+	if err != nil {
+		t.Skipf("cannot bind blackhole port %d: %v", port, err)
+	}
+	defer func() { _ = pc.Close() }()
+	go func() {
+		buf := make([]byte, 4096)
+		for {
+			if _, _, err := pc.ReadFromUDP(buf); err != nil {
+				return
+			}
+		}
+	}()
+	mdnsConn, err := landisc.Announce(code, net.IPv4(127, 0, 0, 1))
+	if err != nil {
+		t.Skipf("mDNS announce unavailable: %v", err)
+	}
+	defer landisc.StopAnnounce(mdnsConn)
+
+	recvDir := t.TempDir()
+	recvCmd := h.fsendCmd(xdg, code, "--yes", "--debug", "--out", recvDir)
+	var out, errb bytes.Buffer
+	recvCmd.Stdout = &out
+	recvCmd.Stderr = &errb
+	start := time.Now()
+	recvErr := recvCmd.Run()
+	elapsed := time.Since(start)
+	stderr := errb.String()
+
+	// Without discovery the run never exercises the doomed dial and the
+	// test would pass vacuously.
+	if !strings.Contains(stderr, "sender address:") {
+		t.Skipf("mDNS discovery did not resolve in this environment\n%s", stderr)
+	}
+	if code := exitCodeOf(t, recvErr); code != 0 {
+		t.Fatalf("receiver exit %d\n%s", code, stderr)
+	}
+	if !strings.Contains(stderr, "Local sender unreachable") {
+		t.Fatalf("expected the LAN-dial fallback notice\n%s", stderr)
+	}
+	// Post-fix this completes in ~2-3 s; pre-fix the dial alone was 10 s.
+	if elapsed > 8*time.Second {
+		t.Fatalf("receive took %v; the first LAN dial must stay RTT-scale", elapsed)
+	}
+	if _, err := os.Stat(filepath.Join(recvDir, "payload.bin")); err != nil {
+		t.Fatalf("payload not received: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Two Windows-only bugs, both root-caused from a user report and reproduced locally.

### 1. Receiver took ~10s to connect on Windows (`fix(receive)`)

Windows Defender silently drops inbound UDP to the sender's LAN QUIC listener (code-derived ports 50000–50999), while mDNS discovery still works — Windows ships a built-in firewall allow rule for UDP 5353. So the receiver *found* the sender via mDNS, then burned the full 10s `quicconn.HandshakeTimeout` dialing a black hole, with no spinner, before falling back to the server path — whose host↔host ICE connects in under a second and shows the same "Direct on local network" label, masking the fallback. Confirmed on a real Windows box via `--debug`.

**Fix:** the *first* LAN dial gets an RTT-scale 2s budget (`lanFirstDialTimeout`) — a real same-LAN handshake takes milliseconds, and a false timeout just lands on the same host↔host pair via ICE. The "Connecting" spinner now also covers the dial window. Mid-transfer re-dials keep the full timeout (listener known-good there).

**Measured** (mDNS announce + read-and-drop socket on the derived port, simulating Defender):

| Scenario | Before | After |
|---|---|---|
| Black-holed LAN dial (the Windows case) | 10.5s | 2.4s |
| Healthy LAN dial | 0.4s | 0.4s |

New e2e regression test `TestReceive_LANBlackholeFallsBackFast` reproduces the failure mode in-process; verified it **fails at 10.46s against the pre-fix code** and passes at 2.38s with the fix. It skips (not passes) when mDNS discovery is unavailable in the environment.

Also refreshes the stale `joinRetryBudget` comment describing a sender LAN-only window that no longer exists.

### 2. Installer printed `âº extracting` (`fix(install)`)

`â€º` is UTF-8 `›` decoded as a single-byte codepage. Both delivery paths corrupt it on Windows PowerShell 5.1: `getfsend.alzina.dev/windows` 302s to a GitHub release asset served `application/octet-stream` with **no charset** (→ `irm` decodes as ISO-8859-1), and the BOM-less `.ps1` parses as ANSI when run from a file. Neither hop is fixable from our side, so the output markers are now ASCII (`>`, `OK`, `x`) and the whole file is kept 100% ASCII. Simulated both decode hops: the old glyph reproduces the reported garbage exactly; the new lines pass through byte-identical.

## Testing

- `go test -short ./cmd/fsend/... ./internal/...` — pass
- `go test ./test/e2e -count=1` — full suite pass (86s)
- Negative check: regression test fails against pre-fix `receive.go`
- End-to-end repro timings above, payloads verified byte-identical

🤖 Generated with [Claude Code](https://claude.com/claude-code)