### PR TITLE
fix(e2e): pick the relay's UDP port with a UDP bind, not a TCP one

### DIFF
--- a/test/e2e/harness_test.go
+++ b/test/e2e/harness_test.go
@@ -99,7 +99,7 @@ func startHarness() (*harness, error) {
 	if err != nil {
 		return nil, fmt.Errorf("pick http port: %w", err)
 	}
-	hh.udpPort, err = freePort()
+	hh.udpPort, err = freeUDPPort()
 	if err != nil {
 		return nil, fmt.Errorf("pick udp port: %w", err)
 	}
@@ -197,6 +197,20 @@ func freePort() (int, error) {
 	}
 	port := l.Addr().(*net.TCPAddr).Port
 	_ = l.Close()
+	return port, nil
+}
+
+// freeUDPPort is freePort for UDP listeners. Windows keeps separate
+// (Hyper-V/WinNAT) excluded port ranges per protocol, so a TCP-free
+// port can be UDP-forbidden (WSAEACCES) — probe with the protocol the
+// port will actually serve.
+func freeUDPPort() (int, error) {
+	pc, err := net.ListenPacket("udp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	port := pc.LocalAddr().(*net.UDPAddr).Port
+	_ = pc.Close()
 	return port, nil
 }
 

--- a/test/e2e/smoke_test.go
+++ b/test/e2e/smoke_test.go
@@ -135,7 +135,7 @@ func TestServer_PasswordGate(t *testing.T) {
 	if err != nil {
 		t.Fatalf("pick http port: %v", err)
 	}
-	udpPort, err := freePort()
+	udpPort, err := freeUDPPort()
 	if err != nil {
 		t.Fatalf("pick udp port: %v", err)
 	}


### PR DESCRIPTION
## What

The e2e harness (and `TestServer_PasswordGate`) picked the relay's UDP port via `freePort()`, which probes by binding **TCP**. Windows runners keep separate Hyper-V/WinNAT excluded port ranges per protocol, so a TCP-free port can be UDP-forbidden — the v1.11.0 release run drew one (64231) and the harness server died with WSAEACCES on `FSEND_RELAY_ADDR`, failing the `test (windows-latest)` job. A rerun with a fresh draw passed; this fixes the flake class at the root.

New `freeUDPPort()` probes with `net.ListenPacket("udp", ...)` — the protocol the port will actually serve. HTTP ports keep the TCP probe.

## Testing

- `go test ./test/e2e -count=1` — full suite pass (90s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)